### PR TITLE
fix(tomorrow): honor goal display precision via Beeminder's dueby

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -13,29 +13,41 @@ import (
 
 // Goal represents a Beeminder goal with relevant fields
 type Goal struct {
-	Slug        string       `json:"slug"`
-	Title       string       `json:"title"`
-	Fineprint   string       `json:"fineprint"` // User-provided description of what they're committing to
-	GoalType    string       `json:"goal_type"` // Goal type (hustler, biker, fatloser, gainer, inboxer, drinker)
-	Losedate    int64        `json:"losedate"`
-	Pledge      float64      `json:"pledge"`
-	PledgeCap   *float64     `json:"pledge_cap"` // Pointer to handle null values from API
-	Safebuf     int          `json:"safebuf"`
-	Limsum      string       `json:"limsum"`
-	Baremin     string       `json:"baremin"`
-	Autodata    string       `json:"autodata"`
-	Autoratchet *float64     `json:"autoratchet"` // Pointer to handle null values from API
-	Rate        *float64     `json:"rate"`        // Pointer to handle null values from API
-	Runits      string       `json:"runits"`
-	Gunits      string       `json:"gunits"`     // Goal units, like "hours" or "pushups" or "pages"
-	Deadline    int          `json:"deadline"`   // Seconds by which deadline differs from midnight
-	Yaw         int          `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
-	Dir         int          `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
-	Curval      *float64     `json:"curval"`     // Most recent datapoint value
-	Goalval     *float64     `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
-	Mathishard  []*float64   `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)
-	Roadall     [][]*float64 `json:"roadall"`    // Full piecewise bright line: rows of [t, v, r] with exactly one of v/r null per row (except the first row, which anchors the road start)
-	Datapoints  []Datapoint  `json:"datapoints,omitempty"`
+	Slug        string                `json:"slug"`
+	Title       string                `json:"title"`
+	Fineprint   string                `json:"fineprint"` // User-provided description of what they're committing to
+	GoalType    string                `json:"goal_type"` // Goal type (hustler, biker, fatloser, gainer, inboxer, drinker)
+	Losedate    int64                 `json:"losedate"`
+	Pledge      float64               `json:"pledge"`
+	PledgeCap   *float64              `json:"pledge_cap"` // Pointer to handle null values from API
+	Safebuf     int                   `json:"safebuf"`
+	Limsum      string                `json:"limsum"`
+	Baremin     string                `json:"baremin"`
+	Autodata    string                `json:"autodata"`
+	Autoratchet *float64              `json:"autoratchet"` // Pointer to handle null values from API
+	Rate        *float64              `json:"rate"`        // Pointer to handle null values from API
+	Runits      string                `json:"runits"`
+	Gunits      string                `json:"gunits"`     // Goal units, like "hours" or "pushups" or "pages"
+	Deadline    int                   `json:"deadline"`   // Seconds by which deadline differs from midnight
+	Yaw         int                   `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
+	Dir         int                   `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
+	Curval      *float64              `json:"curval"`     // Most recent datapoint value
+	Goalval     *float64              `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
+	Mathishard  []*float64            `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)
+	Roadall     [][]*float64          `json:"roadall"`    // Full piecewise bright line: rows of [t, v, r] with exactly one of v/r null per row (except the first row, which anchors the road start)
+	Dueby       map[string]DuebyEntry `json:"dueby"`      // Per-daystamp deltas/totals, pre-rounded to the goal's display precision. Keys are YYYYMMDD strings.
+	Datapoints  []Datapoint           `json:"datapoints,omitempty"`
+}
+
+// DuebyEntry is one entry in a goal's `dueby` map, keyed by daystamp.
+// Beeminder pre-rounds FormattedDelta and FormattedTotal to the goal's
+// configured Display Precision, so honouring those strings avoids the
+// trailing-decimals problem we'd hit doing float arithmetic ourselves.
+type DuebyEntry struct {
+	Delta          float64 `json:"delta"`
+	Total          float64 `json:"total"`
+	FormattedDelta string  `json:"formatted_delta_for_beedroid"`
+	FormattedTotal string  `json:"formatted_total_for_beedroid"`
 }
 
 // Datapoint represents a Beeminder datapoint

