### PR TITLE
refactor: extract goaltable.Table for shared list rendering

### DIFF
--- a/goaltable.go
+++ b/goaltable.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// goaltable renders a list of goals as a column-aligned text table. The
+// pipeline every list command was reimplementing —
+//
+//	measure max width per column → pad cells → optionally colour by urgency → join with two-space separators
+//
+// — now lives here. Callers describe their columns declaratively and call
+// Render; sorting and filtering stay outside the renderer where they belong.
+
+// Column is one column in a goal table.
+//
+// Cell is a pure function from a Goal to its rendered string value. The
+// renderer calls it once per goal during measure and again during print, so it
+// must be cheap and deterministic.
+type Column struct {
+	Header string
+	Cell   func(Goal) string
+}
+
+// Table is a declarative description of a goal table.
+//
+//   - Columns gives the header text and per-cell formatter for each column.
+//   - ShowHeader adds a header row and a hyphen-rule separator above the data
+//     rows (matches `buzz list`); filtered list commands set it false.
+//   - Colorize wraps each data row in the goal's urgency TextStyle so the
+//     `today` / `tomorrow` / `due` / `less` / `all` views keep their colour
+//     coding. The header row is never coloured.
+type Table struct {
+	Columns    []Column
+	ShowHeader bool
+	Colorize   bool
+}
+
+// Render produces the table as a single string with a trailing newline per
+// row. Columns are separated by two spaces; the last column is not padded so
+// trailing whitespace doesn't bleed past the value (matches the previous
+// fmt.Printf("...%s\n") pattern in every list command).
+func (t Table) Render(goals []Goal) string {
+	if len(t.Columns) == 0 {
+		return ""
+	}
+
+	// Precompute every cell so we can measure once and print without
+	// re-calling the Cell functions during render.
+	cells := make([][]string, len(goals))
+	widths := make([]int, len(t.Columns))
+	if t.ShowHeader {
+		// Seed widths from header lengths so the header row never gets clipped.
+		for i, c := range t.Columns {
+			widths[i] = len(c.Header)
+		}
+	}
+	for i, g := range goals {
+		row := make([]string, len(t.Columns))
+		for j, c := range t.Columns {
+			row[j] = c.Cell(g)
+			if len(row[j]) > widths[j] {
+				widths[j] = len(row[j])
+			}
+		}
+		cells[i] = row
+	}
+
+	var b strings.Builder
+
+	if t.ShowHeader {
+		headers := make([]string, len(t.Columns))
+		for i, c := range t.Columns {
+			headers[i] = c.Header
+		}
+		b.WriteString(padRow(headers, widths))
+		b.WriteString("\n")
+		rule := make([]string, len(t.Columns))
+		for i, w := range widths {
+			rule[i] = strings.Repeat("-", w)
+		}
+		b.WriteString(padRow(rule, widths))
+		b.WriteString("\n")
+	}
+
+	for i, row := range cells {
+		line := padRow(row, widths)
+		if t.Colorize {
+			line = UrgencyFor(goals[i].Safebuf).TextStyle().Render(line)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// padRow joins cells with two-space separators, left-padding every column
+// except the last to its measured width.
+func padRow(cells []string, widths []int) string {
+	parts := make([]string, len(cells))
+	for i, cell := range cells {
+		if i == len(cells)-1 {
+			parts[i] = cell
+		} else {
+			parts[i] = fmt.Sprintf("%-*s", widths[i], cell)
+		}
+	}
+	return strings.Join(parts, "  ")
+}

--- a/goaltable.go
+++ b/goaltable.go
@@ -16,8 +16,9 @@ import (
 // Column is one column in a goal table.
 //
 // Cell is a pure function from a Goal to its rendered string value. The
-// renderer calls it once per goal during measure and again during print, so it
-// must be cheap and deterministic.
+// renderer calls it once per goal to measure column widths, caches the result,
+// and reuses it during print — so it must be deterministic but doesn't need to
+// be especially cheap.
 type Column struct {
 	Header string
 	Cell   func(Goal) string

--- a/goaltable_test.go
+++ b/goaltable_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// TestTableRenderEmpty exercises the degenerate cases: no columns and no
+// goals. Both should produce an empty string (no header row when there are
+// no columns; no rows when there are no goals).
+func TestTableRenderEmpty(t *testing.T) {
+	if got := (Table{}).Render(nil); got != "" {
+		t.Errorf("empty table render = %q, want empty", got)
+	}
+	tbl := Table{
+		Columns:    []Column{{Header: "Slug", Cell: func(g Goal) string { return g.Slug }}},
+		ShowHeader: false,
+	}
+	if got := tbl.Render(nil); got != "" {
+		t.Errorf("table with columns but no goals = %q, want empty", got)
+	}
+}
+
+// TestTableRenderHeader checks the `buzz list`-style table: header row, rule
+// row, two-space column separators, last column unpadded.
+func TestTableRenderHeader(t *testing.T) {
+	tbl := Table{
+		ShowHeader: true,
+		Columns: []Column{
+			{Header: "Slug", Cell: func(g Goal) string { return g.Slug }},
+			{Header: "Title", Cell: func(g Goal) string { return g.Title }},
+			{Header: "Stakes", Cell: func(g Goal) string { return g.Slug + "$" }},
+		},
+	}
+	goals := []Goal{
+		{Slug: "abc", Title: "Short"},
+		{Slug: "longslug", Title: "A longer title"},
+	}
+	got := tbl.Render(goals)
+
+	// "Slug" widens to 8 (longslug), "Title" widens to 14, last column not padded.
+	wantHeader := "Slug      Title           Stakes\n"
+	wantRule := "--------  --------------  ---------\n"
+	wantRow1 := "abc       Short           abc$\n"
+	wantRow2 := "longslug  A longer title  longslug$\n"
+
+	expected := wantHeader + wantRule + wantRow1 + wantRow2
+	if got != expected {
+		t.Errorf("table render mismatch\ngot:\n%s\nwant:\n%s", got, expected)
+	}
+}
+
+// TestTableRenderNoHeader checks the filtered-command style: no header rows,
+// last column unpadded, every data row colourized when Colorize is set.
+func TestTableRenderNoHeader(t *testing.T) {
+	tbl := Table{
+		Columns: []Column{
+			{Cell: func(g Goal) string { return g.Slug }},
+			{Cell: func(g Goal) string { return g.Baremin }},
+		},
+	}
+	goals := []Goal{
+		{Slug: "short", Baremin: "+1"},
+		{Slug: "wider-slug", Baremin: "+0.5"},
+	}
+	got := tbl.Render(goals)
+	// Slug column widens to 10, baremin column not padded (last column).
+	want := "short       +1\nwider-slug  +0.5\n"
+	if got != want {
+		t.Errorf("no-header render mismatch\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestTableRenderColorize asserts every data row gets the urgency style
+// wrapper. lipgloss strips ANSI when the test process isn't a TTY, so we
+// force TrueColor for the duration of this test and assert the colour
+// prefixes differ between two rows with different urgencies.
+func TestTableRenderColorize(t *testing.T) {
+	orig := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(orig) })
+
+	tbl := Table{
+		Colorize: true,
+		Columns: []Column{
+			{Cell: func(g Goal) string { return g.Slug }},
+		},
+	}
+	overdue := Goal{Slug: "overdue", Safebuf: 0}
+	distant := Goal{Slug: "distant", Safebuf: 100}
+	out := tbl.Render([]Goal{overdue, distant})
+
+	if !strings.Contains(out, "overdue") || !strings.Contains(out, "distant") {
+		t.Fatalf("expected both slugs in output, got %q", out)
+	}
+	overdueLine, _, _ := strings.Cut(out, "\n")
+	distantLine, _, _ := strings.Cut(strings.SplitN(out, "\n", 2)[1], "\n")
+
+	// The lines should differ because they wrap different colours; if
+	// colourisation were a no-op they'd be byte-equal aside from the slug.
+	if strings.ReplaceAll(overdueLine, "overdue", "") == strings.ReplaceAll(distantLine, "distant", "") {
+		t.Errorf("colourised rows for different urgencies are identical; expected different ANSI wrappers\noverdue: %q\ndistant: %q",
+			overdueLine, distantLine)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -659,70 +659,22 @@ func handleListCommand() {
 	// Print summary header
 	fmt.Printf("Total goals: %d\n\n", len(goals))
 
-	// Calculate column widths
-	maxSlugWidth := 4   // minimum for "Slug" header
-	maxTitleWidth := 5  // minimum for "Title" header
-	maxUnitsWidth := 5  // minimum for "Units" header
-	maxRateWidth := 4   // minimum for "Rate" header
-	maxStakesWidth := 6 // minimum for "Stakes" header
-
-	for _, goal := range goals {
-		if len(goal.Slug) > maxSlugWidth {
-			maxSlugWidth = len(goal.Slug)
-		}
-		if len(goal.Title) > maxTitleWidth {
-			maxTitleWidth = len(goal.Title)
-		}
-		// Calculate units width
-		units := getDisplayUnits(goal.Gunits)
-		if len(units) > maxUnitsWidth {
-			maxUnitsWidth = len(units)
-		}
-		// Format rate to calculate its width
-		rateStr := formatListRate(goal.Rate, goal.Runits)
-		if len(rateStr) > maxRateWidth {
-			maxRateWidth = len(rateStr)
-		}
-		// Format stakes to calculate its width
-		stakesStr := fmt.Sprintf("$%.2f", goal.Pledge)
-		if len(stakesStr) > maxStakesWidth {
-			maxStakesWidth = len(stakesStr)
-		}
+	table := Table{
+		ShowHeader: true,
+		Columns: []Column{
+			{Header: "Slug", Cell: func(g Goal) string { return g.Slug }},
+			{Header: "Title", Cell: func(g Goal) string {
+				if g.Title == "" {
+					return "-"
+				}
+				return g.Title
+			}},
+			{Header: "Units", Cell: func(g Goal) string { return getDisplayUnits(g.Gunits) }},
+			{Header: "Rate", Cell: func(g Goal) string { return formatListRate(g.Rate, g.Runits) }},
+			{Header: "Stakes", Cell: func(g Goal) string { return fmt.Sprintf("$%.2f", g.Pledge) }},
+		},
 	}
-
-	// Print header
-	fmt.Printf("%-*s  %-*s  %-*s  %-*s  %s\n",
-		maxSlugWidth, "Slug",
-		maxTitleWidth, "Title",
-		maxUnitsWidth, "Units",
-		maxRateWidth, "Rate",
-		"Stakes")
-
-	// Print separator
-	fmt.Printf("%s  %s  %s  %s  %s\n",
-		strings.Repeat("-", maxSlugWidth),
-		strings.Repeat("-", maxTitleWidth),
-		strings.Repeat("-", maxUnitsWidth),
-		strings.Repeat("-", maxRateWidth),
-		strings.Repeat("-", maxStakesWidth))
-
-	// Print each goal
-	for _, goal := range goals {
-		title := goal.Title
-		if title == "" {
-			title = "-"
-		}
-		units := getDisplayUnits(goal.Gunits)
-		rateStr := formatListRate(goal.Rate, goal.Runits)
-		stakesStr := fmt.Sprintf("$%.2f", goal.Pledge)
-
-		fmt.Printf("%-*s  %-*s  %-*s  %-*s  %s\n",
-			maxSlugWidth, goal.Slug,
-			maxTitleWidth, title,
-			maxUnitsWidth, units,
-			maxRateWidth, rateStr,
-			stakesStr)
-	}
+	fmt.Print(table.Render(goals))
 
 	// Check for updates and display message if available
 	fmt.Print(getUpdateMessage())
@@ -897,56 +849,16 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 	// displayed losedates are equal.
 	sortGoalsByDisplayedLosedate(filteredGoals, losedateFor)
 
-	// Pre-calculate formatted values to avoid redundant formatting calls
-	type goalDisplay struct {
-		goal             Goal
-		baremin          string
-		timeframe        string
-		absoluteDeadline string
+	table := Table{
+		Colorize: true,
+		Columns: []Column{
+			{Cell: func(g Goal) string { return g.Slug }},
+			{Cell: func(g Goal) string { return bareminFor(g) }},
+			{Cell: func(g Goal) string { return FormatDueDate(losedateFor(g)) }},
+			{Cell: func(g Goal) string { return FormatAbsoluteDeadline(losedateFor(g)) }},
+		},
 	}
-
-	displays := make([]goalDisplay, len(filteredGoals))
-	maxSlugWidth := 0
-	maxBareminWidth := 0
-	maxRelativeWidth := 0
-
-	for i, goal := range filteredGoals {
-		losedate := losedateFor(goal)
-		timeframe := FormatDueDate(losedate)
-		absoluteDeadline := FormatAbsoluteDeadline(losedate)
-		baremin := bareminFor(goal)
-		displays[i] = goalDisplay{
-			goal:             goal,
-			baremin:          baremin,
-			timeframe:        timeframe,
-			absoluteDeadline: absoluteDeadline,
-		}
-
-		if len(goal.Slug) > maxSlugWidth {
-			maxSlugWidth = len(goal.Slug)
-		}
-		if len(baremin) > maxBareminWidth {
-			maxBareminWidth = len(baremin)
-		}
-		if len(timeframe) > maxRelativeWidth {
-			maxRelativeWidth = len(timeframe)
-		}
-	}
-
-	// Output each goal on a separate line with aligned columns and color coding
-	for _, display := range displays {
-		style := UrgencyFor(display.goal.Safebuf).TextStyle()
-
-		// Format the line with proper spacing
-		line := fmt.Sprintf("%-*s  %-*s  %-*s  %s",
-			maxSlugWidth, display.goal.Slug,
-			maxBareminWidth, display.baremin,
-			maxRelativeWidth, display.timeframe,
-			display.absoluteDeadline)
-
-		// Apply color and print
-		fmt.Println(style.Render(line))
-	}
+	fmt.Print(table.Render(filteredGoals))
 
 	// Check for updates and display message if available
 	fmt.Print(getUpdateMessage())


### PR DESCRIPTION
Closes #248.

## Summary

`handleListCommand` and `handleFilteredCommandWithDisplay` were each hand-rolling the same pipeline —

> measure max width per column → pad cells → optionally apply the urgency text style per row → join with two-space separators, last column unpadded

— with small per-command variations (which columns, whether to colourise, whether to show a header). The *algorithm* was duplicated; PRs #244 (Client) and #247 (Urgency) had already extracted the API/auth boilerplate and the colour mapping, leaving the column arithmetic as the last big block of copy-paste.

## What changed

A new `Table` type in `goaltable.go` takes a declarative list of `Column{Header, Cell}` plus `ShowHeader` and `Colorize` flags and owns the measure-pad-colour-print pipeline. Cell functions are called once per goal, results cached.

Callers shrink to a few-line table declaration:

- **`handleListCommand`** — 5 columns, `ShowHeader: true`, `Colorize: false`. Was ~100 lines of column-width arithmetic + manual padding loops.
- **`handleFilteredCommandWithDisplay`** — 4 columns, `ShowHeader: false`, `Colorize: true` (the renderer consumes `Urgency` from `urgency.go` for the per-row style).

## Out of scope

`review.go`'s single-goal detail page and `grid.go`'s 2D cell grid are different shapes — neither fits the "table of goals" abstraction. Left them alone.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — pre-existing `TestExtractTimeSlots*` timezone failures unchanged
- [x] New `TestTableRender{Empty,Header,NoHeader,Colorize}` cover both modes and the colour wrapping (uses `lipgloss.SetColorProfile(termenv.TrueColor)` to force ANSI in the non-TTY test env, matching the precedent in `main_test.go`)
- [x] Two local `coderabbit review --agent` cycles return zero findings (first cycle flagged a docstring inaccuracy on `Cell`, fixed in b314bf0)

## Diff stats

```
main.go            | -88 net  (collapsed two hand-rolled tables)
goaltable.go       | +111 (new)
goaltable_test.go  | +108 (new)
```

Adding a future list command (e.g. `buzz week`) is now a filter plus a few-line `Table` declaration instead of another ~50 lines of column arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved goals list display rendering system for enhanced consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for goals table formatting and colorization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/256)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->