### PR TITLE
feat(tomorrow): include due-today goals with bumped baremin

### DIFF
--- a/main.go
+++ b/main.go
@@ -544,6 +544,12 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	if g.Rate == nil {
 		return g.Baremin
 	}
+	// Without recognised runits we can't safely convert the rate to a per-day
+	// amount, so fall back to the original baremin rather than producing a
+	// dimensionally-wrong bump.
+	if !isKnownRunits(g.Runits) {
+		return g.Baremin
+	}
 	value := ParseBareminValue(g.Baremin)
 	base, err := strconv.ParseFloat(value, 64)
 	if err != nil {
@@ -556,6 +562,17 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 		sign = ""
 	}
 	return fmt.Sprintf("%s%g in 1 day", sign, total)
+}
+
+// isKnownRunits reports whether the given runits string is one of the values
+// Beeminder uses (y/m/w/d/h). Callers that need a dimensionally-correct
+// per-day conversion should bail out for anything else.
+func isKnownRunits(runits string) bool {
+	switch runits {
+	case "y", "m", "w", "d", "h":
+		return true
+	}
+	return false
 }
 
 // ratePerDay converts a rate expressed in the given runits into an equivalent

--- a/main.go
+++ b/main.go
@@ -729,9 +729,9 @@ func handleTodayCommand() {
 // to not be due tomorrow.
 func handleTomorrowCommand() {
 	now := time.Now()
-	handleFilteredCommandWithBaremin("tomorrow", isDueTomorrowFilter, func(g Goal) string {
-		return bareminByEndOfTomorrowAt(g, now)
-	})
+	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
+	bareminFor := func(g Goal) string { return bareminByEndOfTomorrowAt(g, now) }
+	handleFilteredCommandWithBaremin("tomorrow", filter, bareminFor)
 }
 
 // handleLessCommand outputs all do-less type goals

--- a/main.go
+++ b/main.go
@@ -511,15 +511,71 @@ func isDueTodayFilter(g Goal) bool {
 	return isDueTodayFilterAt(g, time.Now())
 }
 
-// isDueTomorrowFilterAt returns true if the goal is due tomorrow (relative to now) and
-// hasn't already reached its end value. Exposed for deterministic time-based tests.
+// isDueTomorrowFilterAt returns true if the goal is due by the end of tomorrow
+// (i.e. due today or tomorrow) and hasn't already reached its end value. Goals
+// due today are included so the tomorrow view shows the full set of goals the
+// user must address to avoid a beemergency tomorrow. Exposed for deterministic
+// time-based tests.
 func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
-	return IsDueTomorrowAt(g.Losedate, now) && !IsEndValueReached(g)
+	if IsEndValueReached(g) {
+		return false
+	}
+	return IsDueTodayAt(g.Losedate, now) || IsDueTomorrowAt(g.Losedate, now)
 }
 
-// isDueTomorrowFilter returns true if the goal is due tomorrow and hasn't already reached its end value
+// isDueTomorrowFilter returns true if the goal is due by the end of tomorrow and hasn't already reached its end value
 func isDueTomorrowFilter(g Goal) bool {
 	return isDueTomorrowFilterAt(g, time.Now())
+}
+
+// bareminByEndOfTomorrowAt returns the baremin string to display for a goal in
+// the "due tomorrow" view. For goals already due tomorrow, the goal's existing
+// Baremin string is returned (it already reflects what's needed by tomorrow's
+// deadline). For goals due today, one day's worth of rate is added so the
+// displayed amount reflects what's required to avoid a beemergency tomorrow.
+//
+// If the baremin can't be parsed as a plain number (e.g. it's an HH:MM time
+// value) or rate information is missing, the original Baremin string is
+// returned unchanged.
+func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
+	if !IsDueTodayAt(g.Losedate, now) {
+		return g.Baremin
+	}
+	if g.Rate == nil {
+		return g.Baremin
+	}
+	value := ParseBareminValue(g.Baremin)
+	base, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return g.Baremin
+	}
+	perDay := ratePerDay(*g.Rate, g.Runits)
+	total := base + perDay
+	sign := "+"
+	if total < 0 {
+		sign = ""
+	}
+	return fmt.Sprintf("%s%g in 1 day", sign, total)
+}
+
+// ratePerDay converts a rate expressed in the given runits into an equivalent
+// amount per day. Supports the runits Beeminder reports: y, m, w, d, h. For
+// unrecognised units the rate is returned unchanged.
+func ratePerDay(rate float64, runits string) float64 {
+	switch runits {
+	case "y":
+		return rate / 365.0
+	case "m":
+		return rate / 30.0
+	case "w":
+		return rate / 7.0
+	case "d":
+		return rate
+	case "h":
+		return rate * 24.0
+	default:
+		return rate
+	}
 }
 
 // isDoLessFilter returns true if the goal is a do-less type goal
@@ -667,9 +723,15 @@ func handleTodayCommand() {
 	handleFilteredCommand("today", isDueTodayFilter)
 }
 
