### PR TITLE
feat(ci): add automated semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,26 @@ on:
     branches:
       - main
 
-concurrency: 
+permissions:
+  contents: write
+
+concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+
       - name: Fetch tags
         run: git fetch --prune --tags
-        
+
       - name: Calculate semantic version
         id: semver
         uses: paulhatch/semantic-version@v5.4.0
@@ -36,7 +39,7 @@ jobs:
           user_format_type: "csv"
           enable_prerelease_mode: false
           debug: false
-          
+
       - name: Check if release is needed
         id: check
         run: |
@@ -47,19 +50,19 @@ jobs:
             echo "Version to release: ${{ steps.semver.outputs.version_tag }}"
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
-          
+
       - name: Set up Go
         if: steps.check.outputs.skip == 'false'
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
-          
+
       - name: Build Linux binary
         if: steps.check.outputs.skip == 'false'
         run: |
           GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o buzz-linux-amd64 .
-          
+
       - name: Create Release
         if: steps.check.outputs.skip == 'false'
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: 
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Fetch tags
+        run: git fetch --prune --tags
+        
+      - name: Calculate semantic version
+        id: semver
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          major_pattern: "(BREAKING CHANGE|!:)"
+          minor_pattern: "(feat|feature)"
+          patch_pattern: "(fix|bug|hotfix)"
+          version_format: "${major}.${minor}.${patch}"
+          change_path: "."
+          search_commit_body: true
+          user_format_type: "csv"
+          enable_prerelease_mode: false
+          debug: false
+          
+      - name: Check if release is needed
+        id: check
+        run: |
+          if [ -z "${{ steps.semver.outputs.version_tag }}" ]; then
+            echo "No conventional commits found - skipping release"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version to release: ${{ steps.semver.outputs.version_tag }}"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Set up Go
+        if: steps.check.outputs.skip == 'false'
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: true
+          
+      - name: Build Linux binary
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o buzz-linux-amd64 .
+          
+      - name: Create Release
+        if: steps.check.outputs.skip == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.semver.outputs.version_tag }}
+          name: Release ${{ steps.semver.outputs.version_tag }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            buzz-linux-amd64
+            README.md
+            LICENSE
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Creates releases on push to main using conventional commits
- Builds Linux amd64 binary with optimized flags
- Includes buzz binary, README, and LICENSE in releases
- Skips release creation when no conventional commits found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow that computes semantic versions from commit messages and publishes GitHub Releases on main merges.
  * Generates release notes and uploads a prebuilt Linux (amd64) binary plus README and LICENSE.
  * Uses consistent "v"-prefixed version tags and skips creating a release when no version change is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->