### PR TITLE
refactor: thread context.Context through Client interface

### DIFF
--- a/add.go
+++ b/add.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -136,7 +137,7 @@ func handleAddCommand() {
 	}
 
 	// Create the datapoint
-	err = client.CreateDatapointWithDaystamp(goalSlug, timestamp, daystampForAPI, value, comment, *requestid)
+	err = client.CreateDatapointWithDaystamp(context.Background(), goalSlug, timestamp, daystampForAPI, value, comment, *requestid)
 	if err != nil {
 		fmt.Printf("Error: Failed to add datapoint: %s\n", redactError(err))
 		os.Exit(1)
@@ -161,7 +162,7 @@ func handleAddCommand() {
 	time.Sleep(limsumFetchDelay)
 
 	// Fetch the goal to display the updated limsum
-	goal, err := client.FetchGoal(goalSlug)
+	goal, err := client.FetchGoal(context.Background(), goalSlug)
 	if err != nil {
 		// Don't fail the command if fetching limsum fails, just skip displaying it
 		fmt.Fprintf(os.Stderr, "Warning: Could not fetch goal status: %s\n", redactError(err))

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2208,15 +2208,15 @@ func TestCallUncleWithMockServer(t *testing.T) {
 }
 
 // TestHTTPClientCancellation verifies that a cancelled context propagates
-// into the in-flight HTTP request. The mock server blocks until the test
-// signals it; we cancel the parent context partway through and assert that
-// the call returns context.Canceled (rather than the success it would have
-// produced after the server eventually responded).
+// into the in-flight HTTP request. The mock server signals `started` as soon
+// as it begins handling, then blocks until `released`; the test cancels the
+// parent context strictly after `started` fires so cancellation is guaranteed
+// to land mid-request rather than racing against a fixed sleep.
 func TestHTTPClientCancellation(t *testing.T) {
+	started := make(chan struct{})
 	released := make(chan struct{})
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Block until the test side closes `released` so we exercise the
-		// cancellation path deterministically rather than racing the response.
+		close(started)
 		<-released
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`[]`))
@@ -2228,10 +2228,8 @@ func TestHTTPClientCancellation(t *testing.T) {
 	client := NewHTTPClient(config)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel after a short delay so FetchGoals has started but the mock
-	// server hasn't responded yet.
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		<-started
 		cancel()
 	}()
 

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -980,7 +982,7 @@ func TestFetchGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).FetchGoal("testgoal")
+		goal, err := NewHTTPClient(config).FetchGoal(context.Background(), "testgoal")
 		if err != nil {
 			t.Fatalf("FetchGoal failed: %v", err)
 		}
@@ -1005,7 +1007,7 @@ func TestFetchGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		_, err := NewHTTPClient(config).FetchGoal("nonexistent")
+		_, err := NewHTTPClient(config).FetchGoal(context.Background(), "nonexistent")
 		if err == nil {
 			t.Error("Expected error for 404 status, got nil")
 		}
@@ -1027,7 +1029,7 @@ func TestFetchGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		_, err := NewHTTPClient(config).FetchGoal("testgoal")
+		_, err := NewHTTPClient(config).FetchGoal(context.Background(), "testgoal")
 		if err == nil {
 			t.Error("Expected error for non-200 status, got nil")
 		}
@@ -1061,7 +1063,7 @@ func TestFetchGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).FetchGoal("test goal")
+		goal, err := NewHTTPClient(config).FetchGoal(context.Background(), "test goal")
 		if err != nil {
 			t.Fatalf("FetchGoal failed: %v", err)
 		}
@@ -1104,7 +1106,7 @@ func TestFetchGoalsWithGoalType(t *testing.T) {
 		BaseURL:   mockServer.URL,
 	}
 
-	goals, err := NewHTTPClient(config).FetchGoals()
+	goals, err := NewHTTPClient(config).FetchGoals(context.Background())
 	if err != nil {
 		t.Fatalf("FetchGoals failed: %v", err)
 	}
@@ -1189,7 +1191,7 @@ func TestRefreshGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		queued, err := NewHTTPClient(config).RefreshGoal("testgoal")
+		queued, err := NewHTTPClient(config).RefreshGoal(context.Background(), "testgoal")
 		if err != nil {
 			t.Fatalf("RefreshGoal failed: %v", err)
 		}
@@ -1213,7 +1215,7 @@ func TestRefreshGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		queued, err := NewHTTPClient(config).RefreshGoal("testgoal")
+		queued, err := NewHTTPClient(config).RefreshGoal(context.Background(), "testgoal")
 		if err != nil {
 			t.Fatalf("RefreshGoal failed: %v", err)
 		}
@@ -1236,7 +1238,7 @@ func TestRefreshGoalWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		_, err := NewHTTPClient(config).RefreshGoal("testgoal")
+		_, err := NewHTTPClient(config).RefreshGoal(context.Background(), "testgoal")
 		if err == nil {
 			t.Error("Expected error for non-200 status, got nil")
 		}
@@ -1302,7 +1304,7 @@ func TestCreateChargeWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		ch, err := NewHTTPClient(config).CreateCharge(10.00, "Test charge", false)
+		ch, err := NewHTTPClient(config).CreateCharge(context.Background(), 10.00, "Test charge", false)
 		if err != nil {
 			t.Fatalf("CreateCharge failed: %v", err)
 		}
@@ -1342,7 +1344,7 @@ func TestCreateChargeWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		ch, err := NewHTTPClient(config).CreateCharge(5.00, "Test charge with dryrun", true)
+		ch, err := NewHTTPClient(config).CreateCharge(context.Background(), 5.00, "Test charge with dryrun", true)
 		if err != nil {
 			t.Fatalf("CreateCharge failed: %v", err)
 		}
@@ -1364,7 +1366,7 @@ func TestCreateChargeWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		ch, err := NewHTTPClient(config).CreateCharge(10.00, "Test charge", false)
+		ch, err := NewHTTPClient(config).CreateCharge(context.Background(), 10.00, "Test charge", false)
 		if err == nil {
 			t.Error("Expected error for non-200 status, got nil")
 		}
@@ -1406,7 +1408,7 @@ func TestCreateChargeWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		ch, err := NewHTTPClient(config).CreateCharge(10.00, specialNote, false)
+		ch, err := NewHTTPClient(config).CreateCharge(context.Background(), 10.00, specialNote, false)
 		if err != nil {
 			t.Fatalf("CreateCharge failed: %v", err)
 		}
@@ -1444,7 +1446,7 @@ func TestCreateChargeWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		ch, err := NewHTTPClient(config).CreateCharge(10.5, "Test", false)
+		ch, err := NewHTTPClient(config).CreateCharge(context.Background(), 10.5, "Test", false)
 		if err != nil {
 			t.Fatalf("CreateCharge failed: %v", err)
 		}
