### PR TITLE
test: add FakeClient + unit tests for Cmd factories and handleAddDatapoint

### DIFF
--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// FakeClient is a test double for the Client interface. Each API method is
+// backed by an optional function field — set the ones a given test needs and
+// leave the rest unset; unset methods return errFakeNotConfigured so a test
+// that exercises an unexpected path fails loudly rather than silently
+// returning a zero value.
+//
+// Lives in a _test.go file so it never ships in the production binary; both
+// command tests and Bubble Tea handler tests can use it because everything is
+// in `package main`.
+type FakeClient struct {
+	FetchGoalsFunc                  func() ([]Goal, error)
+	FetchGoalFunc                   func(goalSlug string) (*Goal, error)
+	FetchGoalWithDatapointsFunc     func(goalSlug string) (*Goal, error)
+	FetchGoalRawJSONFunc            func(goalSlug string, includeDatapoints bool) (json.RawMessage, error)
+	GetLastDatapointValueFunc       func(goalSlug string) (float64, error)
+	CreateDatapointFunc             func(goalSlug, timestamp, value, comment, requestid string) error
+	CreateDatapointWithDaystampFunc func(goalSlug, timestamp, daystamp, value, comment, requestid string) error
+	CreateChargeFunc                func(amount float64, note string, dryrun bool) (*Charge, error)
+	CreateGoalFunc                  func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error)
+	CallUncleFunc                   func(goalSlug string) (*Goal, error)
+	UpdateGoalDeadlineFunc          func(goalSlug string, deadline int) (*Goal, error)
+	RefreshGoalFunc                 func(goalSlug string) (bool, error)
+}
+
+// errFakeNotConfigured is returned by every FakeClient method whose
+// corresponding *Func field is nil. Tests that hit it have a missing setup —
+// surface that rather than letting an unconfigured path succeed silently.
+var errFakeNotConfigured = errors.New("FakeClient method not configured for this test")
+
+func (c *FakeClient) FetchGoals() ([]Goal, error) {
+	if c.FetchGoalsFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.FetchGoalsFunc()
+}
+
+func (c *FakeClient) FetchGoal(goalSlug string) (*Goal, error) {
+	if c.FetchGoalFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.FetchGoalFunc(goalSlug)
+}
+
+func (c *FakeClient) FetchGoalWithDatapoints(goalSlug string) (*Goal, error) {
+	if c.FetchGoalWithDatapointsFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.FetchGoalWithDatapointsFunc(goalSlug)
+}
+
+func (c *FakeClient) FetchGoalRawJSON(goalSlug string, includeDatapoints bool) (json.RawMessage, error) {
+	if c.FetchGoalRawJSONFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.FetchGoalRawJSONFunc(goalSlug, includeDatapoints)
+}
+
+func (c *FakeClient) GetLastDatapointValue(goalSlug string) (float64, error) {
+	if c.GetLastDatapointValueFunc == nil {
+		return 0, errFakeNotConfigured
+	}
+	return c.GetLastDatapointValueFunc(goalSlug)
+}
+
+func (c *FakeClient) CreateDatapoint(goalSlug, timestamp, value, comment, requestid string) error {
+	if c.CreateDatapointFunc == nil {
+		return errFakeNotConfigured
+	}
+	return c.CreateDatapointFunc(goalSlug, timestamp, value, comment, requestid)
+}
+
+func (c *FakeClient) CreateDatapointWithDaystamp(goalSlug, timestamp, daystamp, value, comment, requestid string) error {
+	if c.CreateDatapointWithDaystampFunc == nil {
+		return errFakeNotConfigured
+	}
+	return c.CreateDatapointWithDaystampFunc(goalSlug, timestamp, daystamp, value, comment, requestid)
+}
+
+func (c *FakeClient) CreateCharge(amount float64, note string, dryrun bool) (*Charge, error) {
+	if c.CreateChargeFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.CreateChargeFunc(amount, note, dryrun)
+}
+
+func (c *FakeClient) CreateGoal(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+	if c.CreateGoalFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.CreateGoalFunc(slug, title, goalType, gunits, goaldate, goalval, rate)
+}
+
+func (c *FakeClient) CallUncle(goalSlug string) (*Goal, error) {
+	if c.CallUncleFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.CallUncleFunc(goalSlug)
+}
+
+func (c *FakeClient) UpdateGoalDeadline(goalSlug string, deadline int) (*Goal, error) {
+	if c.UpdateGoalDeadlineFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.UpdateGoalDeadlineFunc(goalSlug, deadline)
+}
+
+func (c *FakeClient) RefreshGoal(goalSlug string) (bool, error) {
+	if c.RefreshGoalFunc == nil {
+		return false, errFakeNotConfigured
+	}
+	return c.RefreshGoalFunc(goalSlug)
+}
+
+// Compile-time check that FakeClient satisfies Client.
+var _ Client = (*FakeClient)(nil)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1416,8 +1416,15 @@ func TestHandleAddDatapointDefaultsToOneOnZeroValue(t *testing.T) {
 	if !called {
 		t.Error("expected GetLastDatapointValue to be called")
 	}
-	if got := updated.(model).appModel.inputValue; got != "1" {
-		t.Errorf("inputValue with zero last value = %q, want %q", got, "1")
+	got := updated.(model).appModel
+	if got.inputValue != "1" {
+		t.Errorf("inputValue with zero last value = %q, want %q", got.inputValue, "1")
+	}
+	if !got.inputMode {
+		t.Error("expected inputMode to be true after handleAddDatapoint")
+	}
+	if got.inputComment != "Added via buzz" {
+		t.Errorf("inputComment = %q, want default %q", got.inputComment, "Added via buzz")
 	}
 }
 
@@ -1444,7 +1451,14 @@ func TestHandleAddDatapointDefaultsToOneOnFetchError(t *testing.T) {
 	if !called {
 		t.Error("expected GetLastDatapointValue to be called")
 	}
-	if got := updated.(model).appModel.inputValue; got != "1" {
-		t.Errorf("inputValue on fetch error = %q, want %q", got, "1")
+	got := updated.(model).appModel
+	if got.inputValue != "1" {
+		t.Errorf("inputValue on fetch error = %q, want %q", got.inputValue, "1")
+	}
+	if !got.inputMode {
+		t.Error("expected inputMode to be true after handleAddDatapoint")
+	}
+	if got.inputComment != "Added via buzz" {
+		t.Errorf("inputComment = %q, want default %q", got.inputComment, "Added via buzz")
 	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1353,3 +1353,83 @@ func TestLimsumFetchDelay(t *testing.T) {
 		}
 	})
 }
+
+// handleAddDatapoint is the modal-open path that pre-fills the input form
+// with the goal's last datapoint value (defaulting to "1" if the value is
+// zero or the API errors). It was previously untestable because every
+// invocation hit the real HTTPClient; now FakeClient lets us cover all
+// three branches cheaply.
+
+func TestHandleAddDatapointPrefillsLastValue(t *testing.T) {
+	fake := &FakeClient{
+		GetLastDatapointValueFunc: func(slug string) (float64, error) {
+			if slug != "exercise" {
+				t.Errorf("client called with slug=%q, want exercise", slug)
+			}
+			return 2.5, nil
+		},
+	}
+	m := model{
+		state: "app",
+		appModel: appModel{
+			client:    fake,
+			modalGoal: &Goal{Slug: "exercise"},
+			showModal: true,
+		},
+	}
+
+	updated, _ := handleAddDatapoint(m)
+	got := updated.(model).appModel
+	if got.inputValue != "2.5" {
+		t.Errorf("inputValue = %q, want %q", got.inputValue, "2.5")
+	}
+	if !got.inputMode {
+		t.Error("expected inputMode to be true after handleAddDatapoint")
+	}
+	if got.inputComment != "Added via buzz" {
+		t.Errorf("inputComment = %q, want default %q", got.inputComment, "Added via buzz")
+	}
+}
+
+func TestHandleAddDatapointDefaultsToOneOnZeroValue(t *testing.T) {
+	// API returned the goal but the last datapoint value was zero — buzz
+	// treats that as "no useful default" and falls back to "1".
+	fake := &FakeClient{
+		GetLastDatapointValueFunc: func(string) (float64, error) { return 0, nil },
+	}
+	m := model{
+		state: "app",
+		appModel: appModel{
+			client:    fake,
+			modalGoal: &Goal{Slug: "any"},
+			showModal: true,
+		},
+	}
+
+	updated, _ := handleAddDatapoint(m)
+	if got := updated.(model).appModel.inputValue; got != "1" {
+		t.Errorf("inputValue with zero last value = %q, want %q", got, "1")
+	}
+}
+
+func TestHandleAddDatapointDefaultsToOneOnFetchError(t *testing.T) {
+	// API errored — same fallback to "1" rather than blocking the modal.
+	fake := &FakeClient{
+		GetLastDatapointValueFunc: func(string) (float64, error) {
+			return 0, errFakeNotConfigured
+		},
+	}
+	m := model{
+		state: "app",
+		appModel: appModel{
+			client:    fake,
+			modalGoal: &Goal{Slug: "any"},
+			showModal: true,
+		},
+	}
+
+	updated, _ := handleAddDatapoint(m)
+	if got := updated.(model).appModel.inputValue; got != "1" {
+		t.Errorf("inputValue on fetch error = %q, want %q", got, "1")
+	}
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1394,8 +1394,14 @@ func TestHandleAddDatapointPrefillsLastValue(t *testing.T) {
 func TestHandleAddDatapointDefaultsToOneOnZeroValue(t *testing.T) {
 	// API returned the goal but the last datapoint value was zero — buzz
 	// treats that as "no useful default" and falls back to "1".
+	// Track whether the client was called so a future change that stops
+	// querying it (and just hard-codes "1") would fail this test.
+	called := false
 	fake := &FakeClient{
-		GetLastDatapointValueFunc: func(string) (float64, error) { return 0, nil },
+		GetLastDatapointValueFunc: func(string) (float64, error) {
+			called = true
+			return 0, nil
+		},
 	}
 	m := model{
 		state: "app",
@@ -1407,6 +1413,9 @@ func TestHandleAddDatapointDefaultsToOneOnZeroValue(t *testing.T) {
 	}
 
 	updated, _ := handleAddDatapoint(m)
+	if !called {
+		t.Error("expected GetLastDatapointValue to be called")
+	}
 	if got := updated.(model).appModel.inputValue; got != "1" {
 		t.Errorf("inputValue with zero last value = %q, want %q", got, "1")
 	}
@@ -1414,8 +1423,11 @@ func TestHandleAddDatapointDefaultsToOneOnZeroValue(t *testing.T) {
 
 func TestHandleAddDatapointDefaultsToOneOnFetchError(t *testing.T) {
 	// API errored — same fallback to "1" rather than blocking the modal.
+	// Track the call so the fallback can't accidentally short-circuit it.
+	called := false
 	fake := &FakeClient{
 		GetLastDatapointValueFunc: func(string) (float64, error) {
+			called = true
 			return 0, errFakeNotConfigured
 		},
 	}
@@ -1429,6 +1441,9 @@ func TestHandleAddDatapointDefaultsToOneOnFetchError(t *testing.T) {
 	}
 
 	updated, _ := handleAddDatapoint(m)
+	if !called {
+		t.Error("expected GetLastDatapointValue to be called")
+	}
 	if got := updated.(model).appModel.inputValue; got != "1" {
 		t.Errorf("inputValue on fetch error = %q, want %q", got, "1")
 	}

--- a/messages_test.go
+++ b/messages_test.go
@@ -118,6 +118,21 @@ func TestLoadGoalDetailsCmdPassesSlug(t *testing.T) {
 	}
 }
 
+func TestLoadGoalDetailsCmdError(t *testing.T) {
+	wantErr := errors.New("goal not found")
+	fake := &FakeClient{
+		FetchGoalWithDatapointsFunc: func(string) (*Goal, error) { return nil, wantErr },
+	}
+
+	msg := loadGoalDetailsCmd(fake, "missing")().(goalDetailsLoadedMsg)
+	if !errors.Is(msg.err, wantErr) {
+		t.Errorf("loadGoalDetailsCmd err = %v, want %v", msg.err, wantErr)
+	}
+	if msg.goal != nil {
+		t.Errorf("loadGoalDetailsCmd returned goal=%v on error path, want nil", msg.goal)
+	}
+}
+
 // createGoalCmd forwards every positional argument to client.CreateGoal and
 // wraps the result in goalCreatedMsg. Use a single happy-path test to verify
 // argument plumbing — the seven-arg signature is what matters here.
@@ -149,5 +164,20 @@ func TestCreateGoalCmdPassesArgs(t *testing.T) {
 		gotGoaldate != "20260101" || gotGoalval != "null" || gotRate != "5" {
 		t.Errorf("createGoalCmd passed (%q, %q, %q, %q, %q, %q, %q), want (newg, New Goal, hustler, pages, 20260101, null, 5)",
 			gotSlug, gotTitle, gotType, gotGunits, gotGoaldate, gotGoalval, gotRate)
+	}
+}
+
+func TestCreateGoalCmdError(t *testing.T) {
+	wantErr := errors.New("slug already exists")
+	fake := &FakeClient{
+		CreateGoalFunc: func(_, _, _, _, _, _, _ string) (*Goal, error) { return nil, wantErr },
+	}
+
+	msg := createGoalCmd(fake, "dup", "", "", "", "", "", "")().(goalCreatedMsg)
+	if !errors.Is(msg.err, wantErr) {
+		t.Errorf("createGoalCmd err = %v, want %v", msg.err, wantErr)
+	}
+	if msg.goal != nil {
+		t.Errorf("createGoalCmd returned goal=%v on error path, want nil", msg.goal)
 	}
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// loadGoalsCmd: calls client.FetchGoals, sorts the result, and packs goals
+// or err into goalsLoadedMsg. The fake client lets us assert both the
+// success and failure branches without an HTTP server.
+
+func TestLoadGoalsCmdSuccess(t *testing.T) {
+	// SortGoals orders by losedate ascending, so the second goal should end up
+	// first after sorting.
+	goal1 := Goal{Slug: "later", Losedate: 200}
+	goal2 := Goal{Slug: "earlier", Losedate: 100}
+	fake := &FakeClient{
+		FetchGoalsFunc: func() ([]Goal, error) {
+			return []Goal{goal1, goal2}, nil
+		},
+	}
+
+	msg, ok := loadGoalsCmd(fake)().(goalsLoadedMsg)
+	if !ok {
+		t.Fatalf("loadGoalsCmd produced %T, want goalsLoadedMsg", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("loadGoalsCmd err = %v, want nil", msg.err)
+	}
+	if len(msg.goals) != 2 {
+		t.Fatalf("loadGoalsCmd returned %d goals, want 2", len(msg.goals))
+	}
+	if msg.goals[0].Slug != "earlier" {
+		t.Errorf("goals not sorted by losedate: got first=%q, want %q", msg.goals[0].Slug, "earlier")
+	}
+}
+
+func TestLoadGoalsCmdError(t *testing.T) {
+	wantErr := errors.New("network down")
+	fake := &FakeClient{
+		FetchGoalsFunc: func() ([]Goal, error) { return nil, wantErr },
+	}
+
+	msg, ok := loadGoalsCmd(fake)().(goalsLoadedMsg)
+	if !ok {
+		t.Fatalf("loadGoalsCmd produced %T, want goalsLoadedMsg", msg)
+	}
+	if !errors.Is(msg.err, wantErr) {
+		t.Errorf("loadGoalsCmd err = %v, want %v", msg.err, wantErr)
+	}
+	if msg.goals != nil {
+		t.Errorf("loadGoalsCmd returned goals=%v on error path, want nil", msg.goals)
+	}
+}
+
+// submitDatapointCmd forwards its args verbatim to client.CreateDatapoint
+// (with empty requestid) and wraps the error in datapointSubmittedMsg.
+
+func TestSubmitDatapointCmdPassesArgs(t *testing.T) {
+	var gotSlug, gotTimestamp, gotValue, gotComment, gotRequestID string
+	fake := &FakeClient{
+		CreateDatapointFunc: func(slug, ts, value, comment, requestID string) error {
+			gotSlug, gotTimestamp, gotValue, gotComment, gotRequestID = slug, ts, value, comment, requestID
+			return nil
+		},
+	}
+
+	msg, ok := submitDatapointCmd(fake, "exercise", "1700000000", "1.5", "morning run")().(datapointSubmittedMsg)
+	if !ok {
+		t.Fatalf("submitDatapointCmd produced %T, want datapointSubmittedMsg", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("submitDatapointCmd err = %v, want nil", msg.err)
+	}
+	if gotSlug != "exercise" || gotTimestamp != "1700000000" || gotValue != "1.5" || gotComment != "morning run" {
+		t.Errorf("client called with (%q, %q, %q, %q), want (exercise, 1700000000, 1.5, morning run)",
+			gotSlug, gotTimestamp, gotValue, gotComment)
+	}
+	if gotRequestID != "" {
+		t.Errorf("submitDatapointCmd should leave requestid empty, got %q", gotRequestID)
+	}
+}
+
+func TestSubmitDatapointCmdError(t *testing.T) {
+	wantErr := errors.New("rate limited")
+	fake := &FakeClient{
+		CreateDatapointFunc: func(_, _, _, _, _ string) error { return wantErr },
+	}
+
+	msg := submitDatapointCmd(fake, "any", "0", "1", "")().(datapointSubmittedMsg)
+	if !errors.Is(msg.err, wantErr) {
+		t.Errorf("submitDatapointCmd err = %v, want %v", msg.err, wantErr)
+	}
+}
+
+// loadGoalDetailsCmd is a thin wrapper around client.FetchGoalWithDatapoints
+// that packs the result into goalDetailsLoadedMsg.
+
+func TestLoadGoalDetailsCmdPassesSlug(t *testing.T) {
+	want := &Goal{Slug: "x", Datapoints: []Datapoint{{ID: "1", Value: 1}}}
+	var gotSlug string
+	fake := &FakeClient{
+		FetchGoalWithDatapointsFunc: func(slug string) (*Goal, error) {
+			gotSlug = slug
+			return want, nil
+		},
+	}
+
+	msg := loadGoalDetailsCmd(fake, "x")().(goalDetailsLoadedMsg)
+	if gotSlug != "x" {
+		t.Errorf("client called with slug=%q, want x", gotSlug)
+	}
+	if msg.goal != want {
+		t.Errorf("loadGoalDetailsCmd goal = %v, want %v", msg.goal, want)
+	}
+	if msg.err != nil {
+		t.Errorf("loadGoalDetailsCmd err = %v, want nil", msg.err)
+	}
+}
+
+// createGoalCmd forwards every positional argument to client.CreateGoal and
+// wraps the result in goalCreatedMsg. Use a single happy-path test to verify
+// argument plumbing — the seven-arg signature is what matters here.
+
+func TestCreateGoalCmdPassesArgs(t *testing.T) {
+	wantGoal := &Goal{Slug: "newg"}
+	var gotSlug, gotTitle, gotType, gotGunits, gotGoaldate, gotGoalval, gotRate string
+	fake := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			gotSlug = slug
+			gotTitle = title
+			gotType = goalType
+			gotGunits = gunits
+			gotGoaldate = goaldate
+			gotGoalval = goalval
+			gotRate = rate
+			return wantGoal, nil
+		},
+	}
+
+	msg := createGoalCmd(fake, "newg", "New Goal", "hustler", "pages", "20260101", "null", "5")().(goalCreatedMsg)
+	if msg.goal != wantGoal {
+		t.Errorf("createGoalCmd goal = %v, want %v", msg.goal, wantGoal)
+	}
+	if msg.err != nil {
+		t.Errorf("createGoalCmd err = %v, want nil", msg.err)
+	}
+	if gotSlug != "newg" || gotTitle != "New Goal" || gotType != "hustler" || gotGunits != "pages" ||
+		gotGoaldate != "20260101" || gotGoalval != "null" || gotRate != "5" {
+		t.Errorf("createGoalCmd passed (%q, %q, %q, %q, %q, %q, %q), want (newg, New Goal, hustler, pages, 20260101, null, 5)",
+			gotSlug, gotTitle, gotType, gotGunits, gotGoaldate, gotGoalval, gotRate)
+	}
+}


### PR DESCRIPTION
Closes #252.

## Summary

PR #251 introduced the `Client` interface so command and handler tests could be written without `httptest` gymnastics. This lands the test-side counterpart: a `FakeClient` test helper plus three concrete uses of it.

## What's in this PR

### `client_fake_test.go` — `FakeClient` test helper

- `FakeClient` struct with one `*Func` field per `Client` method (`FetchGoalsFunc`, `GetLastDatapointValueFunc`, etc.).
- Each method returns `errFakeNotConfigured` when its `*Func` is `nil`, so a test that exercises an unexpected path **fails loudly** instead of silently returning zero values.
- Compile-time check that `FakeClient` satisfies `Client`.
- Lives in a `_test.go` file so it never ships in the production binary.

### `messages_test.go` — covers all four `Cmd` factories

Each factory is a tiny pure function that takes a `Client`, calls one method, and packs the result into a `tea.Msg`. Verifies argument plumbing and the err/value branches end-to-end:

- `loadGoalsCmd` success: confirms the `SortGoals` post-step orders by `losedate`.
- `loadGoalsCmd` error: verifies err propagates and `goals` is nil.
- `submitDatapointCmd`: passes its 4 positional args verbatim with `requestid=""`.
- `submitDatapointCmd` error: err wraps into `datapointSubmittedMsg`.
- `loadGoalDetailsCmd`: passes the slug, packs the goal into `goalDetailsLoadedMsg`.
- `createGoalCmd`: passes all 7 args.

### `handlers_test.go` — `handleAddDatapoint` modal-open path

The issue specifically called this out: the path that fetches `GetLastDatapointValue` and pre-fills `inputValue`. All three branches now have coverage:

- Non-zero last value → `inputValue` set to the formatted value.
- Zero last value → `inputValue` defaults to `"1"`.
- Fetch error → `inputValue` defaults to `"1"`.

Plus checks the modal-state side effects (`inputMode`, default `inputComment`).

## What I did *not* migrate

`beeminder_test.go` still has its 25 `httptest.NewServer` blocks. Each one genuinely exercises the `HTTPClient` adapter — URL building, query params, error decoding, response shape. Those are the right shape for testing the adapter and have value as integration-ish coverage of the API contract. The leverage from `FakeClient` is in tests of *higher-level* behaviour where HTTP details are irrelevant — that's what this PR adds.

A future PR can migrate any `beeminder_test.go` cases whose intent was really "given this response, does the higher level behave correctly" rather than "does the URL/encoding match." But I didn't find clear instances of that on this audit; the `beeminder_test.go` tests are well-targeted at adapter concerns.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — pre-existing `TestExtractTimeSlots*` timezone failures unchanged; all new tests pass
- [x] Local `coderabbit review --agent` returns zero findings

## Diff stats

```
client_fake_test.go  | +122 (new)
messages_test.go     | +153 (new)
handlers_test.go     |  +80
```

Net: zero `httptest.NewServer` in any new test; the foundation is in place for future handler/command coverage to be added cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for datapoint submission modal prefill behavior (handles previous value, zero, and fetch errors).
  * Added thorough tests for goal-related command flows: loading goals, submitting datapoints, loading goal details, and creating goals — covering both success and error paths.
  * Introduced a test double for the client layer to enable these scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/261)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->