--- a/main.go
+++ b/main.go
@@ -546,7 +546,7 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	if !dueLaterTodayAt(g, now) {
 		return g.Baremin
 	}
-	if bumped, ok := bareminFromDueby(g); ok {
+	if bumped, ok := bareminFromDueby(g, now); ok {
 		return bumped + " in 1 day"
 	}
 	perDay, ok := slopePerDayAt(g, now)
@@ -580,29 +580,35 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	return fmt.Sprintf("%s%g in 1 day", sign, total)
 }
 
-// bareminFromDueby returns the formatted delta for the day after the goal's
-// current "today" daystamp, taken from Beeminder's pre-rounded `dueby` map.
-// Beeminder rounds those strings to the goal's Display Precision, so honouring
-// them sidesteps float-formatting noise (e.g. "+10788.140000000001") that
-// arises when we add today's baremin to a per-day rate ourselves. Returns
-// ok=false when dueby is absent, has fewer than two entries, or the
-// tomorrow entry has no formatted delta — callers fall back to local
-// arithmetic in those cases. Daystamps are YYYYMMDD strings, so
-// lexicographic and chronological order coincide.
-func bareminFromDueby(g Goal) (string, bool) {
-	if len(g.Dueby) < 2 {
+// bareminFromDueby returns the formatted delta for tomorrow's daystamp,
+// taken from Beeminder's pre-rounded `dueby` map. Beeminder rounds those
+// strings to the goal's Display Precision, so honouring them sidesteps
+// float-formatting noise (e.g. "+10788.140000000001") that arises when we
+// add today's baremin to a per-day rate ourselves. Returns ok=false when
+// dueby is absent or the tomorrow entry is missing/empty — callers fall
+// back to local arithmetic in those cases.
+func bareminFromDueby(g Goal, now time.Time) (string, bool) {
+	if len(g.Dueby) == 0 {
 		return "", false
 	}
-	keys := make([]string, 0, len(g.Dueby))
-	for k := range g.Dueby {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	tomorrow := g.Dueby[keys[1]].FormattedDelta
-	if tomorrow == "" {
+	entry, ok := g.Dueby[tomorrowDaystampFor(g, now)]
+	if !ok || entry.FormattedDelta == "" {
 		return "", false
 	}
-	return tomorrow, true
+	return entry.FormattedDelta, true
+}
+
+// tomorrowDaystampFor returns the YYYYMMDD daystamp representing the day
+// after the goal's current Beeminder day. Beeminder shifts day boundaries
+// by the goal's `deadline` seconds — positive deadlines push the boundary
+// past midnight (e.g. +10800 = 3am cutoff), negative deadlines pull it
+// before (e.g. -10800 = 9pm cutoff). Subtracting the deadline from `now`
+// produces a wall-clock time inside the user's calendar date that matches
+// the goal's current daystamp; the next calendar day is tomorrow's.
+func tomorrowDaystampFor(g Goal, now time.Time) string {
+	shifted := now.Add(-time.Duration(g.Deadline) * time.Second).In(now.Location())
+	tomorrow := time.Date(shifted.Year(), shifted.Month(), shifted.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, 1)
+	return tomorrow.Format("20060102")
 }
 
 // parseTimeValue parses a "[-]HH:MM" or "[-]HH:MM:SS" string into total

--- a/main.go
+++ b/main.go
@@ -546,6 +546,9 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 	if !dueLaterTodayAt(g, now) {
 		return g.Baremin
 	}
+	if bumped, ok := bareminFromDueby(g); ok {
+		return bumped + " in 1 day"
+	}
 	perDay, ok := slopePerDayAt(g, now)
 	if !ok {
 		return g.Baremin
@@ -575,6 +578,31 @@ func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
 		sign = ""
 	}
 	return fmt.Sprintf("%s%g in 1 day", sign, total)
+}
+
+// bareminFromDueby returns the formatted delta for the day after the goal's
+// current "today" daystamp, taken from Beeminder's pre-rounded `dueby` map.
+// Beeminder rounds those strings to the goal's Display Precision, so honouring
+// them sidesteps float-formatting noise (e.g. "+10788.140000000001") that
+// arises when we add today's baremin to a per-day rate ourselves. Returns
+// ok=false when dueby is absent, has fewer than two entries, or the
+// tomorrow entry has no formatted delta — callers fall back to local
+// arithmetic in those cases. Daystamps are YYYYMMDD strings, so
+// lexicographic and chronological order coincide.
+func bareminFromDueby(g Goal) (string, bool) {
+	if len(g.Dueby) < 2 {
+		return "", false
+	}
+	keys := make([]string, 0, len(g.Dueby))
+	for k := range g.Dueby {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	tomorrow := g.Dueby[keys[1]].FormattedDelta
+	if tomorrow == "" {
+		return "", false
+	}
+	return tomorrow, true
 }
 
 // parseTimeValue parses a "[-]HH:MM" or "[-]HH:MM:SS" string into total

--- a/main_test.go
+++ b/main_test.go
@@ -462,6 +462,23 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			},
 			expected: "+2 in 1 day",
 		},
+		{
+			// Dueby keyed only by past daystamps (defensive — Beeminder
+			// normally starts at today). The deadline-aware lookup misses,
+			// so we fall back instead of mistakenly using a stale entry.
+			name: "due today with only-past dueby keys falls back",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+1 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Dueby: map[string]DuebyEntry{
+					"20250113": {FormattedDelta: "+99"},
+					"20250114": {FormattedDelta: "+99"},
+				},
+			},
+			expected: "+2 in 1 day",
+		},
 	}
 
 	for _, tt := range tests {
@@ -469,6 +486,48 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			got := bareminByEndOfTomorrowAt(tt.goal, now)
 			if got != tt.expected {
 				t.Errorf("bareminByEndOfTomorrowAt = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestTomorrowDaystampFor verifies that the daystamp lookup honours each
+// goal's `deadline` shift. A positive deadline (e.g. +3h cutoff) keeps
+// early-morning runs on yesterday's daystamp; a negative deadline (e.g.
+// -3h, 9pm cutoff) pushes late-evening runs onto tomorrow's daystamp.
+func TestTomorrowDaystampFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		deadline int
+		now      time.Time
+		expected string
+	}{
+		{
+			name:     "midnight cutoff, mid-afternoon",
+			deadline: 0,
+			now:      time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC),
+			expected: "20250116",
+		},
+		{
+			name:     "3am cutoff, 1am run is still 'yesterday' so tomorrow is the calendar day",
+			deadline: 3 * 3600,
+			now:      time.Date(2025, 1, 15, 1, 0, 0, 0, time.UTC),
+			expected: "20250115",
+		},
+		{
+			name:     "9pm cutoff, 10pm run already on next Beeminder day",
+			deadline: -3 * 3600,
+			now:      time.Date(2025, 1, 15, 22, 0, 0, 0, time.UTC),
+			expected: "20250117",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := Goal{Deadline: tt.deadline}
+			got := tomorrowDaystampFor(g, tt.now)
+			if got != tt.expected {
+				t.Errorf("tomorrowDaystampFor(deadline=%d, now=%v) = %q, want %q", tt.deadline, tt.now, got, tt.expected)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -479,6 +479,25 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			},
 			expected: "+2 in 1 day",
 		},
+		{
+			// Dueby includes a past daystamp alongside today and tomorrow.
+			// We must still pick tomorrow's entry (20250116 = "+5"), not the
+			// earlier ones — i.e. don't index by sort order.
+			name: "due today with past+today+tomorrow dueby still picks tomorrow",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+1 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Dueby: map[string]DuebyEntry{
+					"20250114": {FormattedDelta: "+99"},
+					"20250115": {FormattedDelta: "+1"},
+					"20250116": {FormattedDelta: "+5"},
+					"20250117": {FormattedDelta: "+9"},
+				},
+			},
+			expected: "+5 in 1 day",
+		},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -395,6 +395,73 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 			},
 			expected: "+01:25:00 in 1 day",
 		},
