### PR TITLE
fix(tomorrow): bump HH:MM:SS baremin for time-valued goals

### DIFF
--- a/main.go
+++ b/main.go
@@ -620,8 +620,13 @@ func parseTimeValue(s string) (totalSeconds int, includeSeconds bool, ok bool) {
 // formatTimeValue formats a signed second count back into Beeminder's
 // colon-separated baremin style. When includeSeconds is true the output is
 // HH:MM:SS, otherwise HH:MM. Hours, minutes, and seconds are zero-padded and a
-// leading "+" is included for non-negative values.
+// leading "+" is included for non-negative values. When dropping seconds, the
+// value is rounded to the nearest minute first so a fractional-minute bump
+// from the rate conversion doesn't silently undercount by up to 59 seconds.
 func formatTimeValue(totalSeconds int, includeSeconds bool) string {
+	if !includeSeconds {
+		totalSeconds = int(math.Round(float64(totalSeconds)/60.0)) * 60
+	}
 	sign := "+"
 	if totalSeconds < 0 {
 		sign = "-"

--- a/main.go
+++ b/main.go
@@ -531,11 +531,12 @@ func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
 // displayed amount reflects what's required to avoid a beemergency tomorrow.
 //
 // Two baremin value shapes are recognised: plain numeric (e.g. "+2") and the
-// HH:MM time format used by hour-valued goals (e.g. "+00:25"). For both, the
-// goal's rate is interpreted as units-of-baremin per runits and converted to a
-// per-day amount before being added. If rate information is missing, runits
-// isn't one Beeminder uses, or the value can't be parsed, the original Baremin
-// string is returned unchanged.
+// colon-separated time format used by hour-valued goals — both "HH:MM" (e.g.
+// "+00:25") and "HH:MM:SS" (e.g. "+00:25:00"). For both, the goal's rate is
+// interpreted as units-of-baremin per runits and converted to a per-day amount
+// before being added. The output preserves whichever colon format the input
+// used. If rate information is missing, runits isn't one Beeminder uses, or
+// the value can't be parsed, the original Baremin string is returned unchanged.
 func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	if !IsDueTodayAt(g.Losedate, now) {
 		return g.Baremin
@@ -552,15 +553,16 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	value := ParseBareminValue(g.Baremin)
 	perDay := ratePerDay(*g.Rate, g.Runits)
 
-	// HH:MM time format — e.g. "+00:25 in 8 hours". The base value and the rate
-	// share the same unit (hours), so add in hours and reformat as HH:MM.
+	// Colon-separated time formats — HH:MM or HH:MM:SS. The base value and
+	// the rate share the same hour unit, so add in seconds and reformat in
+	// whichever colon format the input used.
 	if strings.Contains(value, ":") {
-		baseHours, ok := parseHoursMinutes(value)
+		baseSeconds, includeSeconds, ok := parseTimeValue(value)
 		if !ok {
 			return g.Baremin
 		}
-		totalMinutes := int(math.Round((baseHours + perDay) * 60))
-		return formatMinutesAsHHMM(totalMinutes) + " in 1 day"
+		totalSeconds := baseSeconds + int(math.Round(perDay*3600))
+		return formatTimeValue(totalSeconds, includeSeconds) + " in 1 day"
 	}
 
 	// Plain numeric.
@@ -576,45 +578,61 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	return fmt.Sprintf("%s%g in 1 day", sign, total)
 }
 
-// parseHoursMinutes parses a "[-]HH:MM" string and returns the value as a
-// fractional hours float. Returns ok=false for anything that isn't exactly two
-// colon-separated integer fields.
-func parseHoursMinutes(s string) (float64, bool) {
-	sign := 1.0
+// parseTimeValue parses a "[-]HH:MM" or "[-]HH:MM:SS" string into total
+// seconds. The second return value reports whether the input included a
+// seconds component, so callers can preserve the original format on output.
+// Returns ok=false for anything that isn't exactly two or three colon-separated
+// non-negative integer fields with minutes and seconds < 60.
+func parseTimeValue(s string) (totalSeconds int, includeSeconds bool, ok bool) {
+	sign := 1
 	if strings.HasPrefix(s, "-") {
-		sign = -1.0
+		sign = -1
 		s = strings.TrimPrefix(s, "-")
 	}
 	parts := strings.Split(s, ":")
-	if len(parts) != 2 {
-		return 0, false
+	if len(parts) != 2 && len(parts) != 3 {
+		return 0, false, false
 	}
 	hh, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return 0, false
+		return 0, false, false
 	}
 	mm, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return 0, false
+		return 0, false, false
 	}
-	// Reject malformed inputs (e.g. "1:75", "1:-05", "--1:30"). The leading
-	// sign has already been stripped into `sign`, so either field being
-	// negative — or minutes outside [0, 60) — means the string was malformed.
-	if hh < 0 || mm < 0 || mm >= 60 {
-		return 0, false
+	ss := 0
+	if len(parts) == 3 {
+		ss, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return 0, false, false
+		}
 	}
-	return sign * (float64(hh) + float64(mm)/60.0), true
+	// Reject malformed inputs (e.g. "1:75", "1:-05:00", "--1:30"). The leading
+	// sign has already been stripped, so any negative field — or minutes/
+	// seconds outside [0, 60) — means the string was malformed.
+	if hh < 0 || mm < 0 || mm >= 60 || ss < 0 || ss >= 60 {
+		return 0, false, false
+	}
+	return sign * (hh*3600 + mm*60 + ss), len(parts) == 3, true
 }
 
-// formatMinutesAsHHMM formats a signed minute count as Beeminder's HH:MM
-// baremin style (zero-padded hours and minutes, leading "+" for non-negative).
-func formatMinutesAsHHMM(totalMinutes int) string {
+// formatTimeValue formats a signed second count back into Beeminder's
+// colon-separated baremin style. When includeSeconds is true the output is
+// HH:MM:SS, otherwise HH:MM. Hours, minutes, and seconds are zero-padded and a
+// leading "+" is included for non-negative values.
+func formatTimeValue(totalSeconds int, includeSeconds bool) string {
 	sign := "+"
-	if totalMinutes < 0 {
+	if totalSeconds < 0 {
 		sign = "-"
-		totalMinutes = -totalMinutes
+		totalSeconds = -totalSeconds
 	}
-	return fmt.Sprintf("%s%02d:%02d", sign, totalMinutes/60, totalMinutes%60)
+	h := totalSeconds / 3600
+	m := (totalSeconds % 3600) / 60
+	if includeSeconds {
+		return fmt.Sprintf("%s%02d:%02d:%02d", sign, h, m, totalSeconds%60)
+	}
+	return fmt.Sprintf("%s%02d:%02d", sign, h, m)
 }
 
 // isKnownRunits reports whether the given runits string is one of the values

--- a/main_test.go
+++ b/main_test.go
@@ -307,9 +307,17 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			expected: "+00:55 in 1 day",
 		},
 		{
-			name:     "due today with HH:MM:SS baremin (3 parts) falls back",
-			goal:     Goal{Losedate: todayDeadline, Baremin: "1:30:00 today", Rate: f(1), Runits: "d"},
-			expected: "1:30:00 today",
+			// Real-world "clean" goal: Beeminder returns HH:MM:SS for some
+			// hour-valued goals (`+00:25:00 today` style). The bumped output
+			// should preserve the HH:MM:SS format the input used.
+			name:     "due today with HH:MM:SS baremin bumps and preserves format",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+00:25:00 today", Rate: f(1), Runits: "d"},
+			expected: "+01:25:00 in 1 day",
+		},
+		{
+			name:     "due today with HH:MM:SS baremin with seconds bumps cleanly",
+			goal:     Goal{Losedate: todayDeadline, Baremin: "+00:25:30 today", Rate: f(1), Runits: "d"},
+			expected: "+01:25:30 in 1 day",
 		},
 		{
 			name:     "due today with garbage baremin falls back",
@@ -338,61 +346,81 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 	}
 }
 
-// TestParseHoursMinutes verifies the HH:MM → fractional-hours parser used by
-// bareminByEndOfTomorrowAt for time-format baremin values.
-func TestParseHoursMinutes(t *testing.T) {
+// TestParseTimeValue verifies the colon-separated time parser used by
+// bareminByEndOfTomorrowAt for HH:MM and HH:MM:SS baremin values.
+func TestParseTimeValue(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected float64
-		ok       bool
+		name            string
+		input           string
+		expectedSeconds int
+		expectedHasSec  bool
+		ok              bool
 	}{
-		{"zero", "0:00", 0, true},
-		{"twenty-five minutes", "00:25", 25.0 / 60.0, true},
-		{"one and a half hours", "1:30", 1.5, true},
-		{"single digit hours", "9:15", 9.25, true},
-		{"double digit hours", "12:30", 12.5, true},
-		{"negative", "-0:15", -0.25, true},
-		{"three parts is rejected", "1:30:00", 0, false},
-		{"missing minutes is rejected", "1", 0, false},
-		{"non-numeric is rejected", "ab:cd", 0, false},
-		{"out-of-range minutes is rejected", "1:75", 0, false},
-		{"negative minutes field is rejected", "1:-05", 0, false},
-		{"double-negative is rejected", "--1:30", 0, false},
-		{"minutes at boundary (60) is rejected", "1:60", 0, false},
+		{"HH:MM zero", "0:00", 0, false, true},
+		{"HH:MM twenty-five minutes", "00:25", 25 * 60, false, true},
+		{"HH:MM one and a half hours", "1:30", 90 * 60, false, true},
+		{"HH:MM single digit hours", "9:15", 9*3600 + 15*60, false, true},
+		{"HH:MM double digit hours", "12:30", 12*3600 + 30*60, false, true},
+		{"HH:MM negative", "-0:15", -15 * 60, false, true},
+		{"HH:MM:SS zero", "0:00:00", 0, true, true},
+		{"HH:MM:SS twenty-five minutes", "00:25:00", 25 * 60, true, true},
+		{"HH:MM:SS with seconds", "01:25:30", 1*3600 + 25*60 + 30, true, true},
+		{"HH:MM:SS negative", "-0:00:15", -15, true, true},
+		{"four parts is rejected", "1:30:00:00", 0, false, false},
+		{"missing minutes is rejected", "1", 0, false, false},
+		{"non-numeric is rejected", "ab:cd", 0, false, false},
+		{"out-of-range minutes is rejected", "1:75", 0, false, false},
+		{"out-of-range seconds is rejected", "1:30:75", 0, false, false},
+		{"negative minutes field is rejected", "1:-05", 0, false, false},
+		{"negative seconds field is rejected", "1:30:-05", 0, false, false},
+		{"double-negative is rejected", "--1:30", 0, false, false},
+		{"minutes at boundary (60) is rejected", "1:60", 0, false, false},
+		{"seconds at boundary (60) is rejected", "1:30:60", 0, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := parseHoursMinutes(tt.input)
+			gotSeconds, gotHasSec, ok := parseTimeValue(tt.input)
 			if ok != tt.ok {
-				t.Fatalf("parseHoursMinutes(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+				t.Fatalf("parseTimeValue(%q) ok = %v, want %v", tt.input, ok, tt.ok)
 			}
-			if ok && got != tt.expected {
-				t.Errorf("parseHoursMinutes(%q) = %v, want %v", tt.input, got, tt.expected)
+			if !ok {
+				return
+			}
+			if gotSeconds != tt.expectedSeconds {
+				t.Errorf("parseTimeValue(%q) seconds = %d, want %d", tt.input, gotSeconds, tt.expectedSeconds)
+			}
+			if gotHasSec != tt.expectedHasSec {
+				t.Errorf("parseTimeValue(%q) includeSeconds = %v, want %v", tt.input, gotHasSec, tt.expectedHasSec)
 			}
 		})
 	}
 }
 
-// TestFormatMinutesAsHHMM verifies the HH:MM formatter matches Beeminder's
-// zero-padded baremin style with a leading sign.
-func TestFormatMinutesAsHHMM(t *testing.T) {
+// TestFormatTimeValue verifies the colon-separated formatter matches
+// Beeminder's zero-padded baremin style with a leading sign, in both HH:MM and
+// HH:MM:SS variants.
+func TestFormatTimeValue(t *testing.T) {
 	tests := []struct {
-		minutes  int
-		expected string
+		seconds        int
+		includeSeconds bool
+		expected       string
 	}{
-		{0, "+00:00"},
-		{25, "+00:25"},
-		{85, "+01:25"},
-		{90, "+01:30"},
-		{605, "+10:05"},
-		{-15, "-00:15"},
+		{0, false, "+00:00"},
+		{25 * 60, false, "+00:25"},
+		{85 * 60, false, "+01:25"},
+		{605 * 60, false, "+10:05"},
+		{-15 * 60, false, "-00:15"},
+		{0, true, "+00:00:00"},
+		{25 * 60, true, "+00:25:00"},
+		{85 * 60, true, "+01:25:00"},
+		{85*60 + 30, true, "+01:25:30"},
+		{-15, true, "-00:00:15"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
-			got := formatMinutesAsHHMM(tt.minutes)
+			got := formatTimeValue(tt.seconds, tt.includeSeconds)
 			if got != tt.expected {
-				t.Errorf("formatMinutesAsHHMM(%d) = %q, want %q", tt.minutes, got, tt.expected)
+				t.Errorf("formatTimeValue(%d, %v) = %q, want %q", tt.seconds, tt.includeSeconds, got, tt.expected)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -410,6 +410,11 @@ func TestFormatTimeValue(t *testing.T) {
 		{85 * 60, false, "+01:25"},
 		{605 * 60, false, "+10:05"},
 		{-15 * 60, false, "-00:15"},
+		// When dropping seconds, round to the nearest minute rather than
+		// truncating — 30 seconds past the minute rounds up to the next.
+		{25*60 + 30, false, "+00:26"},
+		{25*60 + 29, false, "+00:25"},
+		{-15*60 - 30, false, "-00:16"},
 		{0, true, "+00:00:00"},
 		{25 * 60, true, "+00:25:00"},
 		{85 * 60, true, "+01:25:00"},


### PR DESCRIPTION
## Summary

After v0.62.1 a real-world `clean` goal still showed `+00:25:00` in both `buzz today` and `buzz tomorrow`. Beeminder returns baremin in `HH:MM:SS` (not just `HH:MM`) for some hour-valued goals — `parseHoursMinutes` only accepted two colon-separated fields, so the three-field value tripped the fallback path.

Actual output that prompted this fix:

```
buzz today
clean       +00:25:00  1h  5:59 PM

buzz tomorrow
clean       +00:25:00  2h  5:59 PM
```

## Fix

- Replace `parseHoursMinutes` / `formatMinutesAsHHMM` with `parseTimeValue` / `formatTimeValue` that work in seconds and handle both `HH:MM` and `HH:MM:SS`.
- The parser returns `(totalSeconds, includeSeconds, ok)` so the formatter can round-trip whichever format the input used.
- Same out-of-range rejection rules apply to the new seconds field (`ss < 0`, `ss >= 60`).

For the `clean` goal: `+00:25:00` + 1 hour rate per day → `+01:25:00 in 1 day`.

## Test plan

- [x] `TestBareminByEndOfTomorrowAt` now exercises HH:MM:SS bumping (including a `+00:25:30` round-trip)
- [x] `TestParseTimeValue` covers both HH:MM and HH:MM:SS valid inputs plus rejection cases for each (out-of-range minutes/seconds, negatives, 4-part inputs)
- [x] `TestFormatTimeValue` covers both formats including negative seconds
- [ ] Manually verify against the live `clean` goal after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time values now support second-precision (HH:MM:SS) while preserving the input format on output.
  * When a goal is due today, time values are correctly adjusted by one day’s rate and rounded to the nearest second.

* **Bug Fixes / Robustness**
  * Improved parsing and validation of colon-separated time inputs (HH:MM and HH:MM:SS), including sign handling and out-of-range checks, with safe fallback to previous behavior on parse failure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/238)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->