### PR TITLE
fix(tomorrow): derive per-day slope from roadall, not g.Rate

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -13,28 +13,29 @@ import (
 
 // Goal represents a Beeminder goal with relevant fields
 type Goal struct {
-	Slug        string      `json:"slug"`
-	Title       string      `json:"title"`
-	Fineprint   string      `json:"fineprint"` // User-provided description of what they're committing to
-	GoalType    string      `json:"goal_type"` // Goal type (hustler, biker, fatloser, gainer, inboxer, drinker)
-	Losedate    int64       `json:"losedate"`
-	Pledge      float64     `json:"pledge"`
-	PledgeCap   *float64    `json:"pledge_cap"` // Pointer to handle null values from API
-	Safebuf     int         `json:"safebuf"`
-	Limsum      string      `json:"limsum"`
-	Baremin     string      `json:"baremin"`
-	Autodata    string      `json:"autodata"`
-	Autoratchet *float64    `json:"autoratchet"` // Pointer to handle null values from API
-	Rate        *float64    `json:"rate"`        // Pointer to handle null values from API
-	Runits      string      `json:"runits"`
-	Gunits      string      `json:"gunits"`     // Goal units, like "hours" or "pushups" or "pages"
-	Deadline    int         `json:"deadline"`   // Seconds by which deadline differs from midnight
-	Yaw         int         `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
-	Dir         int         `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
-	Curval      *float64    `json:"curval"`     // Most recent datapoint value
-	Goalval     *float64    `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
-	Mathishard  []*float64  `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)
-	Datapoints  []Datapoint `json:"datapoints,omitempty"`
+	Slug        string       `json:"slug"`
+	Title       string       `json:"title"`
+	Fineprint   string       `json:"fineprint"` // User-provided description of what they're committing to
+	GoalType    string       `json:"goal_type"` // Goal type (hustler, biker, fatloser, gainer, inboxer, drinker)
+	Losedate    int64        `json:"losedate"`
+	Pledge      float64      `json:"pledge"`
+	PledgeCap   *float64     `json:"pledge_cap"` // Pointer to handle null values from API
+	Safebuf     int          `json:"safebuf"`
+	Limsum      string       `json:"limsum"`
+	Baremin     string       `json:"baremin"`
+	Autodata    string       `json:"autodata"`
+	Autoratchet *float64     `json:"autoratchet"` // Pointer to handle null values from API
+	Rate        *float64     `json:"rate"`        // Pointer to handle null values from API
+	Runits      string       `json:"runits"`
+	Gunits      string       `json:"gunits"`     // Goal units, like "hours" or "pushups" or "pages"
+	Deadline    int          `json:"deadline"`   // Seconds by which deadline differs from midnight
+	Yaw         int          `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
+	Dir         int          `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
+	Curval      *float64     `json:"curval"`     // Most recent datapoint value
+	Goalval     *float64     `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
+	Mathishard  []*float64   `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)
+	Roadall     [][]*float64 `json:"roadall"`    // Full piecewise bright line: rows of [t, v, r] with exactly one of v/r null per row (except the first row, which anchors the road start)
+	Datapoints  []Datapoint  `json:"datapoints,omitempty"`
 }
 
 // Datapoint represents a Beeminder datapoint