@@ -1474,7 +1476,7 @@ func TestGoalFineprintField(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).FetchGoal("testgoal")
+		goal, err := NewHTTPClient(config).FetchGoal(context.Background(), "testgoal")
 		if err != nil {
 			t.Fatalf("FetchGoal failed: %v", err)
 		}
@@ -1501,7 +1503,7 @@ func TestGoalFineprintField(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).FetchGoal("testgoal")
+		goal, err := NewHTTPClient(config).FetchGoal(context.Background(), "testgoal")
 		if err != nil {
 			t.Fatalf("FetchGoal failed: %v", err)
 		}
@@ -1545,7 +1547,7 @@ func TestGoalTypeField(t *testing.T) {
 				BaseURL:   mockServer.URL,
 			}
 
-			goal, err := NewHTTPClient(config).FetchGoal("testgoal")
+			goal, err := NewHTTPClient(config).FetchGoal(context.Background(), "testgoal")
 			if err != nil {
 				t.Fatalf("FetchGoal failed: %v", err)
 			}
@@ -1613,7 +1615,7 @@ func TestCreateDatapointWithRequestID(t *testing.T) {
 			}
 
 			// Call CreateDatapoint
-			err := NewHTTPClient(config).CreateDatapoint("testgoal", "1234567890", "5.0", "test comment", tt.requestid)
+			err := NewHTTPClient(config).CreateDatapoint(context.Background(), "testgoal", "1234567890", "5.0", "test comment", tt.requestid)
 			if err != nil {
 				t.Fatalf("CreateDatapoint failed: %v", err)
 			}
@@ -1695,7 +1697,7 @@ func TestCreateDatapointWithDaystamp(t *testing.T) {
 			}
 
 			// Call CreateDatapointWithDaystamp
-			err := NewHTTPClient(config).CreateDatapointWithDaystamp("testgoal", tt.timestamp, tt.daystamp, "5.0", "test comment", "")
+			err := NewHTTPClient(config).CreateDatapointWithDaystamp(context.Background(), "testgoal", tt.timestamp, tt.daystamp, "5.0", "test comment", "")
 			if err != nil {
 				t.Fatalf("CreateDatapointWithDaystamp failed: %v", err)
 			}
@@ -2046,7 +2048,7 @@ func TestUpdateGoalDeadline(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).UpdateGoalDeadline("testgoal", -32400)
+		goal, err := NewHTTPClient(config).UpdateGoalDeadline(context.Background(), "testgoal", -32400)
 		if err != nil {
 			t.Fatalf("UpdateGoalDeadline failed: %v", err)
 		}
@@ -2071,7 +2073,7 @@ func TestUpdateGoalDeadline(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		_, err := NewHTTPClient(config).UpdateGoalDeadline("testgoal", 0)
+		_, err := NewHTTPClient(config).UpdateGoalDeadline(context.Background(), "testgoal", 0)
 		if err == nil {
 			t.Error("Expected error for non-200 status, got nil")
 		}
@@ -2115,7 +2117,7 @@ func TestCallUncleWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).CallUncle("testgoal")
+		goal, err := NewHTTPClient(config).CallUncle(context.Background(), "testgoal")
 		if err != nil {
 			t.Fatalf("CallUncle failed: %v", err)
 		}
@@ -2137,7 +2139,7 @@ func TestCallUncleWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).CallUncle("testgoal")
+		goal, err := NewHTTPClient(config).CallUncle(context.Background(), "testgoal")
 		if err == nil {
 			t.Error("Expected error for non-200 status, got nil")
 		}
@@ -2173,7 +2175,7 @@ func TestCallUncleWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).CallUncle(rawSlug)
+		goal, err := NewHTTPClient(config).CallUncle(context.Background(), rawSlug)
 		if err != nil {
 			t.Fatalf("CallUncle failed: %v", err)
 		}
@@ -2195,7 +2197,7 @@ func TestCallUncleWithMockServer(t *testing.T) {
 			BaseURL:   mockServer.URL,
 		}
 
-		goal, err := NewHTTPClient(config).CallUncle("testgoal")
+		goal, err := NewHTTPClient(config).CallUncle(context.Background(), "testgoal")
 		if err == nil {
 			t.Error("Expected error for non-200 status, got nil")
 		}
@@ -2203,4 +2205,41 @@ func TestCallUncleWithMockServer(t *testing.T) {
 			t.Errorf("Expected nil goal on error, got: %+v", goal)
 		}
 	})
