### PR TITLE
Add project skills for documentation workflows

### DIFF
--- a/.claude/skills/docs-audit/SKILL.md
+++ b/.claude/skills/docs-audit/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: docs-audit
+description: "Audit docs/, DEVELOPMENT.md, and README.md against the current state of the buzz codebase and surface drift, broken links, and missing topics. Use when checking docs health or before a release."
+---
+
+# Docs Audit
+
+You are a documentation auditor for the buzz Beeminder TUI. Your role is to produce a concrete drift report — what the docs claim vs. what the code actually does — and recommend specific edits, without making changes unless asked.
+
+## What You Do
+
+- Inventory all docs (`README.md`, `DEVELOPMENT.md`, every file under `docs/`)
+- Cross-check claims against the code, tests, and tooling
+- Report drift, broken links, dead references, and missing coverage as a punch list
+- Recommend an action for each item (edit, delete, link out, leave alone)
+
+## What You Don't Do
+
+- Edit files during the audit — produce the report first, edit only after the user picks items
+- Flag style nits unless they impair comprehension
+- Demand exhaustive docs — small projects don't need a wiki
+
+## Workflow
+
+### Step 1: Inventory the docs
+
+```bash
+ls -la docs/
+ls README.md DEVELOPMENT.md
+find docs -name '*.md' -o -name '*.txt'
+```
+
+For each file, note: purpose, last-touched date, length.
+
+```bash
+for f in README.md DEVELOPMENT.md docs/*.md docs/*.txt; do
+  echo "=== $f ==="
+  git log -1 --pretty=format:'%cs %s' -- "$f"
+  echo
+done
+```
+
+### Step 2: Build a claims list
+
+Skim each doc and extract testable claims:
+
+- Commands and flags (`buzz --foo`)
+- Keybindings (`press q to quit`)
+- Config keys, env vars, file paths
+- Install instructions
+- Links to other docs, files, or external URLs
+- Code-block snippets that should still run
+
+### Step 3: Verify against the code
+
+For each claim, check the source of truth:
+
+| Claim type | Where to verify |
+|------------|----------------|
+| CLI flags | `main.go`, `flag.*` calls |
+| Keybindings | `model.go`, `handlers.go` |
+| Config keys | `config.go`, struct tags |
+| API behavior | `beeminder.go` |
+| Test commands | actually run them in a scratch shell |
+| Internal links | `test -f <path>` |
+| External links | `curl -sI <url> | head -1` (only spot-check obvious ones) |
+
+```bash
+# Quick example: find every flag mentioned in README and check it exists
+grep -oE -- '--[a-z][a-z0-9-]+' README.md | sort -u > /tmp/readme-flags
+grep -oE 'flag\.(String|Bool|Int)\("[a-z0-9-]+"' *.go \
+  | grep -oE '"[a-z0-9-]+"' | tr -d '"' | sort -u > /tmp/code-flags
+diff /tmp/readme-flags /tmp/code-flags
+```
+
+### Step 4: Look for missing coverage
+
+Compare what users see today to what's documented:
+
+```bash
+# Subcommands mentioned in handlers/main but not in README
+grep -E 'case "[a-z]+"' main.go handlers.go
+
+# Recently merged user-facing PRs
+gh pr list --state merged --base main --limit 20 \
+  --search 'feat OR feature' \
+  --json number,title,mergedAt
+```
+
+For each user-visible feature shipped since the last doc edit, ask: is it documented anywhere?
+
+### Step 5: Produce the report
+
+Output a punch list grouped by file. Each item: **what's wrong**, **evidence**, **suggested fix**.
+
+```markdown
+## docs-audit report — YYYY-MM-DD
+
+### README.md
+- **Drift:** mentions `--token` flag, but code uses `--auth-token` since #198.
+  Fix: rename references; add a note in install section.
+- **Missing:** the new `uncle` command (added in #231) is not in the commands list.
+  Fix: add a bullet under Usage.
+
+### docs/TESTING.md
+- **Stale:** says `go test ./...` covers handlers, but `handlers_test.go` was split
+  into `handlers_test.go` and `next_test.go` in #210.
+  Fix: update file list.
+
+### docs/beeminder-api.md
+- **OK:** no drift detected.
+
+### Broken links
+- `DEVELOPMENT.md` → `docs/RELEASING.md` (file does not exist).
+  Fix: remove link or create the doc.
+```
+
+End with a one-line summary: total items, count by severity (drift / missing / broken / nit).
+
+### Step 6: Wait for direction
+
+Ask the user which items they want fixed. Only then make edits — one PR per logical group is usually right.
+
+## Tips
+
+- `git log --since='3 months ago' --name-only -- '*.go' | sort -u` quickly surfaces recently changed code worth re-checking against docs.
+- For internal links, prefer relative paths (`docs/TESTING.md`) so they work both on GitHub and locally.
+- `docs/FORMAT_EXAMPLES.txt` and `docs/GRID_FORMAT_CHANGE.md` are historical — verify before flagging as "stale"; they may be design notes, not user docs.
+- If a doc has no clear audience, that's the most important finding — flag it.

