### PR TITLE
fix(tomorrow): advance displayed deadline for bumped due-today goals

### DIFF
--- a/main.go
+++ b/main.go
@@ -921,14 +921,14 @@ func handleTomorrowCommand() {
 
 // losedateByEndOfTomorrowAt returns the deadline timestamp to display for a
 // goal in the tomorrow view. For goals due today (whose baremin we're bumping
-// by one day's rate), advance the deadline by 24 hours so the displayed
-// deadline matches the bumped baremin's coverage; otherwise return the goal's
-// own losedate unchanged.
+// by one day's rate), advance the deadline by one calendar day in the
+// caller's local zone so the displayed wall-clock deadline stays correct
+// across DST transitions; otherwise return the goal's own losedate unchanged.
 func losedateByEndOfTomorrowAt(g Goal, now time.Time) int64 {
 	if !IsDueTodayAt(g.Losedate, now) {
 		return g.Losedate
 	}
-	return g.Losedate + 86400
+	return time.Unix(g.Losedate, 0).In(now.Location()).AddDate(0, 0, 1).Unix()
 }
 
 // handleLessCommand outputs all do-less type goals

--- a/main.go
+++ b/main.go
@@ -543,7 +543,7 @@ func isDueTomorrowFilterAt(g Goal, now time.Time) bool {
 // determined or the value can't be parsed, the original Baremin string is
 // returned unchanged.
 func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
-	if !IsDueTodayAt(g.Losedate, now) {
+	if !dueLaterTodayAt(g, now) {
 		return g.Baremin
 	}
 	perDay, ok := slopePerDayAt(g, now)
@@ -920,15 +920,25 @@ func handleTomorrowCommand() {
 }
 
 // losedateByEndOfTomorrowAt returns the deadline timestamp to display for a
-// goal in the tomorrow view. For goals due today (whose baremin we're bumping
-// by one day's rate), advance the deadline by one calendar day in the
-// caller's local zone so the displayed wall-clock deadline stays correct
-// across DST transitions; otherwise return the goal's own losedate unchanged.
+// goal in the tomorrow view. For goals due later today (whose baremin we're
+// bumping by one day's rate), advance the deadline by one calendar day in
+// the caller's local zone so the displayed wall-clock deadline stays correct
+// across DST transitions. Overdue goals (losedate already in the past) keep
+// their own losedate so the OVERDUE indicator remains visible — bumping them
+// would silently hide the fact that they've already derailed.
 func losedateByEndOfTomorrowAt(g Goal, now time.Time) int64 {
-	if !IsDueTodayAt(g.Losedate, now) {
+	if !dueLaterTodayAt(g, now) {
 		return g.Losedate
 	}
 	return time.Unix(g.Losedate, 0).In(now.Location()).AddDate(0, 0, 1).Unix()
+}
+
+// dueLaterTodayAt reports whether a goal's losedate falls between now and the
+// start of tomorrow. Used as the gating predicate for the tomorrow-view
+// bumping helpers: overdue goals (losedate < now) and goals due tomorrow or
+// later are left untouched so their actual deadline keeps showing.
+func dueLaterTodayAt(g Goal, now time.Time) bool {
+	return g.Losedate >= now.Unix() && IsDueTodayAt(g.Losedate, now)
 }
 
 // handleLessCommand outputs all do-less type goals

--- a/main.go
+++ b/main.go
@@ -979,16 +979,6 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 	)
 }
 
-// handleFilteredCommandWithBaremin is like handleFilteredCommand but lets the
-// caller customise the baremin string displayed for each goal. The deadline
-// shown for each goal still comes from the goal's own losedate. Kept for
-// backwards compatibility with callers that only need to override baremin.
-func handleFilteredCommandWithBaremin(filterName string, filter func(Goal) bool, bareminFor func(Goal) string) {
-	handleFilteredCommandWithDisplay(filterName, filter, bareminFor,
-		func(g Goal) int64 { return g.Losedate },
-	)
-}
-
 // handleFilteredCommandWithDisplay is the most general filtered-output helper:
 // the caller can override both the displayed baremin string and the deadline
 // timestamp used for the timeframe/absolute-deadline columns. The tomorrow

--- a/main.go
+++ b/main.go
@@ -909,12 +909,26 @@ func handleTodayCommand() {
 // handleTomorrowCommand outputs all goals that are due tomorrow. Goals that
 // are already due today are included with their baremin bumped by one day's
 // rate, so the user sees the total amount they would need to do for the goal
-// to not be due tomorrow.
+// to not be due tomorrow. The displayed deadline is bumped to match — the
+// bumped baremin is what's needed by *tomorrow's* deadline, not today's.
 func handleTomorrowCommand() {
 	now := time.Now()
 	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
 	bareminFor := func(g Goal) string { return bareminByEndOfTomorrowAt(g, now) }
-	handleFilteredCommandWithBaremin("tomorrow", filter, bareminFor)
+	losedateFor := func(g Goal) int64 { return losedateByEndOfTomorrowAt(g, now) }
+	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor)
+}
+
+// losedateByEndOfTomorrowAt returns the deadline timestamp to display for a
+// goal in the tomorrow view. For goals due today (whose baremin we're bumping
+// by one day's rate), advance the deadline by 24 hours so the displayed
+// deadline matches the bumped baremin's coverage; otherwise return the goal's
+// own losedate unchanged.
+func losedateByEndOfTomorrowAt(g Goal, now time.Time) int64 {
+	if !IsDueTodayAt(g.Losedate, now) {
+		return g.Losedate
+	}
+	return g.Losedate + 86400
 }
 
 // handleLessCommand outputs all do-less type goals
@@ -959,13 +973,28 @@ func handleDueCommand() {
 // filterName is used in messages (e.g., "today", "tomorrow", or "do-less")
 // filter is a function that takes a Goal and returns true if the goal matches
 func handleFilteredCommand(filterName string, filter func(Goal) bool) {
-	handleFilteredCommandWithBaremin(filterName, filter, func(g Goal) string { return g.Baremin })
+	handleFilteredCommandWithDisplay(filterName, filter,
+		func(g Goal) string { return g.Baremin },
+		func(g Goal) int64 { return g.Losedate },
+	)
 }
 
 // handleFilteredCommandWithBaremin is like handleFilteredCommand but lets the
-// caller customise the baremin string displayed for each goal. This is used by
-// the tomorrow view to bump due-today goals by one day's rate.
+// caller customise the baremin string displayed for each goal. The deadline
+// shown for each goal still comes from the goal's own losedate. Kept for
+// backwards compatibility with callers that only need to override baremin.
 func handleFilteredCommandWithBaremin(filterName string, filter func(Goal) bool, bareminFor func(Goal) string) {
+	handleFilteredCommandWithDisplay(filterName, filter, bareminFor,
+		func(g Goal) int64 { return g.Losedate },
+	)
+}
+
+// handleFilteredCommandWithDisplay is the most general filtered-output helper:
+// the caller can override both the displayed baremin string and the deadline
+// timestamp used for the timeframe/absolute-deadline columns. The tomorrow
+// view uses this to bump both for due-today goals so the bumped baremin and
+// the displayed deadline are aligned to the same target moment.
+func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool, bareminFor func(Goal) string, losedateFor func(Goal) int64) {
 	// Load config
 	if !ConfigExists() {
 		fmt.Println("Error: No configuration found. Please run 'buzz' first to authenticate.")
@@ -1016,8 +1045,9 @@ func handleFilteredCommandWithBaremin(filterName string, filter func(Goal) bool,
 	maxRelativeWidth := 0
 
 	for i, goal := range filteredGoals {
-		timeframe := FormatDueDate(goal.Losedate)
-		absoluteDeadline := FormatAbsoluteDeadline(goal.Losedate)
+		losedate := losedateFor(goal)
+		timeframe := FormatDueDate(losedate)
+		absoluteDeadline := FormatAbsoluteDeadline(losedate)
 		baremin := bareminFor(goal)
 		displays[i] = goalDisplay{
 			goal:             goal,

--- a/main.go
+++ b/main.go
@@ -989,6 +989,16 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 	)
 }
 
+// sortGoalsByDisplayedLosedate reorders goals in place so the slice ends up
+// sorted by the timestamp that losedateFor would render. SliceStable preserves
+// the input order for ties so any prior sort (e.g. SortGoals's pledge/slug
+// tiebreakers) survives.
+func sortGoalsByDisplayedLosedate(goals []Goal, losedateFor func(Goal) int64) {
+	sort.SliceStable(goals, func(i, j int) bool {
+		return losedateFor(goals[i]) < losedateFor(goals[j])
+	})
+}
+
 // handleFilteredCommandWithDisplay is the most general filtered-output helper:
 // the caller can override both the displayed baremin string and the deadline
 // timestamp used for the timeframe/absolute-deadline columns. The tomorrow
@@ -1030,6 +1040,13 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 		fmt.Printf("No %s goals found.\n", filterName)
 		return
 	}
+
+	// SortGoals ordered by each goal's own losedate, but the tomorrow view may
+	// show a bumped losedate for due-today goals. Re-sort by the displayed
+	// losedate so the rendered order matches the deadline column. SliceStable
+	// preserves the SortGoals tiebreakers (pledge desc, slug asc) when
+	// displayed losedates are equal.
+	sortGoalsByDisplayedLosedate(filteredGoals, losedateFor)
 
 	// Pre-calculate formatted values to avoid redundant formatting calls
 	type goalDisplay struct {

--- a/main_test.go
+++ b/main_test.go
@@ -417,6 +417,52 @@ func piecewiseRoadall(startT int64, startV float64, segments ...float64) [][]*fl
 	return rows
 }
 
+// TestLosedateByEndOfTomorrowAt verifies that due-today goals get their
+// displayed deadline advanced by 24 hours in the tomorrow view, so it lines
+// up with the bumped baremin's coverage. Goals already due tomorrow keep
+// their own losedate.
+func TestLosedateByEndOfTomorrowAt(t *testing.T) {
+	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	todayDeadline := time.Date(2025, 1, 15, 17, 59, 0, 0, time.UTC).Unix()
+	tomorrowDeadline := time.Date(2025, 1, 16, 17, 59, 0, 0, time.UTC).Unix()
+	dayAfterTomorrowDeadline := time.Date(2025, 1, 17, 17, 59, 0, 0, time.UTC).Unix()
+
+	tests := []struct {
+		name     string
+		goal     Goal
+		expected int64
+	}{
+		{
+			// User-reported real-world case: a clean goal due today at 5:59 PM
+			// should show tomorrow's 5:59 PM as the deadline in `buzz tomorrow`
+			// since the displayed baremin covers tomorrow.
+			name:     "due today bumps deadline by 24 hours",
+			goal:     Goal{Losedate: todayDeadline},
+			expected: todayDeadline + 86400,
+		},
+		{
+			name:     "due tomorrow keeps own losedate",
+			goal:     Goal{Losedate: tomorrowDeadline},
+			expected: tomorrowDeadline,
+		},
+		{
+			name:     "due later keeps own losedate",
+			goal:     Goal{Losedate: dayAfterTomorrowDeadline},
+			expected: dayAfterTomorrowDeadline,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := losedateByEndOfTomorrowAt(tt.goal, now)
+			if got != tt.expected {
+				t.Errorf("losedateByEndOfTomorrowAt = %d, want %d (diff %d seconds)",
+					got, tt.expected, got-tt.expected)
+			}
+		})
+	}
+}
+
 // TestRoadallSlopePerDayAt verifies the segment-resolving helper that powers
 // piecewise-aware baremin bumping.
 func TestRoadallSlopePerDayAt(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -513,6 +513,35 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 	})
 }
 
+// TestSortGoalsByDisplayedLosedate locks in the rule that rows render in the
+// order the user actually sees in the deadline column. The tomorrow view
+// bumps due-today losedates by one calendar day, which can flip the relative
+// order of goals if we don't resort using the same losedateFor projection.
+func TestSortGoalsByDisplayedLosedate(t *testing.T) {
+	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	losedateFor := func(g Goal) int64 { return losedateByEndOfTomorrowAt(g, now) }
+
+	// Goal A: due today at 11 PM → displays as tomorrow 11 PM
+	// Goal B: due tomorrow at 9 AM → displays as tomorrow 9 AM (earlier)
+	dueToday11PM := time.Date(2025, 1, 15, 23, 0, 0, 0, time.UTC).Unix()
+	dueTomorrow9AM := time.Date(2025, 1, 16, 9, 0, 0, 0, time.UTC).Unix()
+
+	// Pre-sort by original losedate, like SortGoals would. A comes first
+	// because its original losedate is earlier — but A's *displayed* losedate
+	// is later, so the resort must flip them.
+	goals := []Goal{
+		{Slug: "a", Losedate: dueToday11PM},
+		{Slug: "b", Losedate: dueTomorrow9AM},
+	}
+
+	sortGoalsByDisplayedLosedate(goals, losedateFor)
+
+	if goals[0].Slug != "b" || goals[1].Slug != "a" {
+		t.Errorf("expected [b, a] after resorting by displayed losedate, got [%s, %s]",
+			goals[0].Slug, goals[1].Slug)
+	}
+}
+
 // TestRoadallSlopePerDayAt verifies the segment-resolving helper that powers
 // piecewise-aware baremin bumping.
 func TestRoadallSlopePerDayAt(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -418,9 +418,9 @@ func piecewiseRoadall(startT int64, startV float64, segments ...float64) [][]*fl
 }
 
 // TestLosedateByEndOfTomorrowAt verifies that due-today goals get their
-// displayed deadline advanced by 24 hours in the tomorrow view, so it lines
-// up with the bumped baremin's coverage. Goals already due tomorrow keep
-// their own losedate.
+// displayed deadline advanced by one calendar day in the tomorrow view (in
+// the caller's local zone, so DST transitions stay aligned), while goals
+// already due tomorrow or later keep their own losedate.
 func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
 	todayDeadline := time.Date(2025, 1, 15, 17, 59, 0, 0, time.UTC).Unix()
@@ -435,10 +435,11 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 		{
 			// User-reported real-world case: a clean goal due today at 5:59 PM
 			// should show tomorrow's 5:59 PM as the deadline in `buzz tomorrow`
-			// since the displayed baremin covers tomorrow.
-			name:     "due today bumps deadline by 24 hours",
+			// since the displayed baremin covers tomorrow. Outside DST
+			// transitions this is the same as +86400.
+			name:     "due today bumps deadline by one calendar day",
 			goal:     Goal{Losedate: todayDeadline},
-			expected: todayDeadline + 86400,
+			expected: time.Date(2025, 1, 16, 17, 59, 0, 0, time.UTC).Unix(),
 		},
 		{
 			name:     "due tomorrow keeps own losedate",
@@ -461,6 +462,31 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 			}
 		})
 	}
