### PR TITLE
fix: render completed goals as COMPLETE, not OVERDUE

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -61,6 +61,21 @@ type Charge struct {
 	Username string  `json:"username"`
 }
 
+// filterOutEndValueReached returns a new slice containing only goals whose
+// end value has not yet been reached. Used by views that surface "next/most
+// urgent" goals so completed goals (which can show a negative baremin and a
+// past losedate) don't crowd out goals that still need attention.
+func filterOutEndValueReached(goals []Goal) []Goal {
+	out := make([]Goal, 0, len(goals))
+	for _, g := range goals {
+		if IsEndValueReached(g) {
+			continue
+		}
+		out = append(out, g)
+	}
+	return out
+}
+
 // SortGoals sorts goals by: 1. Due ascending, 2. Stakes descending, 3. Name ascending
 func SortGoals(goals []Goal) {
 	sort.Slice(goals, func(i, j int) bool {

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -943,6 +943,76 @@ func TestIsEndValueReached(t *testing.T) {
 	}
 }
 
+// TestFilterOutEndValueReached verifies that goals whose end value has been
+// reached are dropped, while goals still requiring work are kept in order.
+func TestFilterOutEndValueReached(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	goals := []Goal{
+		{Slug: "active", Dir: 1, Curval: f(50), Goalval: f(100)},
+		{Slug: "done", Dir: 1, Curval: f(100), Goalval: f(100)},
+		{Slug: "weight-done", Dir: -1, Curval: f(150), Goalval: f(150)},
+		{Slug: "weight-active", Dir: -1, Curval: f(180), Goalval: f(150)},
+	}
+
+	got := filterOutEndValueReached(goals)
+	if len(got) != 2 {
+		t.Fatalf("filterOutEndValueReached returned %d goals, want 2", len(got))
+	}
+	if got[0].Slug != "active" || got[1].Slug != "weight-active" {
+		t.Errorf("filterOutEndValueReached returned unexpected order: %q, %q", got[0].Slug, got[1].Slug)
+	}
+}
+
+// TestFormatGoalDueDateAt verifies that goals which have reached their end
+// value render as "COMPLETE" regardless of how far past their losedate is,
+// while still-active goals fall through to the normal losedate-based render.
+func TestFormatGoalDueDateAt(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-3 * 24 * time.Hour).Unix()
+	future := now.Add(5 * time.Hour).Unix()
+
+	tests := []struct {
+		name     string
+		goal     Goal
+		expected string
+	}{
+		{
+			name:     "end value reached with past losedate renders COMPLETE not OVERDUE",
+			goal:     Goal{Losedate: past, Dir: 1, Curval: f(100), Goalval: f(100)},
+			expected: "COMPLETE",
+		},
+		{
+			name:     "end value reached with future losedate still renders COMPLETE",
+			goal:     Goal{Losedate: future, Dir: 1, Curval: f(120), Goalval: f(100)},
+			expected: "COMPLETE",
+		},
+		{
+			name:     "active goal with past losedate still renders OVERDUE",
+			goal:     Goal{Losedate: past, Dir: 1, Curval: f(50), Goalval: f(100)},
+			expected: "OVERDUE",
+		},
+		{
+			name:     "active goal with future losedate renders timeframe",
+			goal:     Goal{Losedate: future, Dir: 1, Curval: f(50), Goalval: f(100)},
+			expected: "5h",
+		},
+		{
+			name:     "do-less goal at cap is not COMPLETE (cap, not endpoint)",
+			goal:     Goal{GoalType: "drinker", Losedate: past, Dir: 1, Curval: f(120), Goalval: f(100)},
+			expected: "OVERDUE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatGoalDueDateAt(tt.goal, now); got != tt.expected {
+				t.Errorf("FormatGoalDueDateAt = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestFetchGoalWithMockServer tests FetchGoal function with a mock HTTP server
 func TestFetchGoalWithMockServer(t *testing.T) {
 	// Test case 1: successful fetch

--- a/deadline.go
+++ b/deadline.go
@@ -123,6 +123,21 @@ func FormatDueDate(losedate int64) string {
 	return FormatDueDateAt(losedate, time.Now())
 }
 
+// FormatGoalDueDate is like FormatDueDate but takes a Goal so it can render
+// "COMPLETE" for goals that have reached their end value, instead of the
+// misleading "OVERDUE" indicator a past losedate would otherwise produce.
+func FormatGoalDueDate(g Goal) string {
+	return FormatGoalDueDateAt(g, time.Now())
+}
+
+// FormatGoalDueDateAt is the deterministic-time variant of FormatGoalDueDate.
+func FormatGoalDueDateAt(g Goal, now time.Time) string {
+	if IsEndValueReached(g) {
+		return "COMPLETE"
+	}
+	return FormatDueDateAt(g.Losedate, now)
+}
+
 // FormatDueDateAt formats the losedate timestamp relative to a given time
 func FormatDueDateAt(losedate int64, now time.Time) string {
 	t := time.Unix(losedate, 0)

--- a/filtered.go
+++ b/filtered.go
@@ -163,7 +163,12 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 		Columns: []Column{
 			{Cell: func(g Goal) string { return g.Slug }},
 			{Cell: func(g Goal) string { return bareminFor(g) }},
-			{Cell: func(g Goal) string { return FormatDueDate(losedateFor(g)) }},
+			{Cell: func(g Goal) string {
+				if IsEndValueReached(g) {
+					return "COMPLETE"
+				}
+				return FormatDueDate(losedateFor(g))
+			}},
 			{Cell: func(g Goal) string { return FormatAbsoluteDeadline(losedateFor(g)) }},
 		},
 	}

--- a/grid.go
+++ b/grid.go
@@ -63,7 +63,7 @@ func RenderGrid(goals []Goal, width, height, scrollRow, cursor int, hasNavigated
 			// Format goal display
 			deltaValue := ParseBareminValue(goal.Baremin)
 			firstLine := formatGoalFirstLine(goal.Slug, goal.Pledge, goal.PledgeCap)
-			secondLine := formatGoalSecondLine(deltaValue, FormatDueDate(goal.Losedate))
+			secondLine := formatGoalSecondLine(deltaValue, FormatGoalDueDate(goal))
 			display := fmt.Sprintf("%s\n%s", firstLine, secondLine)
 
 			cell := style.Render(display)
@@ -142,7 +142,7 @@ func RenderModal(goal *Goal, width, height int, inputDate, inputValue, inputComm
 		goal.Title,
 		pledgeDisplay,
 		goal.Safebuf,
-		FormatDueDate(goal.Losedate),
+		FormatGoalDueDate(*goal),
 		UrgencyFor(goal.Safebuf))
 
 	// Add recent datapoints if available

--- a/next.go
+++ b/next.go
@@ -54,6 +54,11 @@ func displayNextGoal() error {
 		return err
 	}
 
+	// Skip goals that have already reached their end value — they have no
+	// remaining work, so surfacing them as "next" would mislead the user into
+	// acting on a completed goal.
+	goals = filterOutEndValueReached(goals)
+
 	// If no goals, return error
 	if len(goals) == 0 {
 		return fmt.Errorf("no goals found")
@@ -63,7 +68,7 @@ func displayNextGoal() error {
 	nextGoal := goals[0]
 
 	// Format the output: "goalslug baremin timeframe"
-	timeframe := FormatDueDate(nextGoal.Losedate)
+	timeframe := FormatGoalDueDate(nextGoal)
 
 	// Output the terse summary
 	fmt.Printf("%s %s %s\n", nextGoal.Slug, nextGoal.Baremin, timeframe)


### PR DESCRIPTION
## Summary
- `buzz next` was surfacing goals whose end value had already been reached as the most urgent goal, labelled OVERDUE — their losedate stays in the past even though there's no work left to do.
- `buzz next` now filters those goals out before picking the next-most-urgent goal.
- Every view that rendered "OVERDUE" via the losedate (next, all/today/tomorrow/due/less, TUI grid, modal) now renders "COMPLETE" for end-value-reached goals instead.
- Do-less goals are unaffected: their goalval is a cap, not an endpoint, so reaching it is a problem state that should keep being flagged.

## Test plan
- [x] `go test -run "TestFilterOutEndValueReached|TestFormatGoalDueDateAt|TestIsEndValueReached|TestFormatDueDate|TestDueFiltersSkipEndValueReached" ./...` passes
- [x] `go vet ./...` clean
- [ ] Manually verify `buzz next` against an account that has a completed goal with a past losedate
- [ ] Manually verify `buzz all` shows COMPLETE (not OVERDUE) for the same goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)