--- a/main.go
+++ b/main.go
@@ -708,8 +708,11 @@ func roadallSlopePerDayAt(g Goal, t time.Time) (float64, bool) {
 	target := float64(t.Unix())
 	for i := 1; i < len(g.Roadall); i++ {
 		cur := g.Roadall[i]
+		// A malformed boundary row makes the road ambiguous; fail fast so
+		// the caller falls back to g.Rate rather than silently advancing
+		// to a later segment that doesn't actually contain `target`.
 		if len(cur) < 3 || cur[0] == nil {
-			continue
+			return 0, false
 		}
 		if target > *cur[0] {
 			continue

--- a/main.go
+++ b/main.go
@@ -530,28 +530,27 @@ func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
 // deadline). For goals due today, one day's worth of rate is added so the
 // displayed amount reflects what's required to avoid a beemergency tomorrow.
 //
+// The per-day slope is taken from the bright-line segment containing `now`
+// (via roadall) rather than from g.Rate, because g.Rate reports the goal's
+// end-of-graph rate which can differ from the current segment's rate for
+// goals with piecewise schedules.
+//
 // Two baremin value shapes are recognised: plain numeric (e.g. "+2") and the
 // colon-separated time format used by hour-valued goals — both "HH:MM" (e.g.
-// "+00:25") and "HH:MM:SS" (e.g. "+00:25:00"). For both, the goal's rate is
-// interpreted as units-of-baremin per runits and converted to a per-day amount
-// before being added. The output preserves whichever colon format the input
-// used. If rate information is missing, runits isn't one Beeminder uses, or
-// the value can't be parsed, the original Baremin string is returned unchanged.
+// "+00:25") and "HH:MM:SS" (e.g. "+00:25:00"). For both, the slope is
+// interpreted as units-of-baremin per day before being added. The output
+// preserves whichever colon format the input used. If the slope can't be
+// determined or the value can't be parsed, the original Baremin string is
+// returned unchanged.
 func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	if !IsDueTodayAt(g.Losedate, now) {
 		return g.Baremin
 	}
-	if g.Rate == nil {
-		return g.Baremin
-	}
-	// Without recognised runits we can't safely convert the rate to a per-day
-	// amount, so fall back to the original baremin rather than producing a
-	// dimensionally-wrong bump.
-	if !isKnownRunits(g.Runits) {
+	perDay, ok := slopePerDayAt(g, now)
+	if !ok {
 		return g.Baremin
 	}
 	value := ParseBareminValue(g.Baremin)
-	perDay := ratePerDay(*g.Rate, g.Runits)
 
 	// Colon-separated time formats — HH:MM or HH:MM:SS. The base value and
 	// the rate share the same hour unit, so add in seconds and reformat in
@@ -669,6 +668,71 @@ func ratePerDay(rate float64, runits string) float64 {
 	default:
 		return rate
 	}
+}
+
+// slopePerDayAt returns the slope of the goal's bright line at the given
+// moment, expressed in the goal's gunits per day.
+//
+// For goals with a piecewise schedule (rate changes scheduled in the future),
+// g.Rate reports the rate at the *end* of the graph rather than the rate of
+// the segment the user is currently on — so a "1 h/day now, dropping to
+// 0.1 h/day later" goal would otherwise be bumped by the wrong amount. Resolve
+// the current segment from g.Roadall and use its slope; fall back to g.Rate
+// only when roadall isn't usable.
+func slopePerDayAt(g Goal, t time.Time) (float64, bool) {
+	if slope, ok := roadallSlopePerDayAt(g, t); ok {
+		return slope, true
+	}
+	if g.Rate == nil {
+		return 0, false
+	}
+	if !isKnownRunits(g.Runits) {
+		return 0, false
+	}
+	return ratePerDay(*g.Rate, g.Runits), true
+}
+
+// roadallSlopePerDayAt walks Beeminder's piecewise bright line (roadall) and
+// returns the slope of the segment containing t, in gunits/day. Rows are
+// [t, v, r] triples with exactly one of v/r null per row past the first
+// anchor row. When the row's rate is given, it's converted via ratePerDay;
+// when only values are given, the slope is computed directly from
+// (Δvalue / Δtime) so the goal's runits don't matter.
+//
+// Returns ok=false for a missing/short roadall, unparseable rows, or when t
+// is past the goal's end date (caller falls back to g.Rate in that case).
+func roadallSlopePerDayAt(g Goal, t time.Time) (float64, bool) {
+	if len(g.Roadall) < 2 {
+		return 0, false
+	}
+	target := float64(t.Unix())
+	for i := 1; i < len(g.Roadall); i++ {
+		cur := g.Roadall[i]
+		if len(cur) < 3 || cur[0] == nil {
+			continue
+		}
+		if target > *cur[0] {
+			continue
+		}
+		// `t` falls in the segment ending at this row.
+		if cur[2] != nil {
+			if !isKnownRunits(g.Runits) {
+				return 0, false
+			}
+			return ratePerDay(*cur[2], g.Runits), true
+		}
+		// Rate not specified — derive from (Δvalue / Δtime).
+		prev := g.Roadall[i-1]
+		if len(prev) < 3 || prev[0] == nil || prev[1] == nil || cur[1] == nil {
+			return 0, false
+		}
+		seconds := *cur[0] - *prev[0]
+		if seconds <= 0 {
+			return 0, false
+		}
+		return (*cur[1] - *prev[1]) / seconds * 86400.0, true
+	}
+	return 0, false
 }
 
 // isDoLessFilter returns true if the goal is a do-less type goal

--- a/main.go
+++ b/main.go
@@ -714,6 +714,15 @@ func roadallSlopePerDayAt(g Goal, t time.Time) (float64, bool) {
 		if len(cur) < 3 || cur[0] == nil {
 			return 0, false
 		}
+		prev := g.Roadall[i-1]
+		if len(prev) < 3 || prev[0] == nil {
+			return 0, false
+		}
+		// `target` is before the road even starts — don't fall through to
+		// segment 1 just because target <= cur[0].
+		if target < *prev[0] {
+			return 0, false
+		}
 		if target > *cur[0] {
 			continue
 		}
@@ -725,8 +734,7 @@ func roadallSlopePerDayAt(g Goal, t time.Time) (float64, bool) {
 			return ratePerDay(*cur[2], g.Runits), true
 		}
 		// Rate not specified — derive from (Δvalue / Δtime).
-		prev := g.Roadall[i-1]
-		if len(prev) < 3 || prev[0] == nil || prev[1] == nil || cur[1] == nil {
+		if prev[1] == nil || cur[1] == nil {
 			return 0, false
 		}
 		seconds := *cur[0] - *prev[0]

--- a/main.go
+++ b/main.go
@@ -714,8 +714,23 @@ func roadallSlopePerDayAt(g Goal, t time.Time) (float64, bool) {
 		if len(cur) < 3 || cur[0] == nil {
 			return 0, false
 		}
+		// Per Beeminder spec, non-anchor rows must have exactly one of
+		// value/rate set. Both nil or both set means the row is ambiguous.
+		if (cur[1] == nil) == (cur[2] == nil) {
+			return 0, false
+		}
 		prev := g.Roadall[i-1]
 		if len(prev) < 3 || prev[0] == nil {
+			return 0, false
+		}
+		// Validate prev's shape: the first row is the start anchor (value
+		// set, rate nil); subsequent rows follow the same one-of-v-or-r
+		// constraint as cur.
+		if i == 1 {
+			if prev[1] == nil || prev[2] != nil {
+				return 0, false
+			}
+		} else if (prev[1] == nil) == (prev[2] == nil) {
 			return 0, false
 		}
 		// `target` is before the road even starts — don't fall through to

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -334,6 +335,58 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			goal:     Goal{Losedate: todayDeadline, Baremin: "+1 today", Rate: f(1), Runits: "x"},
 			expected: "+1 today",
 		},
+		{
+			// Real-world "clean" scenario: g.Rate reports the end-of-graph
+			// rate (0.1 h/day) but the current segment is 1 h/day. The bump
+			// must use the current segment, not g.Rate, so today's 25 min →
+			// tomorrow's 1:25:00, not 0:31:00.
+			name: "due today with piecewise roadall uses current segment, not end-of-graph rate",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+00:25:00 today",
+				Rate:     f(0.1),
+				Runits:   "d",
+				Roadall: piecewiseRoadall(
+					// Start anchor: 2024-12-01 at value 0
+					time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC).Unix(), 0,
+					// First segment ends 2025-02-01 at rate 1 h/day
+					float64(time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC).Unix()), 1.0,
+					// Second segment runs to 2025-12-31 at 0.1 h/day
+					float64(time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC).Unix()), 0.1,
+				),
+			},
+			expected: "+01:25:00 in 1 day",
+		},
+		{
+			// The goal is in its slower segment; use that slope.
+			name: "due today picks slope from the later piecewise segment",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+00:25:00 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Roadall: piecewiseRoadall(
+					time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC).Unix(), 0,
+					// First segment ends 2025-01-10 (before todayDeadline) at 0.1 h/day
+					float64(time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC).Unix()), 0.1,
+					// Second segment ends 2025-12-31 (after todayDeadline) at 1 h/day
+					float64(time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC).Unix()), 1.0,
+				),
+			},
+			expected: "+01:25:00 in 1 day",
+		},
+		{
+			// Short roadall (just the start anchor) — fall back to g.Rate.
+			name: "due today with short roadall falls back to g.Rate",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+00:25:00 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Roadall:  piecewiseRoadall(time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC).Unix(), 0),
+			},
+			expected: "+01:25:00 in 1 day",
+		},
 	}
 
 	for _, tt := range tests {
@@ -344,6 +397,122 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			}
 		})
 	}