+
+	// DST boundary: in America/New_York the spring-forward jump means
+	// 5:59 PM the next calendar day is only 23 hours away in absolute terms,
+	// not 24. Using AddDate(0,0,1) preserves the wall-clock time, so the
+	// returned losedate is +82800 seconds rather than +86400.
+	t.Run("DST spring-forward preserves wall-clock", func(t *testing.T) {
+		ny, err := time.LoadLocation("America/New_York")
+		if err != nil {
+			t.Skipf("America/New_York not available: %v", err)
+		}
+		// 5:59 PM the day before spring-forward (2025-03-09).
+		losedate := time.Date(2025, 3, 8, 17, 59, 0, 0, ny)
+		nowDST := time.Date(2025, 3, 8, 14, 0, 0, 0, ny)
+		got := losedateByEndOfTomorrowAt(Goal{Losedate: losedate.Unix()}, nowDST)
+		want := time.Date(2025, 3, 9, 17, 59, 0, 0, ny).Unix()
+		if got != want {
+			t.Errorf("DST losedateByEndOfTomorrowAt = %d, want %d (diff %d seconds)",
+				got, want, got-want)
+		}
+		// Sanity: a naive +86400 would land at the wrong wall-clock hour
+		// (6:59 PM instead of 5:59 PM after the spring-forward).
+		if losedate.Unix()+86400 == want {
+			t.Errorf("DST test would also pass with naive +86400 — losedate fixture isn't actually crossing the DST boundary")
+		}
+	})
 }
 
 // TestRoadallSlopePerDayAt verifies the segment-resolving helper that powers

