### PR TITLE
fix(tomorrow): bump HH:MM baremin for hours-valued time goals

### DIFF
--- a/main.go
+++ b/main.go
@@ -597,6 +597,12 @@ func parseHoursMinutes(s string) (float64, bool) {
 	if err != nil {
 		return 0, false
 	}
+	// Reject malformed inputs (e.g. "1:75", "1:-05", "--1:30"). The leading
+	// sign has already been stripped into `sign`, so either field being
+	// negative — or minutes outside [0, 60) — means the string was malformed.
+	if hh < 0 || mm < 0 || mm >= 60 {
+		return 0, false
+	}
 	return sign * (float64(hh) + float64(mm)/60.0), true
 }
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"sort"
@@ -529,9 +530,12 @@ func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
 // deadline). For goals due today, one day's worth of rate is added so the
 // displayed amount reflects what's required to avoid a beemergency tomorrow.
 //
-// If the baremin can't be parsed as a plain number (e.g. it's an HH:MM time
-// value) or rate information is missing, the original Baremin string is
-// returned unchanged.
+// Two baremin value shapes are recognised: plain numeric (e.g. "+2") and the
+// HH:MM time format used by hour-valued goals (e.g. "+00:25"). For both, the
+// goal's rate is interpreted as units-of-baremin per runits and converted to a
+// per-day amount before being added. If rate information is missing, runits
+// isn't one Beeminder uses, or the value can't be parsed, the original Baremin
+// string is returned unchanged.
 func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	if !IsDueTodayAt(g.Losedate, now) {
 		return g.Baremin
@@ -546,17 +550,65 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 		return g.Baremin
 	}
 	value := ParseBareminValue(g.Baremin)
+	perDay := ratePerDay(*g.Rate, g.Runits)
+
+	// HH:MM time format — e.g. "+00:25 in 8 hours". The base value and the rate
+	// share the same unit (hours), so add in hours and reformat as HH:MM.
+	if strings.Contains(value, ":") {
+		baseHours, ok := parseHoursMinutes(value)
+		if !ok {
+			return g.Baremin
+		}
+		totalMinutes := int(math.Round((baseHours + perDay) * 60))
+		return formatMinutesAsHHMM(totalMinutes) + " in 1 day"
+	}
+
+	// Plain numeric.
 	base, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return g.Baremin
 	}
-	perDay := ratePerDay(*g.Rate, g.Runits)
 	total := base + perDay
 	sign := "+"
 	if total < 0 {
 		sign = ""
 	}
 	return fmt.Sprintf("%s%g in 1 day", sign, total)
+}
+
+// parseHoursMinutes parses a "[-]HH:MM" string and returns the value as a
+// fractional hours float. Returns ok=false for anything that isn't exactly two
+// colon-separated integer fields.
+func parseHoursMinutes(s string) (float64, bool) {
+	sign := 1.0
+	if strings.HasPrefix(s, "-") {
+		sign = -1.0
+		s = strings.TrimPrefix(s, "-")
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	hh, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, false
+	}
+	mm, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, false
+	}
+	return sign * (float64(hh) + float64(mm)/60.0), true
+}
+
+// formatMinutesAsHHMM formats a signed minute count as Beeminder's HH:MM
+// baremin style (zero-padded hours and minutes, leading "+" for non-negative).
+func formatMinutesAsHHMM(totalMinutes int) string {
+	sign := "+"
+	if totalMinutes < 0 {
+		sign = "-"
+		totalMinutes = -totalMinutes
+	}
+	return fmt.Sprintf("%s%02d:%02d", sign, totalMinutes/60, totalMinutes%60)
 }
 
 // isKnownRunits reports whether the given runits string is one of the values