--- a/.claude/skills/docs-audit/SKILL.md
+++ b/.claude/skills/docs-audit/SKILL.md
@@ -57,18 +57,20 @@ For each claim, check the source of truth:
 
 | Claim type | Where to verify |
 |------------|----------------|
-| CLI flags | `main.go`, `flag.*` calls |
+| CLI flags | `main.go`, `flag.NewFlagSet(...)` + `<set>.Bool/String/Int(...)` calls |
 | Keybindings | `model.go`, `handlers.go` |
 | Config keys | `config.go`, struct tags |
 | API behavior | `beeminder.go` |
-| Test commands | actually run them in a scratch shell |
+| Test commands | validate syntax/intent first; run only safe, read-only commands, and ask before executing anything with side effects |
 | Internal links | `test -f <path>` |
 | External links | `curl -sI <url> | head -1` (only spot-check obvious ones) |
 
 ```bash
-# Quick example: find every flag mentioned in README and check it exists
+# Quick example: find every flag mentioned in README and check it exists.
+# Flags are registered on a FlagSet (e.g. nextFlags.Bool("watch", ...)), so match
+# the method calls rather than a package-level flag.String("...").
 grep -oE -- '--[a-z][a-z0-9-]+' README.md | sort -u > /tmp/readme-flags
-grep -oE 'flag\.(String|Bool|Int)\("[a-z0-9-]+"' *.go \
+grep -oE '\.(Bool|String|Int|Int64|Uint|Float64|Duration)\("[a-z0-9-]+"' *.go \
   | grep -oE '"[a-z0-9-]+"' | tr -d '"' | sort -u > /tmp/code-flags
 diff /tmp/readme-flags /tmp/code-flags
 ```

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: release-notes
+description: "Draft release notes for a new buzz version from git history and merged PRs. Use when cutting a release or asked to summarize what changed since the last tag."
+---
+
+# Release Notes
+
+You are a release-notes drafter for the buzz Beeminder TUI. Your role is to produce user-facing release notes by reading the commits and PRs merged since the previous tag, grouping them into meaningful categories, and writing copy that an end user (not a contributor) will care about.
+
+## What You Do
+
+- Determine the previous and proposed next version
+- Walk the commits and merged PRs since the previous tag
+- Group changes into **Features**, **Fixes**, **Improvements**, and (if applicable) **Breaking changes**
+- Write user-facing prose — describe behavior, not refactors
+
+## What You Don't Do
+
+- Include internal refactors, dependency bumps, or CI tweaks unless they affect users
+- List every commit verbatim — synthesize related commits into one bullet
+- Invent a version number — ask or infer from existing tags
+- Publish a GitHub release without confirmation
+
+## Workflow
+
+### Step 1: Find the previous tag
+
+```bash
+git fetch --tags
+git tag --sort=-v:refname | head -5
+PREV_TAG=$(git tag --sort=-v:refname | head -1)
+echo "Previous tag: $PREV_TAG"
+```
+
+### Step 2: Gather raw material
+
+```bash
+# Commits since previous tag
+git log --no-merges --pretty=format:'- %s (%h)' "$PREV_TAG"..HEAD
+
+# Merged PRs since previous tag
+gh pr list --state merged --base main --limit 50 \
+  --json number,title,mergedAt,labels,author \
+  --jq '.[] | "#\(.number) \(.title) — @\(.author.login)"'
+```
+
+Read PR bodies for any with non-trivial user-facing impact:
+
+```bash
+gh pr view <number> --json title,body,labels
+```
+
+### Step 3: Classify
+
+Bucket each change:
+
+| Category | Includes |
+|----------|----------|
+| Features | New commands, new screens, new keybindings, new config |
+| Fixes | Bug fixes the user would notice |
+| Improvements | Performance, UX polish, better error messages |
+| Breaking | Renamed flags, removed config keys, changed defaults |
+| Internal (omit) | Refactors, test-only changes, doc-only changes, dep bumps |
+
+When in doubt, ask: "would a user notice if I left this out of the notes?" If no, omit it.
+
+### Step 4: Draft the notes
+
+Use this format:
+
+```markdown
+## vX.Y.Z — YYYY-MM-DD
+
+### Features
+- Short, user-facing description. (#123)
+
+### Fixes
+- Short description of the bug and what now works. (#124)
+
+### Improvements
+- What got better and where the user will feel it. (#125)
+
+### Breaking changes
+- What changed, what to do about it. (#126)
+```
+
+Each bullet should be one line, present-tense, user-facing. Link the PR number in parentheses.
+
+### Step 5: Decide the version bump
+
+Suggest a version following semver:
+
+- **Breaking changes** present → major bump
+- **Features** only → minor bump
+- **Fixes / Improvements** only → patch bump
+
+State the suggestion and the reasoning, but let the user confirm.
+
+### Step 6: Present
+
+Output the draft to the conversation. Do not create files or run `gh release create` unless the user asks.
+
+If the user approves and wants to publish:
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file <(cat <<'EOF'
+... notes ...
+EOF
+)
+```
+
+## Tips
+
+- Squash-merged PRs usually have one clean commit; rebase-merged PRs may need PR-level grouping.
+- If a feature spans multiple PRs, write one bullet and link the most descriptive PR.
+- `gh release view <prev-tag>` shows how prior notes were structured — match the existing style.
+- Skip the "Co-Authored-By" / "Generated with Claude Code" trailers when summarizing commits.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -38,8 +38,11 @@ echo "Previous tag: $PREV_TAG"
 # Commits since previous tag
 git log --no-merges --pretty=format:'- %s (%h)' "$PREV_TAG"..HEAD
 
-# Merged PRs since previous tag
+# Merged PRs since previous tag. Scope by the tag's commit date so this doesn't
+# pull in PRs merged before PREV_TAG (which would skew the notes and version bump).
+SINCE=$(git log -1 --format=%cI "$PREV_TAG")
 gh pr list --state merged --base main --limit 50 \
+  --search "merged:>=$SINCE" \
   --json number,title,mergedAt,labels,author \
   --jq '.[] | "#\(.number) \(.title) — @\(.author.login)"'
 ```

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -34,8 +34,10 @@ cat README.md
 Identify what the app actually exposes today:
 
 ```bash
-# CLI subcommands and flags
-grep -nE 'flag\.(String|Bool|Int)|cobra\.Command|case "' main.go *.go
+# CLI subcommands and flags. Flags are defined via flag.NewFlagSet(...) and then
+# <flagSet>.Bool/String/Int(...) (e.g. nextFlags.Bool("watch", ...)), so match the
+# FlagSet constructor and its method calls — a `flag.String(...)` search misses them.
+grep -nE 'flag\.NewFlagSet|\.(Bool|String|Int|Int64|Uint|Float64|Duration)\("|case "' main.go *.go
 
 # Keybindings (Bubble Tea handlers)
 grep -nE 'tea\.KeyMsg|key\.Matches|"q"|"j"|"k"|ctrl\+' *.go

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: update-readme
+description: "Update README.md to reflect the current feature set, commands, and installation options of the buzz TUI. Use when README has drifted from the code or after shipping user-visible changes."
+---
+
+# Update README
+
+You are a documentation maintainer for the buzz Beeminder TUI. Your role is to keep `README.md` accurate and helpful for end users by reconciling it against the current state of the code and release artifacts.
+
+## What You Do
+
+- Inspect what the application currently does (commands, flags, keybindings, configuration)
+- Compare the live behavior to what `README.md` claims
+- Update sections that have drifted (installation, usage, keybindings, configuration, screenshots)
+- Preserve the existing tone and section structure unless asked to restructure
+
+## What You Don't Do
+
+- Add aspirational features that don't exist yet
+- Duplicate content already covered by `DEVELOPMENT.md` or `docs/*` — link to those instead
+- Rewrite the whole README when a targeted edit suffices
+- Add badges, marketing copy, or emoji unless the user requests them
+
+## Workflow
+
+### Step 1: Read the current README
+
+```bash
+cat README.md
+```
+
+### Step 2: Discover the real surface area
+
+Identify what the app actually exposes today:
+
+```bash
+# CLI subcommands and flags
+grep -nE 'flag\.(String|Bool|Int)|cobra\.Command|case "' main.go *.go
+
+# Keybindings (Bubble Tea handlers)
+grep -nE 'tea\.KeyMsg|key\.Matches|"q"|"j"|"k"|ctrl\+' *.go
+
+# Config keys
+grep -nE 'viper|os\.Getenv|json:"' config.go
+
+# Install options surfaced by release tooling
+ls scripts/ && cat scripts/*.sh 2>/dev/null | head -50
+```
+
+Cross-check the latest release for binary names and platforms:
+
+```bash
+gh release view --json name,tagName,assets -q '.assets[].name'
+```
+
+### Step 3: Identify drift
+
+For each README section, list concrete drift items (e.g. "README mentions `--token` but the flag is now `--auth-token`", "Homebrew tap path changed", "Missing the new `uncle` command"). Walk through:
+
+- Installation methods (bin, Homebrew, direct download)
+- Quickstart / first run
+- Keybindings table
+- Configuration (env vars, config file path)
+- Commands / subcommands
+- Screenshot or asciinema, if any
+
+### Step 4: Edit README.md
+
+Apply targeted edits with the `Edit` tool. Keep changes minimal and grounded in what you found in Step 2.
+
+### Step 5: Verify
+
+```bash
+# Render-check that markdown is well-formed
+grep -nE '^#{1,6} ' README.md
+
+# Make sure every code block has a language tag
+awk '/^```/{n++; if(n%2==1 && $0=="```") print NR": untagged fence"}' README.md
+```
+
+### Step 6: Summarize the change
+
+Tell the user the concrete drift items you fixed and anything you intentionally left alone (and why).
+
+## Tips
+
+- The buzz binary is built with `go build`; running `./buzz --help` is the fastest way to confirm flags.
+- For keybindings, `model.go` and `handlers.go` are the authoritative source.
+- If a feature was added recently, `git log -- README.md` will show whether docs were updated in the same PR.
+- Don't invent install methods — only document the ones present in `scripts/` or recent releases.

--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -37,10 +37,10 @@ Identify what the app actually exposes today:
 # CLI subcommands and flags. Flags are defined via flag.NewFlagSet(...) and then
 # <flagSet>.Bool/String/Int(...) (e.g. nextFlags.Bool("watch", ...)), so match the
 # FlagSet constructor and its method calls — a `flag.String(...)` search misses them.
-grep -nE 'flag\.NewFlagSet|\.(Bool|String|Int|Int64|Uint|Float64|Duration)\("|case "' main.go *.go
+grep -nE 'flag\.NewFlagSet|\.(Bool|String|Int|Int64|Uint|Float64|Duration)\("|case "' *.go
 
 # Keybindings (Bubble Tea handlers)
-grep -nE 'tea\.KeyMsg|key\.Matches|"q"|"j"|"k"|ctrl\+' *.go
+grep -nE 'tea\.KeyMsg|key\.Matches|case tea\.Key|Key(Msg|Type|Runes)|binding' *.go
 
 # Config keys
 grep -nE 'viper|os\.Getenv|json:"' config.go


### PR DESCRIPTION
## Summary
- Scaffolds `.claude/skills/` with three project-specific workflow skills:
  - `update-readme` — reconcile README claims (flags, keybindings, install methods) against actual code
  - `release-notes` — draft user-facing notes from commits/PRs since the last tag, with semver bump suggestion
  - `docs-audit` — produce a drift punch list across README, DEVELOPMENT, and `docs/*` without editing
- Each skill is grounded in the real source-of-truth files (`main.go`, `handlers.go`, `config.go`, `beeminder.go`) so audits and edits stay tied to current behavior rather than assumptions.

## Test plan
- [ ] Invoke `/update-readme` and confirm it walks the code before proposing edits
- [ ] Invoke `/release-notes` on a branch with merged PRs since the last tag and confirm grouping is sensible
- [ ] Invoke `/docs-audit` and confirm the output is a punch list (no edits made)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three new workflow guides for docs auditing, drafting release notes, and updating the README to improve documentation quality and release note consistency.
* **Chores**
  * Introduced internal skill specifications to standardize auditing, release-note generation, and README maintenance processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->