-// handleTomorrowCommand outputs all goals that are due tomorrow
+// handleTomorrowCommand outputs all goals that are due tomorrow. Goals that
+// are already due today are included with their baremin bumped by one day's
+// rate, so the user sees the total amount they would need to do for the goal
+// to not be due tomorrow.
 func handleTomorrowCommand() {
-	handleFilteredCommand("tomorrow", isDueTomorrowFilter)
+	now := time.Now()
+	handleFilteredCommandWithBaremin("tomorrow", isDueTomorrowFilter, func(g Goal) string {
+		return bareminByEndOfTomorrowAt(g, now)
+	})
 }
 
 // handleLessCommand outputs all do-less type goals
@@ -714,6 +776,13 @@ func handleDueCommand() {
 // filterName is used in messages (e.g., "today", "tomorrow", or "do-less")
 // filter is a function that takes a Goal and returns true if the goal matches
 func handleFilteredCommand(filterName string, filter func(Goal) bool) {
+	handleFilteredCommandWithBaremin(filterName, filter, func(g Goal) string { return g.Baremin })
+}
+
+// handleFilteredCommandWithBaremin is like handleFilteredCommand but lets the
+// caller customise the baremin string displayed for each goal. This is used by
+// the tomorrow view to bump due-today goals by one day's rate.
+func handleFilteredCommandWithBaremin(filterName string, filter func(Goal) bool, bareminFor func(Goal) string) {
 	// Load config
 	if !ConfigExists() {
 		fmt.Println("Error: No configuration found. Please run 'buzz' first to authenticate.")
@@ -753,6 +822,7 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 	// Pre-calculate formatted values to avoid redundant formatting calls
 	type goalDisplay struct {
 		goal             Goal
+		baremin          string
 		timeframe        string
 		absoluteDeadline string
 	}
@@ -765,8 +835,10 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 	for i, goal := range filteredGoals {
 		timeframe := FormatDueDate(goal.Losedate)
 		absoluteDeadline := FormatAbsoluteDeadline(goal.Losedate)
+		baremin := bareminFor(goal)
 		displays[i] = goalDisplay{
 			goal:             goal,
+			baremin:          baremin,
 			timeframe:        timeframe,
 			absoluteDeadline: absoluteDeadline,
 		}
@@ -774,8 +846,8 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 		if len(goal.Slug) > maxSlugWidth {
 			maxSlugWidth = len(goal.Slug)
 		}
-		if len(goal.Baremin) > maxBareminWidth {
-			maxBareminWidth = len(goal.Baremin)
+		if len(baremin) > maxBareminWidth {
+			maxBareminWidth = len(baremin)
 		}
 		if len(timeframe) > maxRelativeWidth {
 			maxRelativeWidth = len(timeframe)
@@ -800,7 +872,7 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 		// Format the line with proper spacing
 		line := fmt.Sprintf("%-*s  %-*s  %-*s  %s",
 			maxSlugWidth, display.goal.Slug,
-			maxBareminWidth, display.goal.Baremin,
+			maxBareminWidth, display.baremin,
 			maxRelativeWidth, display.timeframe,
 			display.absoluteDeadline)
 

--- a/main.go
+++ b/main.go
@@ -523,11 +523,6 @@ func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
 	return IsDueTodayAt(g.Losedate, now) || IsDueTomorrowAt(g.Losedate, now)
 }
 
-// isDueTomorrowFilter returns true if the goal is due by the end of tomorrow and hasn't already reached its end value
-func isDueTomorrowFilter(g Goal) bool {
-	return isDueTomorrowFilterAt(g, time.Now())
-}
-
 // bareminByEndOfTomorrowAt returns the baremin string to display for a goal in
 // the "due tomorrow" view. For goals already due tomorrow, the goal's existing
 // Baremin string is returned (it already reflects what's needed by tomorrow's

--- a/main_test.go
+++ b/main_test.go
@@ -293,6 +293,16 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			goal:     Goal{Losedate: todayDeadline, Baremin: "0:05 today", Rate: f(1), Runits: "d"},
 			expected: "0:05 today",
 		},
+		{
+			name:     "due today with empty runits falls back",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+1 today", Rate: f(1), Runits: ""},
+			expected: "+1 today",
+		},
+		{
+			name:     "due today with unknown runits falls back",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+1 today", Rate: f(1), Runits: "x"},
+			expected: "+1 today",
+		},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -185,10 +185,12 @@ func TestDueFiltersSkipEndValueReached(t *testing.T) {
 		tomorrowExpect bool
 	}{
 		{
+			// Due-today goals are also surfaced in the tomorrow view: if the
+			// user does nothing today the goal carries into tomorrow.
 			name:           "do-more goal due today, not yet reached",
 			goal:           Goal{Losedate: todayDeadline, Dir: 1, Curval: f(50), Goalval: f(100)},
 			todayExpect:    true,
-			tomorrowExpect: false,
+			tomorrowExpect: true,
 		},
 		{
 			name:           "do-more goal due today, end value reached",
@@ -217,6 +219,87 @@ func TestDueFiltersSkipEndValueReached(t *testing.T) {
 			}
 			if got := isDueTomorrowFilterAt(tt.goal, now); got != tt.tomorrowExpect {
 				t.Errorf("isDueTomorrowFilterAt = %v, want %v", got, tt.tomorrowExpect)
+			}
+		})
+	}
+}
+
+// TestRatePerDay verifies rate conversion across the runits Beeminder reports.
+func TestRatePerDay(t *testing.T) {
+	tests := []struct {
+		name     string
+		rate     float64
+		runits   string
+		expected float64
+	}{
+		{"per day stays the same", 2, "d", 2},
+		{"per week divides by 7", 7, "w", 1},
+		{"per month divides by 30", 30, "m", 1},
+		{"per year divides by 365", 365, "y", 1},
+		{"per hour multiplies by 24", 0.5, "h", 12},
+		{"unknown unit passes through", 3, "x", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ratePerDay(tt.rate, tt.runits)
+			if got != tt.expected {
+				t.Errorf("ratePerDay(%v, %q) = %v, want %v", tt.rate, tt.runits, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestBareminByEndOfTomorrowAt verifies that due-today goals get their baremin
+// bumped by one day's worth of rate, while goals due tomorrow (or later) are
+// returned unchanged.
+func TestBareminByEndOfTomorrowAt(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	todayDeadline := time.Date(2025, 1, 15, 23, 0, 0, 0, time.UTC).Unix()
+	tomorrowDeadline := time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC).Unix()
+
+	tests := []struct {
+		name     string
+		goal     Goal
+		expected string
+	}{
+		{
+			name:     "due today with rate 1/day bumps +1 to +2",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+1 in 0 days", Rate: f(1), Runits: "d"},
+			expected: "+2 in 1 day",
+		},
+		{
+			name:     "due today with rate 7/week bumps +0 to +1",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+0 today", Rate: f(7), Runits: "w"},
+			expected: "+1 in 1 day",
+		},
+		{
+			name:     "due today with negative baremin still adds rate",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "-2 today", Rate: f(1), Runits: "d"},
+			expected: "-1 in 1 day",
+		},
+		{
+			name:     "due tomorrow is unchanged",
+			goal:     Goal{Losedate: tomorrowDeadline, Baremin: "+3 in 1 day", Rate: f(1), Runits: "d"},
+			expected: "+3 in 1 day",
+		},
+		{
+			name:     "due today with nil rate is unchanged",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+1 today", Rate: nil, Runits: "d"},
+			expected: "+1 today",
+		},
+		{
+			name:     "due today with non-numeric baremin is unchanged",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "0:05 today", Rate: f(1), Runits: "d"},
+			expected: "0:05 today",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bareminByEndOfTomorrowAt(tt.goal, now)
+			if got != tt.expected {
+				t.Errorf("bareminByEndOfTomorrowAt = %q, want %q", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `buzz tomorrow` now includes goals due **today** in addition to goals due tomorrow. Previously these were filtered out, implying a due-today goal won't be due tomorrow — but if the user does nothing today, it will be.
- For due-today goals shown in the tomorrow view, the displayed baremin is bumped by one day's worth of rate. A 1/day goal currently showing `+1` in `buzz today` now shows `+2 in 1 day` in `buzz tomorrow` — directly answering "what do I need to do today to keep this off tomorrow's list?"
- Falls back to the unmodified baremin for non-numeric formats (e.g. HH:MM time goals) or when rate info is missing, so display is never broken.

## Implementation notes

- `isDueTomorrowFilterAt` now accepts goals due today OR tomorrow (end-value-reached goals still excluded).
- New `bareminByEndOfTomorrowAt` + `ratePerDay` helpers handle the baremin adjustment.
- `handleFilteredCommand` refactored to delegate to `handleFilteredCommandWithBaremin`, which threads a per-goal baremin formatter through the column-width and rendering logic. Only the tomorrow command opts into the bumping formatter; other views are unchanged.

## Test plan

- [x] Unit tests for `ratePerDay` across y/m/w/d/h and unknown units
- [x] Unit tests for `bareminByEndOfTomorrowAt` covering rate-1/day bump, weekly rate, negative baremin, due-tomorrow passthrough, nil-rate fallback, and HH:MM non-numeric fallback
- [x] Updated `TestDueFiltersSkipEndValueReached` to reflect the new filter semantics (due-today, not-reached is now tomorrow-visible)
- [ ] Manually verify `buzz tomorrow` output against a live account

Two pre-existing test failures (`TestExtractTimeSlots`, `TestExtractTimeSlotsAcrossDates`) also fail on `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Goals due today that haven't reached their target are now included in the "tomorrow" view.
  * The tomorrow listing shows an adjusted expected-value (baremin) for due-today goals, reflecting one day’s worth of progress when rate and units are available.

* **Tests**
  * Added unit tests for per-day rate conversion and baremin adjustments across due-today/due-tomorrow and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/236)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->