### PR TITLE
fix: hide goals that have reached their end value from due lists

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -31,6 +31,9 @@ type Goal struct {
 	Deadline    int         `json:"deadline"` // Seconds by which deadline differs from midnight
 	Yaw         int         `json:"yaw"`      // Good side of the bright red line (+1 = above, -1 = below)
 	Dir         int         `json:"dir"`      // Direction the bright red line is sloping (+1 = up, -1 = down)
+	Curval      *float64    `json:"curval"`   // Most recent datapoint value
+	Goalval     *float64    `json:"goalval"`  // End value of the goal (may be null if computed from goaldate+rate)
+	Mathishard  []*float64  `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)
 	Datapoints  []Datapoint `json:"datapoints,omitempty"`
 }
 
@@ -297,6 +300,43 @@ func IsDueWithinAt(losedate int64, duration time.Duration, now time.Time) bool {
 
 	// Goal is due within the duration if it's not after the cutoff time
 	return !goalTime.After(cutoffTime)
+}
+
+// IsEndValueReached reports whether the goal's current value has already met or passed
+// its end value (goalval). When this is true the bright red line has plateaued and the
+// goal effectively has no remaining work, so it shouldn't be surfaced as "due".
+//
+// Returns false when the end value can't be determined (e.g., goalval and mathishard
+// are both nil, or direction is unknown), so callers don't accidentally hide goals.
+func IsEndValueReached(goal Goal) bool {
+	if goal.Curval == nil {
+		return false
+	}
+	goalval := resolveGoalval(goal)
+	if goalval == nil {
+		return false
+	}
+	switch {
+	case goal.Dir > 0:
+		return *goal.Curval >= *goalval
+	case goal.Dir < 0:
+		return *goal.Curval <= *goalval
+	default:
+		return false
+	}
+}
+
+// resolveGoalval returns the goal's end value, preferring the direct goalval field and
+// falling back to mathishard[1] (which Beeminder fills in even when goalval itself is
+// the computed-of-three value).
+func resolveGoalval(goal Goal) *float64 {
+	if goal.Goalval != nil {
+		return goal.Goalval
+	}
+	if len(goal.Mathishard) >= 2 && goal.Mathishard[1] != nil {
+		return goal.Mathishard[1]
+	}
+	return nil
 }
 
 // IsDoLess checks if a goal is a "do-less" type goal based on goal_type string.

--- a/beeminder.go
+++ b/beeminder.go
@@ -27,12 +27,12 @@ type Goal struct {
 	Autoratchet *float64    `json:"autoratchet"` // Pointer to handle null values from API
 	Rate        *float64    `json:"rate"`        // Pointer to handle null values from API
 	Runits      string      `json:"runits"`
-	Gunits      string      `json:"gunits"`   // Goal units, like "hours" or "pushups" or "pages"
-	Deadline    int         `json:"deadline"` // Seconds by which deadline differs from midnight
-	Yaw         int         `json:"yaw"`      // Good side of the bright red line (+1 = above, -1 = below)
-	Dir         int         `json:"dir"`      // Direction the bright red line is sloping (+1 = up, -1 = down)
-	Curval      *float64    `json:"curval"`   // Most recent datapoint value
-	Goalval     *float64    `json:"goalval"`  // End value of the goal (may be null if computed from goaldate+rate)
+	Gunits      string      `json:"gunits"`     // Goal units, like "hours" or "pushups" or "pages"
+	Deadline    int         `json:"deadline"`   // Seconds by which deadline differs from midnight
+	Yaw         int         `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
+	Dir         int         `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
+	Curval      *float64    `json:"curval"`     // Most recent datapoint value
+	Goalval     *float64    `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
 	Mathishard  []*float64  `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)
 	Datapoints  []Datapoint `json:"datapoints,omitempty"`
 }

--- a/beeminder.go
+++ b/beeminder.go
@@ -308,7 +308,14 @@ func IsDueWithinAt(losedate int64, duration time.Duration, now time.Time) bool {
 //
 // Returns false when the end value can't be determined (e.g., goalval and mathishard
 // are both nil, or direction is unknown), so callers don't accidentally hide goals.
+//
+// Do-less goals are excluded: their goalval is an ongoing cap, not an endpoint to
+// reach, so curval crossing it indicates a problem state (at/over cap) rather than
+// completion. Hiding such goals would mask the very situations they're meant to flag.
 func IsEndValueReached(goal Goal) bool {
+	if IsDoLessGoal(goal) {
+		return false
+	}
 	if goal.Curval == nil {
 		return false
 	}

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -953,6 +953,16 @@ func TestIsEndValueReached(t *testing.T) {
 			goal:     Goal{Dir: 0, Curval: f(120), Goalval: f(100)},
 			expected: false,
 		},
+		{
+			name:     "drinker do-less goal at/over cap is not 'reached' (must stay visible)",
+			goal:     Goal{GoalType: "drinker", Dir: 1, Curval: f(120), Goalval: f(100)},
+			expected: false,
+		},
+		{
+			name:     "WEEN do-less goal (yaw=-1, dir=+1) at cap is not 'reached'",
+			goal:     Goal{Yaw: -1, Dir: 1, Curval: f(120), Goalval: f(100)},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -939,6 +939,11 @@ func TestIsEndValueReached(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "goalval takes precedence over mathishard[1] when both present",
+			goal:     Goal{Dir: 1, Curval: f(110), Goalval: f(120), Mathishard: []*float64{f(1234567890), f(100), f(1)}},
+			expected: false, // 110 < 120 (goalval); would be true if mathishard[1]=100 were used
+		},
+		{
 			name:     "mathishard with nil goalval slot returns false",
 			goal:     Goal{Dir: 1, Curval: f(120), Mathishard: []*float64{f(1234567890), nil, f(1)}},
 			expected: false,

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -884,6 +884,81 @@ func TestIsDueTomorrow(t *testing.T) {
 	}
 }
 
+// TestIsEndValueReached tests the IsEndValueReached function
+func TestIsEndValueReached(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	tests := []struct {
+		name     string
+		goal     Goal
+		expected bool
+	}{
+		{
+			name:     "do-more goal with curval below goalval",
+			goal:     Goal{Dir: 1, Curval: f(50), Goalval: f(100)},
+			expected: false,
+		},
+		{
+			name:     "do-more goal with curval equal to goalval",
+			goal:     Goal{Dir: 1, Curval: f(100), Goalval: f(100)},
+			expected: true,
+		},
+		{
+			name:     "do-more goal with curval above goalval",
+			goal:     Goal{Dir: 1, Curval: f(120), Goalval: f(100)},
+			expected: true,
+		},
+		{
+			name:     "weight-loss goal with curval above goalval",
+			goal:     Goal{Dir: -1, Curval: f(180), Goalval: f(150)},
+			expected: false,
+		},
+		{
+			name:     "weight-loss goal with curval at goalval",
+			goal:     Goal{Dir: -1, Curval: f(150), Goalval: f(150)},
+			expected: true,
+		},
+		{
+			name:     "weight-loss goal with curval below goalval",
+			goal:     Goal{Dir: -1, Curval: f(140), Goalval: f(150)},
+			expected: true,
+		},
+		{
+			name:     "missing curval returns false",
+			goal:     Goal{Dir: 1, Goalval: f(100)},
+			expected: false,
+		},
+		{
+			name:     "missing goalval and mathishard returns false",
+			goal:     Goal{Dir: 1, Curval: f(120)},
+			expected: false,
+		},
+		{
+			name:     "goalval null but mathishard provides it",
+			goal:     Goal{Dir: 1, Curval: f(120), Mathishard: []*float64{f(1234567890), f(100), f(1)}},
+			expected: true,
+		},
+		{
+			name:     "mathishard with nil goalval slot returns false",
+			goal:     Goal{Dir: 1, Curval: f(120), Mathishard: []*float64{f(1234567890), nil, f(1)}},
+			expected: false,
+		},
+		{
+			name:     "dir == 0 returns false (unknown direction)",
+			goal:     Goal{Dir: 0, Curval: f(120), Goalval: f(100)},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEndValueReached(tt.goal); got != tt.expected {
+				t.Errorf("IsEndValueReached(%+v) = %v, want %v", tt.goal, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestFetchGoalWithMockServer tests FetchGoal function with a mock HTTP server
 func TestFetchGoalWithMockServer(t *testing.T) {
 	// Test case 1: successful fetch

--- a/main.go
+++ b/main.go
@@ -500,14 +500,14 @@ func displayNextGoalWithTimestamp() {
 	fmt.Printf("\nRefreshing every %dm... (Press Ctrl+C to exit)\n", int(RefreshInterval.Minutes()))
 }
 
-// isDueTodayFilter returns true if the goal is due today
+// isDueTodayFilter returns true if the goal is due today and hasn't already reached its end value
 func isDueTodayFilter(g Goal) bool {
-	return IsDueToday(g.Losedate)
+	return IsDueToday(g.Losedate) && !IsEndValueReached(g)
 }
 
-// isDueTomorrowFilter returns true if the goal is due tomorrow
+// isDueTomorrowFilter returns true if the goal is due tomorrow and hasn't already reached its end value
 func isDueTomorrowFilter(g Goal) bool {
-	return IsDueTomorrow(g.Losedate)
+	return IsDueTomorrow(g.Losedate) && !IsEndValueReached(g)
 }
 
 // isDoLessFilter returns true if the goal is a do-less type goal

--- a/main.go
+++ b/main.go
@@ -500,14 +500,26 @@ func displayNextGoalWithTimestamp() {
 	fmt.Printf("\nRefreshing every %dm... (Press Ctrl+C to exit)\n", int(RefreshInterval.Minutes()))
 }
 
+// isDueTodayFilterAt returns true if the goal is due today (relative to now) and
+// hasn't already reached its end value. Exposed for deterministic time-based tests.
+func isDueTodayFilterAt(g Goal, now time.Time) bool {
+	return IsDueTodayAt(g.Losedate, now) && !IsEndValueReached(g)
+}
+
 // isDueTodayFilter returns true if the goal is due today and hasn't already reached its end value
 func isDueTodayFilter(g Goal) bool {
-	return IsDueToday(g.Losedate) && !IsEndValueReached(g)
+	return isDueTodayFilterAt(g, time.Now())
+}
+
+// isDueTomorrowFilterAt returns true if the goal is due tomorrow (relative to now) and
+// hasn't already reached its end value. Exposed for deterministic time-based tests.
+func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
+	return IsDueTomorrowAt(g.Losedate, now) && !IsEndValueReached(g)
 }
 
 // isDueTomorrowFilter returns true if the goal is due tomorrow and hasn't already reached its end value
 func isDueTomorrowFilter(g Goal) bool {
-	return IsDueTomorrow(g.Losedate) && !IsEndValueReached(g)
+	return isDueTomorrowFilterAt(g, time.Now())
 }
 
 // isDoLessFilter returns true if the goal is a do-less type goal

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -161,6 +162,62 @@ func TestNoColorFlag(t *testing.T) {
 				if lipgloss.ColorProfile() != termenv.Ascii {
 					t.Errorf("Expected Ascii color profile when --no-color is set, got %v", lipgloss.ColorProfile())
 				}
+			}
+		})
+	}
+}
+
+// TestDueFiltersSkipEndValueReached verifies that the today and tomorrow filters
+// exclude goals whose end value has already been reached — those goals can show
+// a negative baremin and shouldn't be surfaced as due.
+func TestDueFiltersSkipEndValueReached(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	// Pick a losedate squarely inside "today" and one inside "tomorrow"
+	// (filters use time.Now() internally, so we anchor relative to that).
+	now := time.Now()
+	todayDeadline := time.Date(now.Year(), now.Month(), now.Day(), 23, 0, 0, 0, now.Location()).Unix()
+	tomorrowDeadline := time.Date(now.Year(), now.Month(), now.Day()+1, 12, 0, 0, 0, now.Location()).Unix()
+
+	tests := []struct {
+		name           string
+		goal           Goal
+		todayExpect    bool
+		tomorrowExpect bool
+	}{
+		{
+			name:           "do-more goal due today, not yet reached",
+			goal:           Goal{Losedate: todayDeadline, Dir: 1, Curval: f(50), Goalval: f(100)},
+			todayExpect:    true,
+			tomorrowExpect: false,
+		},
+		{
+			name:           "do-more goal due today, end value reached",
+			goal:           Goal{Losedate: todayDeadline, Dir: 1, Curval: f(120), Goalval: f(100)},
+			todayExpect:    false,
+			tomorrowExpect: false,
+		},
+		{
+			name:           "do-more goal due tomorrow, not yet reached",
+			goal:           Goal{Losedate: tomorrowDeadline, Dir: 1, Curval: f(50), Goalval: f(100)},
+			todayExpect:    false,
+			tomorrowExpect: true,
+		},
+		{
+			name:           "do-more goal due tomorrow, end value reached",
+			goal:           Goal{Losedate: tomorrowDeadline, Dir: 1, Curval: f(120), Goalval: f(100)},
+			todayExpect:    false,
+			tomorrowExpect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDueTodayFilter(tt.goal); got != tt.todayExpect {
+				t.Errorf("isDueTodayFilter = %v, want %v", got, tt.todayExpect)
+			}
+			if got := isDueTomorrowFilter(tt.goal); got != tt.tomorrowExpect {
+				t.Errorf("isDueTomorrowFilter = %v, want %v", got, tt.tomorrowExpect)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -173,11 +173,10 @@ func TestNoColorFlag(t *testing.T) {
 func TestDueFiltersSkipEndValueReached(t *testing.T) {
 	f := func(v float64) *float64 { return &v }
 
-	// Pick a losedate squarely inside "today" and one inside "tomorrow"
-	// (filters use time.Now() internally, so we anchor relative to that).
-	now := time.Now()
-	todayDeadline := time.Date(now.Year(), now.Month(), now.Day(), 23, 0, 0, 0, now.Location()).Unix()
-	tomorrowDeadline := time.Date(now.Year(), now.Month(), now.Day()+1, 12, 0, 0, 0, now.Location()).Unix()
+	// Fixed reference time so the test is deterministic across midnight boundaries.
+	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	todayDeadline := time.Date(2025, 1, 15, 23, 0, 0, 0, time.UTC).Unix()
+	tomorrowDeadline := time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC).Unix()
 
 	tests := []struct {
 		name           string
@@ -213,11 +212,11 @@ func TestDueFiltersSkipEndValueReached(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isDueTodayFilter(tt.goal); got != tt.todayExpect {
-				t.Errorf("isDueTodayFilter = %v, want %v", got, tt.todayExpect)
+			if got := isDueTodayFilterAt(tt.goal, now); got != tt.todayExpect {
+				t.Errorf("isDueTodayFilterAt = %v, want %v", got, tt.todayExpect)
 			}
-			if got := isDueTomorrowFilter(tt.goal); got != tt.tomorrowExpect {
-				t.Errorf("isDueTomorrowFilter = %v, want %v", got, tt.tomorrowExpect)
+			if got := isDueTomorrowFilterAt(tt.goal, now); got != tt.tomorrowExpect {
+				t.Errorf("isDueTomorrowFilterAt = %v, want %v", got, tt.tomorrowExpect)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- \`buzz today\` and \`buzz tomorrow\` previously surfaced goals whose \`curval\` had already met or passed \`goalval\`, displaying a negative baremin like \`best  -00:00:37\` — the give-back delta from the plateaued bright red line. Those goals have no remaining work and shouldn't appear as due.
- Added \`Curval\`, \`Goalval\`, and \`Mathishard\` fields to the \`Goal\` struct and a new \`IsEndValueReached\` helper that checks \`curval\` vs. \`goalval\` (with \`mathishard[1]\` fallback for the auto-computed-of-three case) in the goal's \`dir\` direction.
- \`isDueTodayFilter\` and \`isDueTomorrowFilter\` now exclude end-value-reached goals. Helper returns false on missing data so goals aren't hidden unsafely.

## Test plan
- [x] \`go test -run "TestIsEndValueReached|TestDueFiltersSkipEndValueReached|TestIsDueToday|TestIsDueTomorrow" ./...\`
- [x] \`go vet ./...\` and \`go build ./...\` clean
- [ ] Manually verify \`buzz tomorrow\` no longer shows goals like \`best  -00:00:37\` against a real account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goals that have reached their end value are now excluded from "due today" and "due tomorrow" lists; detection respects current vs target values and goal direction, including special visibility caps for certain goal types.
* **Tests**
  * Added unit tests covering end-value resolution and the updated due-date filters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/235)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->