--- a/main_test.go
+++ b/main_test.go
@@ -290,6 +290,14 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			expected: "+1 today",
 		},
 		{
+			// Overdue goals keep their original baremin paired with the
+			// original (overdue) losedate — bumping either would hide the
+			// fact that the goal has already derailed.
+			name:     "overdue is unchanged",
+			goal:     Goal{Losedate: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC).Unix(), Baremin: "+1 today", Rate: f(1), Runits: "d"},
+			expected: "+1 today",
+		},
+		{
 			// Real-world scenario from a "clean" hours-valued goal: 25 minutes
 			// due today, rate 1 hour/day. Tomorrow needs today's 25 minutes
 			// plus another hour = 1:25.
@@ -450,6 +458,22 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 			name:     "due later keeps own losedate",
 			goal:     Goal{Losedate: dayAfterTomorrowDeadline},
 			expected: dayAfterTomorrowDeadline,
+		},
+		{
+			// Overdue goals keep their losedate so the OVERDUE indicator
+			// remains visible — bumping it would silently move the deadline
+			// into the future and hide the fact that the goal has derailed.
+			name:     "overdue keeps own losedate",
+			goal:     Goal{Losedate: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC).Unix()},
+			expected: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC).Unix(),
+		},
+		{
+			// Edge case: losedate exactly equals now — treat as still
+			// "due later today" so bumping happens. Anything strictly less
+			// than now is overdue.
+			name:     "losedate at exactly now still bumps",
+			goal:     Goal{Losedate: now.Unix()},
+			expected: time.Unix(now.Unix(), 0).In(now.Location()).AddDate(0, 0, 1).Unix(),
 		},
 	}
 