--- a/main_test.go
+++ b/main_test.go
@@ -356,6 +356,10 @@ func TestParseHoursMinutes(t *testing.T) {
 		{"three parts is rejected", "1:30:00", 0, false},
 		{"missing minutes is rejected", "1", 0, false},
 		{"non-numeric is rejected", "ab:cd", 0, false},
+		{"out-of-range minutes is rejected", "1:75", 0, false},
+		{"negative minutes field is rejected", "1:-05", 0, false},
+		{"double-negative is rejected", "--1:30", 0, false},
+		{"minutes at boundary (60) is rejected", "1:60", 0, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -289,9 +289,32 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			expected: "+1 today",
 		},
 		{
-			name:     "due today with non-numeric baremin is unchanged",
-			goal:     Goal{Losedate: todayDeadline, Baremin: "0:05 today", Rate: f(1), Runits: "d"},
-			expected: "0:05 today",
+			// Real-world scenario from a "clean" hours-valued goal: 25 minutes
+			// due today, rate 1 hour/day. Tomorrow needs today's 25 minutes
+			// plus another hour = 1:25.
+			name:     "due today with HH:MM baremin and rate 1/day bumps by 1 hour",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+00:25 in 8 hours", Rate: f(1), Runits: "d"},
+			expected: "+01:25 in 1 day",
+		},
+		{
+			name:     "due today with HH:MM baremin and rate 7/week bumps by 1 hour",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+00:30 today", Rate: f(7), Runits: "w"},
+			expected: "+01:30 in 1 day",
+		},
+		{
+			name:     "due today with HH:MM baremin and fractional rate rounds minutes",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+00:25 today", Rate: f(0.5), Runits: "d"},
+			expected: "+00:55 in 1 day",
+		},
+		{
+			name:     "due today with HH:MM:SS baremin (3 parts) falls back",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "1:30:00 today", Rate: f(1), Runits: "d"},
+			expected: "1:30:00 today",
+		},
+		{
+			name:     "due today with garbage baremin falls back",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "garbage today", Rate: f(1), Runits: "d"},
+			expected: "garbage today",
 		},
 		{
 			name:     "due today with empty runits falls back",
@@ -310,6 +333,62 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			got := bareminByEndOfTomorrowAt(tt.goal, now)
 			if got != tt.expected {
 				t.Errorf("bareminByEndOfTomorrowAt = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestParseHoursMinutes verifies the HH:MM → fractional-hours parser used by
+// bareminByEndOfTomorrowAt for time-format baremin values.
+func TestParseHoursMinutes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected float64
+		ok       bool
+	}{
+		{"zero", "0:00", 0, true},
+		{"twenty-five minutes", "00:25", 25.0 / 60.0, true},
+		{"one and a half hours", "1:30", 1.5, true},
+		{"single digit hours", "9:15", 9.25, true},
+		{"double digit hours", "12:30", 12.5, true},
+		{"negative", "-0:15", -0.25, true},
+		{"three parts is rejected", "1:30:00", 0, false},
+		{"missing minutes is rejected", "1", 0, false},
+		{"non-numeric is rejected", "ab:cd", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseHoursMinutes(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("parseHoursMinutes(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if ok && got != tt.expected {
+				t.Errorf("parseHoursMinutes(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestFormatMinutesAsHHMM verifies the HH:MM formatter matches Beeminder's
+// zero-padded baremin style with a leading sign.
+func TestFormatMinutesAsHHMM(t *testing.T) {
+	tests := []struct {
+		minutes  int
+		expected string
+	}{
+		{0, "+00:00"},
+		{25, "+00:25"},
+		{85, "+01:25"},
+		{90, "+01:30"},
+		{605, "+10:05"},
+		{-15, "-00:15"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := formatMinutesAsHHMM(tt.minutes)
+			if got != tt.expected {
+				t.Errorf("formatMinutesAsHHMM(%d) = %q, want %q", tt.minutes, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

After #236 merged, `buzz tomorrow` was still showing the same baremin as `buzz today` for any hours-valued goal — e.g. a 25-minute "clean" goal due today showed `+00:25` in both views instead of `+01:25` in the tomorrow view.

Root cause: `bareminByEndOfTomorrowAt` ran the baremin value through `strconv.ParseFloat`, which fails for the `HH:MM` format Beeminder uses for hour-valued goals. The error path fell back to the original `Baremin` string, silently disabling bumping for the entire family of time goals.

## Fix

- Detect colon-separated values and parse them via a new `parseHoursMinutes` helper (fractional hours, signed).
- Add `ratePerDay` directly in matching hour units, then reformat with `formatMinutesAsHHMM` to match Beeminder's zero-padded `+HH:MM` style.
- HH:MM:SS, garbage strings, missing/unknown runits, and nil rate still fall through to the existing fallback path.

For a `clean` goal with `+00:25` baremin and rate `1/day`, `buzz tomorrow` now shows `+01:25 in 1 day`.

## Test plan

- [x] New cases in `TestBareminByEndOfTomorrowAt`: rate 1/day, rate 7/week, fractional rate rounding, HH:MM:SS fallback, garbage fallback
- [x] New unit tests `TestParseHoursMinutes` and `TestFormatMinutesAsHHMM`
- [ ] Manually verify against the live `clean` goal after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for HH:MM time entries in due-tomorrow deadline calculations, with rate-based daily adjustments and proper rounding.

* **Bug Fixes**
  * Malformed times, unrecognized units, or missing rates now reliably fall back to the original deadline value.

* **Tests**
  * Expanded tests covering HH:MM parsing, formatting, rounding, negative values, and malformed inputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/237)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->