+}
+
+// TestHTTPClientCancellation verifies that a cancelled context propagates
+// into the in-flight HTTP request. The mock server blocks until the test
+// signals it; we cancel the parent context partway through and assert that
+// the call returns context.Canceled (rather than the success it would have
+// produced after the server eventually responded).
+func TestHTTPClientCancellation(t *testing.T) {
+	released := make(chan struct{})
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block until the test side closes `released` so we exercise the
+		// cancellation path deterministically rather than racing the response.
+		<-released
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer mockServer.Close()
+	defer close(released)
+
+	config := &Config{Username: "test", AuthToken: "x", BaseURL: mockServer.URL}
+	client := NewHTTPClient(config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay so FetchGoals has started but the mock
+	// server hasn't responded yet.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.FetchGoals(ctx)
+	if err == nil {
+		t.Fatal("FetchGoals returned nil error after context cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("FetchGoals err = %v, want it to wrap context.Canceled", err)
+	}
 }

--- a/charge.go
+++ b/charge.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -71,7 +72,7 @@ func handleChargeCommand() {
 	client := NewHTTPClient(config)
 
 	// Create the charge (API returns the created/dry-run charge)
-	ch, err := client.CreateCharge(amount, note, dryrun)
+	ch, err := client.CreateCharge(context.Background(), amount, note, dryrun)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to create charge: %s\n", redactError(err))
 		os.Exit(1)

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,29 +11,30 @@ import (
 	"time"
 )
 
-// httpClientTimeout caps every Beeminder request so a stalled connection can't
-// freeze the CLI or block a Bubble Tea Cmd indefinitely. A real cancellation
-// story (per-request context, user-quit propagation) is tracked in issue #253;
-// this timeout is the cheap stopgap until then.
+// httpClientTimeout caps every Beeminder request so a stalled connection
+// can't freeze the CLI or block a Bubble Tea Cmd indefinitely. Per-request
+// context (this file) layers on top: callers can cancel a request before
+// the timeout fires, e.g. when the user quits the TUI.
 const httpClientTimeout = 30 * time.Second
 
-// Client is the Beeminder API seam. Production code depends on this interface;
-// HTTPClient is the only adapter today, and tests use it via NewHTTPClient
-// pointed at httptest. Future work (see issue #244 follow-on) can introduce a
-// fake adapter so command/handler tests don't need an HTTP server.
+// Client is the Beeminder API seam. Every method takes a context.Context as
+// its first parameter; callers should pass either the long-lived appModel
+// context (TUI) or context.Background() (short-lived CLI commands). The
+// context.Context support enables future quit-cancellation wiring without
+// further interface changes — that wiring is tracked in a follow-up.
 type Client interface {
-	FetchGoals() ([]Goal, error)
-	FetchGoal(goalSlug string) (*Goal, error)
-	FetchGoalWithDatapoints(goalSlug string) (*Goal, error)
-	FetchGoalRawJSON(goalSlug string, includeDatapoints bool) (json.RawMessage, error)
-	GetLastDatapointValue(goalSlug string) (float64, error)
-	CreateDatapoint(goalSlug, timestamp, value, comment, requestid string) error
-	CreateDatapointWithDaystamp(goalSlug, timestamp, daystamp, value, comment, requestid string) error
-	CreateCharge(amount float64, note string, dryrun bool) (*Charge, error)
-	CreateGoal(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error)
-	CallUncle(goalSlug string) (*Goal, error)
-	UpdateGoalDeadline(goalSlug string, deadline int) (*Goal, error)
-	RefreshGoal(goalSlug string) (bool, error)
+	FetchGoals(ctx context.Context) ([]Goal, error)
+	FetchGoal(ctx context.Context, goalSlug string) (*Goal, error)
+	FetchGoalWithDatapoints(ctx context.Context, goalSlug string) (*Goal, error)
+	FetchGoalRawJSON(ctx context.Context, goalSlug string, includeDatapoints bool) (json.RawMessage, error)
+	GetLastDatapointValue(ctx context.Context, goalSlug string) (float64, error)
+	CreateDatapoint(ctx context.Context, goalSlug, timestamp, value, comment, requestid string) error
+	CreateDatapointWithDaystamp(ctx context.Context, goalSlug, timestamp, daystamp, value, comment, requestid string) error
+	CreateCharge(ctx context.Context, amount float64, note string, dryrun bool) (*Charge, error)
+	CreateGoal(ctx context.Context, slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error)
+	CallUncle(ctx context.Context, goalSlug string) (*Goal, error)
+	UpdateGoalDeadline(ctx context.Context, goalSlug string, deadline int) (*Goal, error)
+	RefreshGoal(ctx context.Context, goalSlug string) (bool, error)
 }
 
 // HTTPClient is the HTTP-backed Client. Construct with NewHTTPClient.
@@ -64,18 +66,37 @@ func (c *HTTPClient) baseURL() string {
 	return getBaseURL(c.config)
 }
 
+// doRequest builds a context-aware request, executes it, and emits the
+// LogRequest/LogResponse pair. The contentType argument is set as the
+// Content-Type header when non-empty (POST/PUT bodies). Per-method callers
+// own status-code interpretation and body decoding.
+func (c *HTTPClient) doRequest(ctx context.Context, method, url string, body io.Reader, contentType string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	LogRequest(c.config, method, url)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	LogResponse(c.config, resp.StatusCode, url)
+	return resp, nil
+}
+
 // FetchGoals fetches the user's goals from Beeminder API.
-func (c *HTTPClient) FetchGoals() ([]Goal, error) {
+func (c *HTTPClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 	url := fmt.Sprintf("%s/api/v1/users/%s/goals.json?auth_token=%s",
 		c.baseURL(), c.config.Username, c.config.AuthToken)
 
-	LogRequest(c.config, "GET", url)
-	resp, err := c.http.Get(url)
+	resp, err := c.doRequest(ctx, http.MethodGet, url, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch goals: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, url)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
@@ -90,17 +111,15 @@ func (c *HTTPClient) FetchGoals() ([]Goal, error) {
 }
 
 // GetLastDatapointValue fetches the last datapoint value for a goal.
-func (c *HTTPClient) GetLastDatapointValue(goalSlug string) (float64, error) {
+func (c *HTTPClient) GetLastDatapointValue(ctx context.Context, goalSlug string) (float64, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s&skinny=true",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	LogRequest(c.config, "GET", apiURL)
-	resp, err := c.http.Get(apiURL)
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch goal details: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		return 0, fmt.Errorf("API returned status %d", resp.StatusCode)
@@ -122,13 +141,13 @@ func (c *HTTPClient) GetLastDatapointValue(goalSlug string) (float64, error) {
 }
 
 // CreateDatapoint submits a new datapoint to a Beeminder goal.
-func (c *HTTPClient) CreateDatapoint(goalSlug, timestamp, value, comment, requestid string) error {
-	return c.CreateDatapointWithDaystamp(goalSlug, timestamp, "", value, comment, requestid)
+func (c *HTTPClient) CreateDatapoint(ctx context.Context, goalSlug, timestamp, value, comment, requestid string) error {
+	return c.CreateDatapointWithDaystamp(ctx, goalSlug, timestamp, "", value, comment, requestid)
 }
 
 // CreateDatapointWithDaystamp submits a new datapoint with optional daystamp.
 // If daystamp is provided (format YYYYMMDD), it is used instead of timestamp.
-func (c *HTTPClient) CreateDatapointWithDaystamp(goalSlug, timestamp, daystamp, value, comment, requestid string) error {
+func (c *HTTPClient) CreateDatapointWithDaystamp(ctx context.Context, goalSlug, timestamp, daystamp, value, comment, requestid string) error {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/datapoints.json",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug))
 
@@ -147,14 +166,11 @@ func (c *HTTPClient) CreateDatapointWithDaystamp(goalSlug, timestamp, daystamp, 
 		data.Set("requestid", requestid)
 	}
 
-	LogRequest(c.config, "POST", apiURL)
-	resp, err := c.http.Post(apiURL, "application/x-www-form-urlencoded",
-		strings.NewReader(data.Encode()))
+	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
 	if err != nil {
 		return fmt.Errorf("failed to create datapoint: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API returned status %d", resp.StatusCode)
@@ -164,7 +180,7 @@ func (c *HTTPClient) CreateDatapointWithDaystamp(goalSlug, timestamp, daystamp, 
 }
 
 // CreateCharge creates a new charge for the authenticated user and returns it.
-func (c *HTTPClient) CreateCharge(amount float64, note string, dryrun bool) (*Charge, error) {
+func (c *HTTPClient) CreateCharge(ctx context.Context, amount float64, note string, dryrun bool) (*Charge, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/charges.json", c.baseURL())
 
 	data := url.Values{}
@@ -176,14 +192,11 @@ func (c *HTTPClient) CreateCharge(amount float64, note string, dryrun bool) (*Ch
 		data.Set("dryrun", "true")
 	}
 
-	LogRequest(c.config, "POST", apiURL)
-	resp, err := c.http.Post(apiURL, "application/x-www-form-urlencoded",
-		strings.NewReader(data.Encode()))
+	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create charge: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(resp.Body)
@@ -202,17 +215,15 @@ func (c *HTTPClient) CreateCharge(amount float64, note string, dryrun bool) (*Ch
 
 // CallUncle instantly derails a goal that is in the red (safebuf <= 0).
 // It charges the pledge amount and inserts the post-derail respite into the graph.
-func (c *HTTPClient) CallUncle(goalSlug string) (*Goal, error) {
+func (c *HTTPClient) CallUncle(ctx context.Context, goalSlug string) (*Goal, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/uncleme.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	LogRequest(c.config, "POST", apiURL)
-	resp, err := c.http.Post(apiURL, "application/x-www-form-urlencoded", strings.NewReader(""))
+	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(""), "application/x-www-form-urlencoded")
 	if err != nil {
 		return nil, fmt.Errorf("failed to call uncle: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
@@ -231,17 +242,15 @@ func (c *HTTPClient) CallUncle(goalSlug string) (*Goal, error) {
 }
 
 // FetchGoal fetches a single goal by slug.
-func (c *HTTPClient) FetchGoal(goalSlug string) (*Goal, error) {
+func (c *HTTPClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	LogRequest(c.config, "GET", apiURL)
-	resp, err := c.http.Get(apiURL)
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch goal: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("goal not found: %s", goalSlug)
@@ -260,17 +269,15 @@ func (c *HTTPClient) FetchGoal(goalSlug string) (*Goal, error) {
 }
 
 // FetchGoalWithDatapoints fetches goal details including recent datapoints.
-func (c *HTTPClient) FetchGoalWithDatapoints(goalSlug string) (*Goal, error) {
+func (c *HTTPClient) FetchGoalWithDatapoints(ctx context.Context, goalSlug string) (*Goal, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s&datapoints=true",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	LogRequest(c.config, "GET", apiURL)
-	resp, err := c.http.Get(apiURL)
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch goal details: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
@@ -286,7 +293,7 @@ func (c *HTTPClient) FetchGoalWithDatapoints(goalSlug string) (*Goal, error) {
 
 // FetchGoalRawJSON fetches a goal and returns the raw JSON response.
 // This preserves all fields from the API, not just the ones defined in the Goal struct.
-func (c *HTTPClient) FetchGoalRawJSON(goalSlug string, includeDatapoints bool) (json.RawMessage, error) {
+func (c *HTTPClient) FetchGoalRawJSON(ctx context.Context, goalSlug string, includeDatapoints bool) (json.RawMessage, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
@@ -294,13 +301,11 @@ func (c *HTTPClient) FetchGoalRawJSON(goalSlug string, includeDatapoints bool) (
 		apiURL += "&datapoints=true"
 	}
 
-	LogRequest(c.config, "GET", apiURL)
-	resp, err := c.http.Get(apiURL)
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch goal: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("goal not found: %s", goalSlug)
@@ -320,7 +325,7 @@ func (c *HTTPClient) FetchGoalRawJSON(goalSlug string, includeDatapoints bool) (
 
 // CreateGoal creates a new goal for the user.
 // Requires slug, title, goal_type, gunits, and exactly 2 of 3: goaldate, goalval, rate.
-func (c *HTTPClient) CreateGoal(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+func (c *HTTPClient) CreateGoal(ctx context.Context, slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals.json",
 		c.baseURL(), c.config.Username)
 
@@ -334,14 +339,11 @@ func (c *HTTPClient) CreateGoal(slug, title, goalType, gunits, goaldate, goalval
 	data.Set("goalval", goalval)
 	data.Set("rate", rate)
 
-	LogRequest(c.config, "POST", apiURL)
-	resp, err := c.http.Post(apiURL, "application/x-www-form-urlencoded",
-		strings.NewReader(data.Encode()))
+	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create goal: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
@@ -358,7 +360,7 @@ func (c *HTTPClient) CreateGoal(slug, title, goalType, gunits, goaldate, goalval
 // UpdateGoalDeadline updates the deadline (seconds from midnight) for a goal.
 // The deadline parameter is undocumented in the official API but is supported:
 // https://forum.beeminder.com/t/api-deadline/10666
-func (c *HTTPClient) UpdateGoalDeadline(goalSlug string, deadline int) (*Goal, error) {
+func (c *HTTPClient) UpdateGoalDeadline(ctx context.Context, goalSlug string, deadline int) (*Goal, error) {
 	escapedSlug := url.PathEscape(goalSlug)
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json",
 		c.baseURL(), c.config.Username, escapedSlug)
@@ -367,19 +369,11 @@ func (c *HTTPClient) UpdateGoalDeadline(goalSlug string, deadline int) (*Goal, e
 	data.Set("auth_token", c.config.AuthToken)
 	data.Set("deadline", fmt.Sprintf("%d", deadline))
 
-	req, err := http.NewRequest(http.MethodPut, apiURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	LogRequest(c.config, "PUT", apiURL)
-	resp, err := c.http.Do(req)
+	resp, err := c.doRequest(ctx, http.MethodPut, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
 	if err != nil {
 		return nil, fmt.Errorf("failed to update goal deadline: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(resp.Body)
@@ -399,17 +393,15 @@ func (c *HTTPClient) UpdateGoalDeadline(goalSlug string, deadline int) (*Goal, e
 
 // RefreshGoal forces a fetch of autodata and graph refresh for a goal.
 // Returns true if the goal was queued for refresh, false if not.
-func (c *HTTPClient) RefreshGoal(goalSlug string) (bool, error) {
+func (c *HTTPClient) RefreshGoal(ctx context.Context, goalSlug string) (bool, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/refresh_graph.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	LogRequest(c.config, "GET", apiURL)
-	resp, err := c.http.Get(apiURL)
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
 	if err != nil {
 		return false, fmt.Errorf("failed to refresh goal: %w", err)
 	}
 	defer resp.Body.Close()
-	LogResponse(c.config, resp.StatusCode, apiURL)
 
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("API returned status %d", resp.StatusCode)

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -16,11 +16,12 @@ import (
 // command tests and Bubble Tea handler tests can use it because everything is
 // in `package main`.
 //
-// The *Func signatures intentionally omit the context.Context argument —
-// every Client method takes one, but the value is rarely interesting to
-// assertion-side code. Tests that need to check cancellation/deadlines can
-// wrap a *Func that closes over the context, or use FakeClient.LastCtx
-// (currently unimplemented; add if a test needs it).
+// The *Func signatures intentionally omit context.Context — every Client
+// method takes one, but the fake drops it before invoking *Func, so the
+// callback can't observe it. Tests that need to assert
+// cancellation/deadline propagation should drive HTTPClient against
+// httptest (see TestHTTPClientCancellation) or extend this fake with an
+// explicit context-capture field when the need arises.
 type FakeClient struct {
 	FetchGoalsFunc                  func() ([]Goal, error)
 	FetchGoalFunc                   func(goalSlug string) (*Goal, error)

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -14,6 +15,12 @@ import (
 // Lives in a _test.go file so it never ships in the production binary; both
 // command tests and Bubble Tea handler tests can use it because everything is
 // in `package main`.
+//
+// The *Func signatures intentionally omit the context.Context argument —
+// every Client method takes one, but the value is rarely interesting to
+// assertion-side code. Tests that need to check cancellation/deadlines can
+// wrap a *Func that closes over the context, or use FakeClient.LastCtx
+// (currently unimplemented; add if a test needs it).
 type FakeClient struct {
 	FetchGoalsFunc                  func() ([]Goal, error)
 	FetchGoalFunc                   func(goalSlug string) (*Goal, error)
@@ -34,84 +41,84 @@ type FakeClient struct {
 // surface that rather than letting an unconfigured path succeed silently.
 var errFakeNotConfigured = errors.New("FakeClient method not configured for this test")
 
-func (c *FakeClient) FetchGoals() ([]Goal, error) {
+func (c *FakeClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 	if c.FetchGoalsFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.FetchGoalsFunc()
 }
 
-func (c *FakeClient) FetchGoal(goalSlug string) (*Goal, error) {
+func (c *FakeClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, error) {
 	if c.FetchGoalFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.FetchGoalFunc(goalSlug)
 }
 
-func (c *FakeClient) FetchGoalWithDatapoints(goalSlug string) (*Goal, error) {
+func (c *FakeClient) FetchGoalWithDatapoints(ctx context.Context, goalSlug string) (*Goal, error) {
 	if c.FetchGoalWithDatapointsFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.FetchGoalWithDatapointsFunc(goalSlug)
 }
 
-func (c *FakeClient) FetchGoalRawJSON(goalSlug string, includeDatapoints bool) (json.RawMessage, error) {
+func (c *FakeClient) FetchGoalRawJSON(ctx context.Context, goalSlug string, includeDatapoints bool) (json.RawMessage, error) {
 	if c.FetchGoalRawJSONFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.FetchGoalRawJSONFunc(goalSlug, includeDatapoints)
 }
 
-func (c *FakeClient) GetLastDatapointValue(goalSlug string) (float64, error) {
+func (c *FakeClient) GetLastDatapointValue(ctx context.Context, goalSlug string) (float64, error) {
 	if c.GetLastDatapointValueFunc == nil {
 		return 0, errFakeNotConfigured
 	}
 	return c.GetLastDatapointValueFunc(goalSlug)
 }
 
-func (c *FakeClient) CreateDatapoint(goalSlug, timestamp, value, comment, requestid string) error {
+func (c *FakeClient) CreateDatapoint(ctx context.Context, goalSlug, timestamp, value, comment, requestid string) error {
 	if c.CreateDatapointFunc == nil {
 		return errFakeNotConfigured
 	}
 	return c.CreateDatapointFunc(goalSlug, timestamp, value, comment, requestid)
 }
 
-func (c *FakeClient) CreateDatapointWithDaystamp(goalSlug, timestamp, daystamp, value, comment, requestid string) error {
+func (c *FakeClient) CreateDatapointWithDaystamp(ctx context.Context, goalSlug, timestamp, daystamp, value, comment, requestid string) error {
 	if c.CreateDatapointWithDaystampFunc == nil {
 		return errFakeNotConfigured
 	}
 	return c.CreateDatapointWithDaystampFunc(goalSlug, timestamp, daystamp, value, comment, requestid)
 }
 
-func (c *FakeClient) CreateCharge(amount float64, note string, dryrun bool) (*Charge, error) {
+func (c *FakeClient) CreateCharge(ctx context.Context, amount float64, note string, dryrun bool) (*Charge, error) {
 	if c.CreateChargeFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.CreateChargeFunc(amount, note, dryrun)
 }
 
-func (c *FakeClient) CreateGoal(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+func (c *FakeClient) CreateGoal(ctx context.Context, slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
 	if c.CreateGoalFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.CreateGoalFunc(slug, title, goalType, gunits, goaldate, goalval, rate)
 }
 
-func (c *FakeClient) CallUncle(goalSlug string) (*Goal, error) {
+func (c *FakeClient) CallUncle(ctx context.Context, goalSlug string) (*Goal, error) {
 	if c.CallUncleFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.CallUncleFunc(goalSlug)
 }
 
-func (c *FakeClient) UpdateGoalDeadline(goalSlug string, deadline int) (*Goal, error) {
+func (c *FakeClient) UpdateGoalDeadline(ctx context.Context, goalSlug string, deadline int) (*Goal, error) {
 	if c.UpdateGoalDeadlineFunc == nil {
 		return nil, errFakeNotConfigured
 	}
 	return c.UpdateGoalDeadlineFunc(goalSlug, deadline)
 }
 
-func (c *FakeClient) RefreshGoal(goalSlug string) (bool, error) {
+func (c *FakeClient) RefreshGoal(ctx context.Context, goalSlug string) (bool, error) {
 	if c.RefreshGoalFunc == nil {
 		return false, errFakeNotConfigured
 	}

--- a/deadline_cmd.go
+++ b/deadline_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -66,7 +67,7 @@ func handleDeadlineCommand() {
 		// confirmation prompt — with --yes set, the pre-fetch is just an
 		// extra API call that can fail before UpdateGoalDeadline gets a
 		// chance to run.
-		currentGoal, err := client.FetchGoal(goalSlug)
+		currentGoal, err := client.FetchGoal(context.Background(), goalSlug)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: Failed to fetch goal: %s\n", redactError(err))
 			os.Exit(1)
@@ -88,7 +89,7 @@ func handleDeadlineCommand() {
 		}
 	}
 
-	goal, err := client.UpdateGoalDeadline(goalSlug, offset)
+	goal, err := client.UpdateGoalDeadline(context.Background(), goalSlug, offset)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to update deadline: %s\n", redactError(err))
 		os.Exit(1)

--- a/filtered.go
+++ b/filtered.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -127,7 +128,7 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 	client := NewHTTPClient(config)
 
 	// Fetch goals
-	goals, err := client.FetchGoals()
+	goals, err := client.FetchGoals(context.Background())
 	if err != nil {
 		fmt.Printf("Error: Failed to fetch goals: %s\n", redactError(err))
 		os.Exit(1)

--- a/handlers.go
+++ b/handlers.go
@@ -297,7 +297,7 @@ func handleAddDatapoint(m model) (tea.Model, tea.Cmd) {
 		m.appModel.inputComment = "Added via buzz"
 
 		// Try to get the last datapoint value, default to "1" if it fails
-		if lastValue, err := m.appModel.client.GetLastDatapointValue(m.appModel.modalGoal.Slug); err == nil && lastValue != 0 {
+		if lastValue, err := m.appModel.client.GetLastDatapointValue(m.appModel.ctx, m.appModel.modalGoal.Slug); err == nil && lastValue != 0 {
 			m.appModel.inputValue = fmt.Sprintf("%.1f", lastValue)
 		} else {
 			m.appModel.inputValue = "1"
@@ -500,7 +500,7 @@ func handleEnterKey(m model) (tea.Model, tea.Cmd) {
 
 		// Set creating state and submit goal creation asynchronously
 		m.appModel.creatingGoal = true
-		return m, createGoalCmd(m.appModel.client, m.appModel.createSlug, m.appModel.createTitle,
+		return m, createGoalCmd(m.appModel.ctx, m.appModel.client, m.appModel.createSlug, m.appModel.createTitle,
 			m.appModel.createGoalType, m.appModel.createGunits, m.appModel.createGoaldate,
 			m.appModel.createGoalval, m.appModel.createRate)
 	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.submitting {
@@ -519,7 +519,7 @@ func handleEnterKey(m model) (tea.Model, tea.Cmd) {
 
 		// Set submitting state and submit datapoint asynchronously
 		m.appModel.submitting = true
-		return m, submitDatapointCmd(m.appModel.client, m.appModel.modalGoal.Slug,
+		return m, submitDatapointCmd(m.appModel.ctx, m.appModel.client, m.appModel.modalGoal.Slug,
 			timestamp, m.appModel.inputValue, m.appModel.inputComment)
 	} else if !m.appModel.showModal {
 		// Show goal details modal (existing functionality)
@@ -538,7 +538,7 @@ func handleEnterKey(m model) (tea.Model, tea.Cmd) {
 			}
 
 			// Load detailed goal information including datapoints
-			return m, loadGoalDetailsCmd(m.appModel.client, m.appModel.modalGoal.Slug)
+			return m, loadGoalDetailsCmd(m.appModel.ctx, m.appModel.client, m.appModel.modalGoal.Slug)
 		}
 	}
 	return m, nil
@@ -592,7 +592,7 @@ func handleNavigationLeft(m model) (tea.Model, tea.Cmd) {
 			m.appModel.cursor--
 			m.appModel.modalGoal = &m.appModel.goals[m.appModel.cursor]
 			// Load detailed goal information including datapoints
-			return m, loadGoalDetailsCmd(m.appModel.client, m.appModel.modalGoal.Slug)
+			return m, loadGoalDetailsCmd(m.appModel.ctx, m.appModel.client, m.appModel.modalGoal.Slug)
 		}
 	} else if !m.appModel.showModal && !m.appModel.showCreateModal {
 		displayGoals := m.appModel.getDisplayGoals()
@@ -620,7 +620,7 @@ func handleNavigationRight(m model) (tea.Model, tea.Cmd) {
 			m.appModel.cursor++
 			m.appModel.modalGoal = &m.appModel.goals[m.appModel.cursor]
 			// Load detailed goal information including datapoints
-			return m, loadGoalDetailsCmd(m.appModel.client, m.appModel.modalGoal.Slug)
+			return m, loadGoalDetailsCmd(m.appModel.ctx, m.appModel.client, m.appModel.modalGoal.Slug)
 		}
 	} else if !m.appModel.showModal && !m.appModel.showCreateModal {
 		displayGoals := m.appModel.getDisplayGoals()
@@ -666,7 +666,7 @@ func handleScrollDown(m model) (tea.Model, tea.Cmd) {
 func handleRefresh(m model) (tea.Model, tea.Cmd) {
 	if !m.appModel.showModal && !m.appModel.showCreateModal {
 		m.appModel.loading = true
-		return m, loadGoalsCmd(m.appModel.client)
+		return m, loadGoalsCmd(m.appModel.ctx, m.appModel.client)
 	}
 	return m, nil
 }

--- a/list.go
+++ b/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 )
@@ -22,7 +23,7 @@ func handleListCommand() {
 	client := NewHTTPClient(config)
 
 	// Fetch goals
-	goals, err := client.FetchGoals()
+	goals, err := client.FetchGoals(context.Background())
 	if err != nil {
 		fmt.Printf("Error: Failed to fetch goals: %s\n", redactError(err))
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -177,7 +178,7 @@ func loadConfigAndGoals() (*Config, Client, []Goal, error) {
 	}
 
 	client := NewHTTPClient(config)
-	goals, err := client.FetchGoals()
+	goals, err := client.FetchGoals(context.Background())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to fetch goals: %w", err)
 	}

--- a/messages.go
+++ b/messages.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -41,10 +42,15 @@ type checkRefreshFlagMsg struct{}
 // navigationTimeoutMsg is sent when navigation highlight should be auto-disabled
 type navigationTimeoutMsg struct{}
 
-// loadGoalsCmd fetches goals from Beeminder API
-func loadGoalsCmd(client Client) tea.Cmd {
+// loadGoalsCmd fetches goals from Beeminder API.
+//
+// The ctx is captured into the returned Cmd so cancellation from the caller
+// propagates through to the in-flight HTTP request. Today the only ctx
+// callers pass is the appModel's ctx (currently context.Background); future
+// quit-cancellation wiring will turn that into a cancellable parent.
+func loadGoalsCmd(ctx context.Context, client Client) tea.Cmd {
 	return func() tea.Msg {
-		goals, err := client.FetchGoals()
+		goals, err := client.FetchGoals(ctx)
 		if err != nil {
 			return goalsLoadedMsg{err: err}
 		}
@@ -61,25 +67,25 @@ func refreshTickCmd() tea.Cmd {
 }
 
 // submitDatapointCmd submits a datapoint to Beeminder API
-func submitDatapointCmd(client Client, goalSlug, timestamp, value, comment string) tea.Cmd {
+func submitDatapointCmd(ctx context.Context, client Client, goalSlug, timestamp, value, comment string) tea.Cmd {
 	return func() tea.Msg {
-		err := client.CreateDatapoint(goalSlug, timestamp, value, comment, "")
+		err := client.CreateDatapoint(ctx, goalSlug, timestamp, value, comment, "")
 		return datapointSubmittedMsg{err: err}
 	}
 }
 
 // loadGoalDetailsCmd fetches detailed goal information including datapoints
-func loadGoalDetailsCmd(client Client, goalSlug string) tea.Cmd {
+func loadGoalDetailsCmd(ctx context.Context, client Client, goalSlug string) tea.Cmd {
 	return func() tea.Msg {
-		goal, err := client.FetchGoalWithDatapoints(goalSlug)
+		goal, err := client.FetchGoalWithDatapoints(ctx, goalSlug)
 		return goalDetailsLoadedMsg{goal: goal, err: err}
 	}
 }
 
 // createGoalCmd submits a new goal to Beeminder API
-func createGoalCmd(client Client, slug, title, goalType, gunits, goaldate, goalval, rate string) tea.Cmd {
+func createGoalCmd(ctx context.Context, client Client, slug, title, goalType, gunits, goaldate, goalval, rate string) tea.Cmd {
 	return func() tea.Msg {
-		goal, err := client.CreateGoal(slug, title, goalType, gunits, goaldate, goalval, rate)
+		goal, err := client.CreateGoal(ctx, slug, title, goalType, gunits, goaldate, goalval, rate)
 		return goalCreatedMsg{goal: goal, err: err}
 	}
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -20,7 +21,7 @@ func TestLoadGoalsCmdSuccess(t *testing.T) {
 		},
 	}
 
-	msg, ok := loadGoalsCmd(fake)().(goalsLoadedMsg)
+	msg, ok := loadGoalsCmd(context.Background(), fake)().(goalsLoadedMsg)
 	if !ok {
 		t.Fatalf("loadGoalsCmd produced %T, want goalsLoadedMsg", msg)
 	}
@@ -41,7 +42,7 @@ func TestLoadGoalsCmdError(t *testing.T) {
 		FetchGoalsFunc: func() ([]Goal, error) { return nil, wantErr },
 	}
 
-	msg, ok := loadGoalsCmd(fake)().(goalsLoadedMsg)
+	msg, ok := loadGoalsCmd(context.Background(), fake)().(goalsLoadedMsg)
 	if !ok {
 		t.Fatalf("loadGoalsCmd produced %T, want goalsLoadedMsg", msg)
 	}
@@ -65,7 +66,7 @@ func TestSubmitDatapointCmdPassesArgs(t *testing.T) {
 		},
 	}
 
-	msg, ok := submitDatapointCmd(fake, "exercise", "1700000000", "1.5", "morning run")().(datapointSubmittedMsg)
+	msg, ok := submitDatapointCmd(context.Background(), fake, "exercise", "1700000000", "1.5", "morning run")().(datapointSubmittedMsg)
 	if !ok {
 		t.Fatalf("submitDatapointCmd produced %T, want datapointSubmittedMsg", msg)
 	}
@@ -87,7 +88,7 @@ func TestSubmitDatapointCmdError(t *testing.T) {
 		CreateDatapointFunc: func(_, _, _, _, _ string) error { return wantErr },
 	}
 
-	msg := submitDatapointCmd(fake, "any", "0", "1", "")().(datapointSubmittedMsg)
+	msg := submitDatapointCmd(context.Background(), fake, "any", "0", "1", "")().(datapointSubmittedMsg)
 	if !errors.Is(msg.err, wantErr) {
 		t.Errorf("submitDatapointCmd err = %v, want %v", msg.err, wantErr)
 	}
@@ -106,7 +107,7 @@ func TestLoadGoalDetailsCmdPassesSlug(t *testing.T) {
 		},
 	}
 
-	msg := loadGoalDetailsCmd(fake, "x")().(goalDetailsLoadedMsg)
+	msg := loadGoalDetailsCmd(context.Background(), fake, "x")().(goalDetailsLoadedMsg)
 	if gotSlug != "x" {
 		t.Errorf("client called with slug=%q, want x", gotSlug)
 	}
@@ -124,7 +125,7 @@ func TestLoadGoalDetailsCmdError(t *testing.T) {
 		FetchGoalWithDatapointsFunc: func(string) (*Goal, error) { return nil, wantErr },
 	}
 
-	msg := loadGoalDetailsCmd(fake, "missing")().(goalDetailsLoadedMsg)
+	msg := loadGoalDetailsCmd(context.Background(), fake, "missing")().(goalDetailsLoadedMsg)
 	if !errors.Is(msg.err, wantErr) {
 		t.Errorf("loadGoalDetailsCmd err = %v, want %v", msg.err, wantErr)
 	}
@@ -153,7 +154,7 @@ func TestCreateGoalCmdPassesArgs(t *testing.T) {
 		},
 	}
 
-	msg := createGoalCmd(fake, "newg", "New Goal", "hustler", "pages", "20260101", "null", "5")().(goalCreatedMsg)
+	msg := createGoalCmd(context.Background(), fake, "newg", "New Goal", "hustler", "pages", "20260101", "null", "5")().(goalCreatedMsg)
 	if msg.goal != wantGoal {
 		t.Errorf("createGoalCmd goal = %v, want %v", msg.goal, wantGoal)
 	}
@@ -173,7 +174,7 @@ func TestCreateGoalCmdError(t *testing.T) {
 		CreateGoalFunc: func(_, _, _, _, _, _, _ string) (*Goal, error) { return nil, wantErr },
 	}
 
-	msg := createGoalCmd(fake, "dup", "", "", "", "", "", "")().(goalCreatedMsg)
+	msg := createGoalCmd(context.Background(), fake, "dup", "", "", "", "", "", "")().(goalCreatedMsg)
 	if !errors.Is(msg.err, wantErr) {
 		t.Errorf("createGoalCmd err = %v, want %v", msg.err, wantErr)
 	}

--- a/model.go
+++ b/model.go
@@ -1,23 +1,27 @@
 package main
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // appModel is the main application model (previously just "model")
 type appModel struct {
-	goals              []Goal    // Beeminder goals
-	cursor             int       // which goal our cursor is pointing at
-	config             *Config   // Beeminder credentials (kept for openBrowser URL building)
-	client             Client    // Beeminder API client
-	loading            bool      // whether we're loading goals
-	err                error     // error from loading goals
-	width              int       // terminal width
-	height             int       // terminal height
-	scrollRow          int       // current scroll position (in rows)
-	refreshActive      bool      // whether auto-refresh is active
-	showModal          bool      // whether to show goal details modal
-	modalGoal          *Goal     // the goal to show in modal
-	hasNavigated       bool      // whether user has used arrow keys
-	lastNavigationTime time.Time // last time user navigated with arrow keys
+	goals              []Goal          // Beeminder goals
+	cursor             int             // which goal our cursor is pointing at
+	config             *Config         // Beeminder credentials (kept for openBrowser URL building)
+	client             Client          // Beeminder API client
+	ctx                context.Context // long-lived context passed to every Client call; today context.Background, future quit-cancellation wiring will replace it with a cancellable parent
+	loading            bool            // whether we're loading goals
+	err                error           // error from loading goals
+	width              int             // terminal width
+	height             int             // terminal height
+	scrollRow          int             // current scroll position (in rows)
+	refreshActive      bool            // whether auto-refresh is active
+	showModal          bool            // whether to show goal details modal
+	modalGoal          *Goal           // the goal to show in modal
+	hasNavigated       bool            // whether user has used arrow keys
+	lastNavigationTime time.Time       // last time user navigated with arrow keys
 
 	// Modal input fields
 	inputDate    string // date input (YYYY-MM-DD format)
@@ -61,6 +65,7 @@ func initialAppModel(config *Config) appModel {
 		goals:         []Goal{},
 		config:        config,
 		client:        NewHTTPClient(config),
+		ctx:           context.Background(),
 		loading:       true,
 		refreshActive: true,
 		searchMode:    false,

--- a/refresh.go
+++ b/refresh.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 )
@@ -35,7 +36,7 @@ func handleRefreshCommand() {
 	client := NewHTTPClient(config)
 
 	// Refresh the goal
-	queued, err := client.RefreshGoal(goalSlug)
+	queued, err := client.RefreshGoal(context.Background(), goalSlug)
 	if err != nil {
 		fmt.Printf("Error: Failed to refresh goal: %s\n", redactError(err))
 		os.Exit(1)

--- a/review.go
+++ b/review.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -29,7 +30,7 @@ func handleReviewCommand() {
 	client := NewHTTPClient(config)
 
 	// Fetch goals
-	goals, err := client.FetchGoals()
+	goals, err := client.FetchGoals(context.Background())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to fetch goals: %s\n", redactError(err))
 		os.Exit(1)

--- a/tui.go
+++ b/tui.go
@@ -22,7 +22,7 @@ func (m model) Init() tea.Cmd {
 	}
 	// In app state, load goals and start refresh timer
 	return tea.Batch(
-		loadGoalsCmd(m.appModel.client),
+		loadGoalsCmd(m.appModel.ctx, m.appModel.client),
 		refreshTickCmd(),
 		checkRefreshFlagCmd(),
 	)
@@ -55,7 +55,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appModel.width = m.width
 			m.appModel.height = m.height
 			return m, tea.Batch(
-				loadGoalsCmd(m.appModel.client),
+				loadGoalsCmd(m.appModel.ctx, m.appModel.client),
 				refreshTickCmd(),
 				checkRefreshFlagCmd(),
 			)
@@ -95,7 +95,7 @@ func (m model) updateApp(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Time to refresh data
 		if m.appModel.refreshActive {
 			return m, tea.Batch(
-				loadGoalsCmd(m.appModel.client),
+				loadGoalsCmd(m.appModel.ctx, m.appModel.client),
 				refreshTickCmd(), // Schedule the next refresh
 			)
 		}
@@ -112,7 +112,7 @@ func (m model) updateApp(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appModel.inputFocus = 0
 			m.appModel.inputError = ""
 			// Don't set loading = true here to avoid the full-app loading state
-			return m, loadGoalsCmd(m.appModel.client)
+			return m, loadGoalsCmd(m.appModel.ctx, m.appModel.client)
 		}
 		return m, nil
 
@@ -139,7 +139,7 @@ func (m model) updateApp(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Success - close modal and refresh goals
 			m.appModel.showCreateModal = false
 			m.appModel.createError = ""
-			return m, loadGoalsCmd(m.appModel.client)
+			return m, loadGoalsCmd(m.appModel.ctx, m.appModel.client)
 		}
 		return m, nil
 
@@ -150,7 +150,7 @@ func (m model) updateApp(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// New refresh event detected - update our last processed timestamp
 			m.lastRefreshTimestamp = flagTimestamp
 			return m, tea.Batch(
-				loadGoalsCmd(m.appModel.client),
+				loadGoalsCmd(m.appModel.ctx, m.appModel.client),
 				checkRefreshFlagCmd(), // Schedule next check
 			)
 		}

--- a/uncle.go
+++ b/uncle.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -70,7 +71,7 @@ func handleUncleCommand() {
 		}
 	}
 
-	goal, err := client.CallUncle(goalSlug)
+	goal, err := client.CallUncle(context.Background(), goalSlug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to call uncle: %s\n", redactError(err))
 		os.Exit(1)

--- a/view.go
+++ b/view.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -86,7 +87,7 @@ func handleViewCommand() {
 
 	// If --json flag is present, fetch and output raw JSON
 	if jsonFlag {
-		rawJSON, err := client.FetchGoalRawJSON(goalSlug, datapointsFlag)
+		rawJSON, err := client.FetchGoalRawJSON(context.Background(), goalSlug, datapointsFlag)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
 			os.Exit(1)
@@ -108,7 +109,7 @@ func handleViewCommand() {
 	}
 
 	// Fetch the goal for human-readable output
-	goal, err := client.FetchGoal(goalSlug)
+	goal, err := client.FetchGoal(context.Background(), goalSlug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
 		os.Exit(1)


### PR DESCRIPTION
Closes #253.

## Summary

Every `Client` method now takes a `context.Context` as its first parameter. `HTTPClient` builds requests via `http.NewRequestWithContext` + `c.http.Do` so context cancellation propagates into the in-flight HTTP request. Follows the same pattern as PR #251 — **establish the seam without changing runtime behaviour**, leaving the cancellation source as a follow-up.

## What changed

- **`Client` interface**: 12 methods grow a `ctx context.Context` first arg.
- **`HTTPClient`**: introduces a `doRequest` helper that wraps `NewRequestWithContext` + `c.http.Do` + `LogRequest` / `LogResponse`, so each method body stays close to its previous shape (the per-method status-code interpretation and body decoding logic is preserved verbatim).
- **`appModel`**: gains a `ctx context.Context` field (today `context.Background`) that Cmd factories thread into client calls.
- **Bubble Tea Cmd factories** (`loadGoalsCmd`, `submitDatapointCmd`, `loadGoalDetailsCmd`, `createGoalCmd`): take `ctx` as first arg, pass it to the client.
- **CLI handlers** in `main.go` and the per-command files: pass `context.Background()` at call sites.
- **`FakeClient`** (test helper): matching signatures; the `*Func` test-side fields keep the pre-ctx shape (the ctx value is rarely interesting to assertions, but tests that need it can wrap a closure).
- **Tests**: pass `context.Background()` throughout.

## What's deferred

- **Actual quit-cancellation wiring** — the TUI `ctx` is currently `context.Background`. Cancelling it when the user quits (or the modal closes mid-fetch) will be a follow-up. I'll open an issue for it after this merges.
- **Per-CLI-command timeouts** — the 30s `http.Client.Timeout` (added in PR #251) still bounds every request. Per-call deadlines via `context.WithTimeout` can come later if/when latency expectations diverge per command.

## New test

**`TestHTTPClientCancellation`** spins up an `httptest` server that blocks until the test releases it, cancels the parent context while a `FetchGoals` call is in flight, and asserts the returned error wraps `context.Canceled`. Verifies the wiring end-to-end.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./...` — pre-existing `TestExtractTimeSlots*` timezone failures unchanged; new `TestHTTPClientCancellation` passes; all 25 existing `httptest`-based tests still pass with `context.Background()` plumbed through
- [x] Local `coderabbit review --agent` returns zero findings

## Diff stats

```
18 files changed, +229 / -169
```

- 12 method signatures on `Client` + `HTTPClient` (consolidated via the new `doRequest` helper — fewer lines per method than before)
- 1 new field on `appModel`
- ~20 ctx-arg threading sites across `main.go`, the per-command files, `handlers.go`, `tui.go`, and `messages.go`
- ~25 ctx-arg threading sites across `beeminder_test.go`
- 1 new test (`TestHTTPClientCancellation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app and CLI to propagate request contexts so network operations respect cancellation and timeouts, improving reliability of goal fetches, datapoint submissions, charges, and refreshes across the UI and commands.
* **Tests**
  * Added a cancellation test to ensure interrupted requests return the expected cancellation error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/262)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->