### PR DESCRIPTION
## Summary

After the baremin-bumping fixes landed, a `clean` goal due today at 5:59 PM was reported as:

```
clean   +01:25:00 in 1 day            57m   5:59 PM
```

The baremin (`+01:25:00 in 1 day`) is correct — it's the amount needed by *tomorrow's* deadline. But the timeframe (`57m`) and absolute deadline (`5:59 PM`) still came from the goal's own losedate, i.e. *today's* 5:59 PM. Those columns belong to the bumped baremin's coverage window, not the goal's untouched losedate.

## Fix

- Thread a `losedateFor func(Goal) int64` formatter through `handleFilteredCommandWithDisplay` (sibling of the existing `bareminFor`).
- New `losedateByEndOfTomorrowAt(g, now)` returns `g.Losedate + 86400` for due-today goals and `g.Losedate` otherwise.
- `handleTomorrowCommand` wires the new formatter in. All other views (today, all, do-less, due-within, list) keep the existing pass-through behaviour via `handleFilteredCommand`.

For the `clean` goal this produces:

```
clean   +01:25:00 in 1 day            1d  5:59 PM
```

## Test plan

- [x] New `TestLosedateByEndOfTomorrowAt` covers due-today (+24h bump), due-tomorrow (passthrough), and due-later (passthrough)
- [x] Existing `TestBareminByEndOfTomorrowAt` and `TestRoadallSlopePerDayAt` still pass — no behaviour change for other paths
- [ ] Manually verify against the live `clean` goal after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tomorrow view now advances displayed deadlines by one calendar day for goals due today and aligns timeframe/absolute-deadline displays with that projected "tomorrow" moment; rendered order follows the adjusted displayed deadline.

* **Bug Fixes**
  * Overdue goals no longer get their displayed deadline bumped; displayed deadlines respect local calendar/DST boundaries.

* **Tests**
  * Added tests for deadline projection, DST edge cases, overdue behavior, and sorting by displayed deadline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/240)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->