+		{
+			// Real-world steps-goal scenario: API returns dueby pre-rounded
+			// to the goal's Display Precision, so we should honour the
+			// formatted tomorrow delta instead of doing our own float math
+			// (which would print "+10788.140000000001").
+			name: "due today with dueby uses Beeminder's formatted tomorrow delta",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+2283",
+				Rate:     f(8505.140000000001),
+				Runits:   "d",
+				Dueby: map[string]DuebyEntry{
+					"20250115": {FormattedDelta: "+2283"},
+					"20250116": {FormattedDelta: "+10789"},
+					"20250117": {FormattedDelta: "+10789"},
+				},
+			},
+			expected: "+10789 in 1 day",
+		},
+		{
+			// Timey goals also get pre-formatted dueby entries; honour them
+			// over our own colon-format reconstruction.
+			name: "due today with timey dueby honours Beeminder's tomorrow formatting",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+00:25 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Dueby: map[string]DuebyEntry{
+					"20250115": {FormattedDelta: "+00:25"},
+					"20250116": {FormattedDelta: "+01:25"},
+				},
+			},
+			expected: "+01:25 in 1 day",
+		},
+		{
+			// Dueby with only today's entry can't tell us tomorrow's value —
+			// fall back to the existing slope-based bump.
+			name: "due today with single-entry dueby falls back to slope bump",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+1 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Dueby: map[string]DuebyEntry{
+					"20250115": {FormattedDelta: "+1"},
+				},
+			},
+			expected: "+2 in 1 day",
+		},
+		{
+			// Dueby present but tomorrow's entry has an empty FormattedDelta
+			// (defensive — shouldn't happen in practice). Fall back so we
+			// still produce a useful display string.
+			name: "due today with empty tomorrow FormattedDelta falls back",
+			goal: Goal{
+				Losedate: todayDeadline,
+				Baremin:  "+1 today",
+				Rate:     f(1),
+				Runits:   "d",
+				Dueby: map[string]DuebyEntry{
+					"20250115": {FormattedDelta: "+1"},
+					"20250116": {FormattedDelta: ""},
+				},
+			},
+			expected: "+2 in 1 day",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `buzz tomorrow` was printing values like `steps +10788.140000000001 in 1 day` because `bareminByEndOfTomorrowAt` did its own float addition (today's baremin + per-day rate) and formatted with `%g`.
- Beeminder's API already publishes per-day deltas rounded to each goal's Display Precision under `dueby[<daystamp>].formatted_delta_for_beedroid`. We now use that for due-today goals in the tomorrow view.
- The per-goal "precision" (a.k.a. internal `quantum`) setting isn't exposed as a top-level goal attribute, but `dueby` is — so we honor precision indirectly by trusting Beeminder's pre-rounded strings.
- Falls back to the existing slope-based bump when `dueby` is missing, has <2 entries, or tomorrow's entry has no formatted delta.

Before / after for the reporter's `steps` goal:

```
- steps        +10788.140000000001 in 1 day  1d   tomorrow 11:59 PM
+ steps        +10789 in 1 day               1d   tomorrow 11:59 PM
```

(Bonus accuracy fix: our local bump used `g.Rate` end-of-graph slope, so it produced `10788.14`; Beeminder's own day-by-day computation gives `10788.12` → `+10789`.)

## Test plan
- [x] `go test -run TestBareminByEndOfTomorrow ./...` — 18 subtests pass (14 pre-existing + 4 new: real steps-style precision case, timey goal, single-entry-dueby fallback, empty-FormattedDelta fallback)
- [x] `go vet ./...` clean, `gofmt -l .` clean
- [x] Live run against a real account: every "due today, shown in tomorrow view" line now matches `dueby.formatted_delta_for_beedroid` exactly (steps `+10789`, active `+94`, nasal `+2`, etc.)
- [ ] Reviewer: spot-check `buzz tomorrow` on a goal with a non-integer rate

Two unrelated test failures (`TestExtractTimeSlots`, `TestExtractTimeSlotsAcrossDates`) also fail on `main` — pre-existing, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-day “dueby” entries from Beeminder’s API so the app can surface pre-formatted daily deltas/totals.

* **Bug Fixes**
  * Improved baremin bumping to prefer Beeminder’s pre-formatted tomorrow value when present, with robust fallback to existing calculations.

* **Tests**
  * Added tests covering tomorrow daystamp selection and baremin bumping behavior across edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/241)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->