+}
+
+// piecewiseRoadall builds a roadall matrix from a start anchor (t, v) followed
+// by zero or more (t, r) rate-segment pairs. Mirrors the rate-only form
+// Beeminder typically emits.
+func piecewiseRoadall(startT int64, startV float64, segments ...float64) [][]*float64 {
+	if len(segments)%2 != 0 {
+		panic("piecewiseRoadall: segments must be (t, rate) pairs")
+	}
+	t := float64(startT)
+	v := startV
+	rows := [][]*float64{{&t, &v, nil}}
+	for i := 0; i < len(segments); i += 2 {
+		segT := segments[i]
+		segR := segments[i+1]
+		rows = append(rows, []*float64{&segT, nil, &segR})
+	}
+	return rows
+}
+
+// TestRoadallSlopePerDayAt verifies the segment-resolving helper that powers
+// piecewise-aware baremin bumping.
+func TestRoadallSlopePerDayAt(t *testing.T) {
+	target := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	startT := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC).Unix()
+	segEnd1 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC).Unix()
+	segEnd2 := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC).Unix()
+
+	tests := []struct {
+		name     string
+		goal     Goal
+		expected float64
+		ok       bool
+	}{
+		{
+			name: "empty roadall returns false",
+			goal: Goal{Runits: "d"},
+			ok:   false,
+		},
+		{
+			name: "start-anchor only returns false",
+			goal: Goal{Runits: "d", Roadall: piecewiseRoadall(startT, 0)},
+			ok:   false,
+		},
+		{
+			name:     "first segment (target before segEnd1) uses segment 1 rate",
+			goal:     Goal{Runits: "d", Roadall: piecewiseRoadall(startT, 0, float64(segEnd1), 1.0, float64(segEnd2), 0.1)},
+			expected: 1.0,
+			ok:       true,
+		},
+		{
+			name:     "second segment (target after segEnd1, before segEnd2) uses segment 2 rate",
+			goal:     Goal{Runits: "d", Roadall: piecewiseRoadall(startT, 0, float64(target.Unix()-1), 0.1, float64(segEnd2), 1.0)},
+			expected: 1.0,
+			ok:       true,
+		},
+		{
+			name:     "weekly runits converts to per-day",
+			goal:     Goal{Runits: "w", Roadall: piecewiseRoadall(startT, 0, float64(segEnd1), 7.0)},
+			expected: 1.0,
+			ok:       true,
+		},
+		{
+			name: "value-only segment computes slope from Δv/Δt",
+			goal: Goal{
+				Runits: "d",
+				Roadall: [][]*float64{
+					floatPtrRow(float64(startT), 0, math.NaN()),
+					// Segment ends at segEnd1 with value 30 (≈ 0.477 / day over 63 days)
+					floatPtrRow(float64(segEnd1), 30, math.NaN()),
+				},
+			},
+			expected: 30.0 / float64(segEnd1-startT) * 86400.0,
+			ok:       true,
+		},
+		{
+			name: "target past last segment returns false",
+			goal: Goal{
+				Runits: "d",
+				// Segment ending before target — target is "past goal end".
+				Roadall: piecewiseRoadall(startT, 0, float64(target.Unix()-86400), 1.0),
+			},
+			ok: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t2 *testing.T) {
+			got, ok := roadallSlopePerDayAt(tt.goal, target)
+			if ok != tt.ok {
+				t2.Fatalf("roadallSlopePerDayAt ok = %v, want %v", ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if math.Abs(got-tt.expected) > 1e-9 {
+				t2.Errorf("roadallSlopePerDayAt = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// floatPtrRow builds a [t, v, r] row. NaN signals "this field is nil" so we
+// can describe value-only or rate-only rows inline in the table.
+func floatPtrRow(t, v, r float64) []*float64 {
+	row := []*float64{nil, nil, nil}
+	if !math.IsNaN(t) {
+		row[0] = &t
+	}
+	if !math.IsNaN(v) {
+		row[1] = &v
+	}
+	if !math.IsNaN(r) {
+		row[2] = &r
+	}
+	return row
 }
 
 // TestParseTimeValue verifies the colon-separated time parser used by

--- a/main_test.go
+++ b/main_test.go
@@ -481,6 +481,21 @@ func TestRoadallSlopePerDayAt(t *testing.T) {
 			},
 			ok: false,
 		},
+		{
+			// A malformed boundary row (missing time) makes the road
+			// ambiguous — must fail fast rather than silently jumping to the
+			// next segment, which would pick the wrong slope.
+			name: "malformed boundary row fails fast",
+			goal: Goal{
+				Runits: "d",
+				Roadall: [][]*float64{
+					floatPtrRow(float64(startT), 0, math.NaN()),
+					floatPtrRow(math.NaN(), math.NaN(), 0.1),                 // malformed: no time
+					floatPtrRow(float64(target.Unix()+86400), math.NaN(), 1), // would otherwise be selected
+				},
+			},
+			ok: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -493,6 +493,53 @@ func TestRoadallSlopePerDayAt(t *testing.T) {
 			ok: false,
 		},
 		{
+			// Per Beeminder spec, a non-anchor row has exactly one of v/r
+			// set. Both set is ambiguous — must fail fast rather than
+			// silently preferring the rate field.
+			name: "row with both value and rate set fails fast",
+			goal: Goal{
+				Runits: "d",
+				Roadall: [][]*float64{
+					floatPtrRow(float64(startT), 0, math.NaN()),
+					floatPtrRow(float64(segEnd1), 30, 1.0), // both v and r set
+				},
+			},
+			ok: false,
+		},
+		{
+			name: "row with neither value nor rate set fails fast",
+			goal: Goal{
+				Runits: "d",
+				Roadall: [][]*float64{
+					floatPtrRow(float64(startT), 0, math.NaN()),
+					floatPtrRow(float64(segEnd1), math.NaN(), math.NaN()), // neither v nor r
+				},
+			},
+			ok: false,
+		},
+		{
+			name: "anchor row missing value fails fast",
+			goal: Goal{
+				Runits: "d",
+				Roadall: [][]*float64{
+					floatPtrRow(float64(startT), math.NaN(), math.NaN()), // anchor with no v
+					floatPtrRow(float64(segEnd1), math.NaN(), 1.0),
+				},
+			},
+			ok: false,
+		},
+		{
+			name: "anchor row with rate set fails fast",
+			goal: Goal{
+				Runits: "d",
+				Roadall: [][]*float64{
+					floatPtrRow(float64(startT), 0, 1.0), // anchor must not have r
+					floatPtrRow(float64(segEnd1), math.NaN(), 0.5),
+				},
+			},
+			ok: false,
+		},
+		{
 			// A malformed boundary row (missing time) makes the road
 			// ambiguous — must fail fast rather than silently jumping to the
 			// next segment, which would pick the wrong slope.

--- a/main_test.go
+++ b/main_test.go
@@ -473,6 +473,17 @@ func TestRoadallSlopePerDayAt(t *testing.T) {
 			ok:       true,
 		},
 		{
+			// Target is before the road's start anchor — shouldn't match
+			// segment 1 just because target <= segEnd1.
+			name: "target before road start returns false",
+			goal: Goal{
+				Runits: "d",
+				// Road starts in the future, well after `target`.
+				Roadall: piecewiseRoadall(target.Unix()+86400, 0, float64(target.Unix()+10*86400), 1.0),
+			},
+			ok: false,
+		},
+		{
 			name: "target past last segment returns false",
 			goal: Goal{
 				Runits: "d",


### PR DESCRIPTION
## Summary

After v0.62.2 a `clean` goal whose current bright-line segment is `1 h/day` but whose end-of-graph rate is `0.1 h/day` still bumped wrong:

```
buzz today
clean       +00:25:00  1h  5:59 PM

buzz tomorrow
clean        +00:31:00 in 1 day            1h   5:59 PM
```

Expected `+01:25:00` (today's 25 min + 1 hour from the current segment). The 6-minute bump that did show up is `g.Rate × 24h = 0.1 × 60 min`, the goal's end-of-graph rate — wrong for a piecewise schedule.

## Root cause

Beeminder's `g.Rate` is the rate at the end of the bright line, not the slope at the current moment. Goals with rate changes scheduled in the future report their post-change rate here. The previous code used `ratePerDay(*g.Rate, g.Runits)` directly.

## Fix

- Add `Roadall [][]*float64` (the full piecewise bright line) to the `Goal` struct.
- New `slopePerDayAt(g, now)` resolves the segment containing `now` from `roadall` and returns its slope in gunits/day. Rows that specify a rate get converted via `ratePerDay`; rows that specify only a target value compute the slope directly from `Δvalue/Δtime` (so the goal's `runits` don't matter for that path).
- Fall back to `g.Rate` (existing behavior) only when `roadall` is missing, short, or doesn't cover `now`.

For the `clean` goal: the segment containing today reports rate `1 h/day` in `roadall[i].r`, so `+00:25:00 + 3600s = +01:25:00 in 1 day`.

## Test plan

- [x] New `TestBareminByEndOfTomorrowAt` case: piecewise roadall with current segment `1/d` and `g.Rate = 0.1/d` → bumps by the segment rate, not `g.Rate`
- [x] New case: target time falls in the second segment of a multi-segment roadall — picks that segment's slope
- [x] New case: short roadall (anchor only) — falls back to `g.Rate`
- [x] New `TestRoadallSlopePerDayAt` covers: empty roadall, anchor-only, first segment hit, second segment hit, weekly-runits conversion, value-only segments (`Δv/Δt`), and "target past goal end → ok=false"
- [ ] Manually verify against the live `clean` goal after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Use piecewise goal segments to determine per-day slope for deadline bumping, enabling accurate single-day adjustments based on the active segment.
  * Added representation of full piecewise bright-line data within goal tracking.

* **Bug Fixes**
  * Bumping logic now prefers segment-derived slope and falls back to legacy rate when segment data is insufficient; preserves existing time-format behavior.

* **Tests**
  * Expanded tests for multi-segment scenarios, slope resolution, and fallback behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/239)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->