### PR TITLE
feat(auth): add `buzz auth login` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ go install github.com/pinepeakdigital/buzz@latest
 
 ## Authentication
 
-On first run, you'll be prompted to authenticate with Beeminder:
+The first time you launch the interactive TUI (`buzz` with no arguments), you'll be prompted to authenticate with Beeminder. You can also authenticate explicitly at any time with `buzz auth login`, which is what the other subcommands (`buzz today`, `buzz next`, etc.) will point you to if no credentials are found.
+
+Either way, the steps are the same:
 
 1. Visit https://www.beeminder.com/api/v1/auth_token.json to get your credentials
 2. Copy the JSON output (format: `{"username":"your_username","auth_token":"your_token"}`)
-3. Paste it into the application when prompted
+3. Paste it in when prompted
 4. Press Enter to save
 
-Your credentials will be stored securely in `~/.buzzrc` with read/write permissions for your user only.
+Credentials are read interactively (not as command-line arguments), so your auth token stays out of your shell history. They're stored in `~/.buzzrc` with read/write permissions for your user only.
 
 ## Configuration
 
@@ -379,6 +381,14 @@ This launches an interactive interface that displays one goal at a time, allowin
   - **Quit:** `q` or `Esc`
 - See your progress through the list with a goal counter (e.g., "Goal 1 of 10")
 - Goals are color-coded based on urgency (same as the main TUI)
+
+**buzz auth login** - Authenticate with Beeminder:
+
+```bash
+buzz auth login
+```
+
+Prompts you to paste your Beeminder API credentials (read interactively from stdin, so your token stays out of shell history) and saves them to `~/.buzzrc`. The interactive TUI auto-prompts for these on first run, so you typically only need this command to re-authenticate or when a subcommand reports that no configuration was found. See [Authentication](#authentication) for the credential format. Piped input (`buzz auth login < creds.json`) is also supported for scripting.
 
 Running `buzz` without arguments launches the interactive TUI.
 

--- a/add.go
+++ b/add.go
@@ -93,7 +93,7 @@ func handleAddCommand() {
 
 	// Load config
 	if !ConfigExists() {
-		fmt.Println("Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -3,10 +3,38 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// parseAndSaveCredentials parses a JSON Beeminder credentials blob, validates
+// that the required fields are present, and persists it to the config file. It
+// is shared by the interactive TUI auth screen and the `buzz auth login`
+// command so both accept identical input and report identical errors.
+func parseAndSaveCredentials(input string) (*Config, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, fmt.Errorf("please enter your credentials")
+	}
+
+	var config Config
+	if err := json.Unmarshal([]byte(input), &config); err != nil {
+		return nil, fmt.Errorf("invalid JSON format: %v", err)
+	}
+
+	// Validate that required fields are present
+	if config.Username == "" || config.AuthToken == "" {
+		return nil, fmt.Errorf("username and auth_token are required")
+	}
+
+	if err := SaveConfig(&config); err != nil {
+		return nil, fmt.Errorf("failed to save config: %v", err)
+	}
+
+	return &config, nil
+}
 
 type authModel struct {
 	textInput textinput.Model
@@ -48,30 +76,9 @@ func (m authModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "enter":
 			// Try to parse and save the credentials
-			input := m.textInput.Value()
-			if input == "" {
-				m.err = fmt.Errorf("please enter your credentials")
-				m.textInput.SetValue("")
-				return m, nil
-			}
-
-			var config Config
-			if err := json.Unmarshal([]byte(input), &config); err != nil {
-				m.err = fmt.Errorf("invalid JSON format: %v", err)
-				m.textInput.SetValue("")
-				return m, nil
-			}
-
-			// Validate that required fields are present
-			if config.Username == "" || config.AuthToken == "" {
-				m.err = fmt.Errorf("username and auth_token are required")
-				m.textInput.SetValue("")
-				return m, nil
-			}
-
-			// Save the config
-			if err := SaveConfig(&config); err != nil {
-				m.err = fmt.Errorf("failed to save config: %v", err)
+			config, err := parseAndSaveCredentials(m.textInput.Value())
+			if err != nil {
+				m.err = err
 				m.textInput.SetValue("")
 				return m, nil
 			}
@@ -79,7 +86,7 @@ func (m authModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Signal success
 			m.success = true
 			return m, func() tea.Msg {
-				return authSuccessMsg{config: &config}
+				return authSuccessMsg{config: config}
 			}
 		}
 	}

--- a/auth.go
+++ b/auth.go
@@ -21,16 +21,21 @@ func parseAndSaveCredentials(input string) (*Config, error) {
 
 	var config Config
 	if err := json.Unmarshal([]byte(input), &config); err != nil {
-		return nil, fmt.Errorf("invalid JSON format: %v", err)
+		return nil, fmt.Errorf("invalid JSON format: %w", err)
 	}
 
-	// Validate that required fields are present
+	// Validate that required fields are present. Trim first so whitespace-only
+	// values (e.g. "username":"   ") are rejected rather than persisted, and
+	// store the trimmed values so stray surrounding whitespace never reaches
+	// the API.
+	config.Username = strings.TrimSpace(config.Username)
+	config.AuthToken = strings.TrimSpace(config.AuthToken)
 	if config.Username == "" || config.AuthToken == "" {
 		return nil, fmt.Errorf("username and auth_token are required")
 	}
 
 	if err := SaveConfig(&config); err != nil {
-		return nil, fmt.Errorf("failed to save config: %v", err)
+		return nil, fmt.Errorf("failed to save config: %w", err)
 	}
 
 	return &config, nil

--- a/auth_cmd.go
+++ b/auth_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -47,14 +48,29 @@ func handleAuthLoginCommand() {
 	fmt.Println(`Format: {"username":"your_username","auth_token":"your_token"}`)
 	fmt.Print("> ")
 
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	// ReadString returns io.EOF along with any data read before the stream
-	// ended (e.g. piped input with no trailing newline). Only treat it as a
-	// failure when nothing was read at all.
-	if err != nil && input == "" {
-		fmt.Fprintf(os.Stderr, "Error: failed to read credentials: %s\n", err)
-		os.Exit(1)
+	// When stdin is piped (not a terminal), read the whole stream so
+	// pretty-printed/multiline JSON survives intact. For an interactive
+	// terminal, read a single line so the prompt returns as soon as the user
+	// pastes their one-line credentials and presses Enter (reading to EOF
+	// would instead block until Ctrl+D).
+	var input string
+	if fi, statErr := os.Stdin.Stat(); statErr == nil && (fi.Mode()&os.ModeCharDevice) == 0 {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to read credentials: %s\n", err)
+			os.Exit(1)
+		}
+		input = string(b)
+	} else {
+		// ReadString returns io.EOF along with any data read before the stream
+		// ended (e.g. piped input with no trailing newline). Only treat it as a
+		// failure when nothing was read at all.
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil && line == "" {
+			fmt.Fprintf(os.Stderr, "Error: failed to read credentials: %s\n", err)
+			os.Exit(1)
+		}
+		input = line
 	}
 
 	if _, err := parseAndSaveCredentials(input); err != nil {

--- a/auth_cmd.go
+++ b/auth_cmd.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// printAuthHelp prints usage for the `buzz auth` command group.
+func printAuthHelp() {
+	fmt.Println("buzz auth - Manage Beeminder authentication")
+	fmt.Println("")
+	fmt.Println("USAGE:")
+	fmt.Println("  buzz auth login                   Authenticate by pasting your API credentials")
+	fmt.Println("  buzz auth help                    Show this help message")
+}
+
+// handleAuthCommand dispatches `buzz auth <subcommand>`.
+func handleAuthCommand() {
+	if len(os.Args) < 3 {
+		printAuthHelp()
+		os.Exit(1)
+	}
+
+	switch os.Args[2] {
+	case "login":
+		handleAuthLoginCommand()
+	case "help", "-h", "--help":
+		printAuthHelp()
+	default:
+		fmt.Printf("Unknown auth subcommand: %s\n", os.Args[2])
+		printAuthHelp()
+		os.Exit(1)
+	}
+}
+
+// handleAuthLoginCommand reads Beeminder credentials interactively from stdin
+// and saves them. Reading from stdin (rather than command-line arguments) keeps
+// the auth token out of shell history. It also works with piped input, so
+// `buzz auth login < creds.json` is supported for scripting.
+func handleAuthLoginCommand() {
+	fmt.Println("Beeminder Authentication")
+	fmt.Println("")
+	fmt.Println("Paste your Beeminder API credentials in JSON format.")
+	fmt.Println("Get them from: https://www.beeminder.com/api/v1/auth_token.json")
+	fmt.Println("")
+	fmt.Println(`Format: {"username":"your_username","auth_token":"your_token"}`)
+	fmt.Print("> ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	// ReadString returns io.EOF along with any data read before the stream
+	// ended (e.g. piped input with no trailing newline). Only treat it as a
+	// failure when nothing was read at all.
+	if err != nil && input == "" {
+		fmt.Fprintf(os.Stderr, "Error: failed to read credentials: %s\n", err)
+		os.Exit(1)
+	}
+
+	if _, err := parseAndSaveCredentials(input); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("")
+	fmt.Println("✓ Authentication successful! Credentials saved to ~/.buzzrc")
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestParseAndSaveCredentials covers the shared credentials parsing/validation/
+// save helper used by both the TUI auth screen and `buzz auth login`. HOME is
+// redirected to a temp dir so the real ~/.buzzrc is never touched.
+func TestParseAndSaveCredentials(t *testing.T) {
+	t.Run("valid credentials are parsed and saved", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir)
+
+		config, err := parseAndSaveCredentials(`{"username":"alice","auth_token":"secret"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if config.Username != "alice" || config.AuthToken != "secret" {
+			t.Errorf("got %+v, want username=alice auth_token=secret", config)
+		}
+
+		// The config file should now exist and round-trip.
+		if !ConfigExists() {
+			t.Fatalf("expected config file at %s", filepath.Join(tmpDir, ".buzzrc"))
+		}
+		loaded, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+		if loaded.Username != "alice" || loaded.AuthToken != "secret" {
+			t.Errorf("loaded %+v, want username=alice auth_token=secret", loaded)
+		}
+	})
+
+	t.Run("surrounding whitespace is trimmed", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+
+		if _, err := parseAndSaveCredentials("  \n{\"username\":\"bob\",\"auth_token\":\"t\"}\n  "); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects empty input", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+
+		if _, err := parseAndSaveCredentials("   \n  "); err == nil {
+			t.Error("expected error for empty input")
+		}
+		if ConfigExists() {
+			t.Error("config should not be written for empty input")
+		}
+	})
+
+	t.Run("rejects invalid JSON", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+
+		if _, err := parseAndSaveCredentials("not json"); err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+		if ConfigExists() {
+			t.Error("config should not be written for invalid JSON")
+		}
+	})
+
+	t.Run("rejects missing required fields", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+
+		if _, err := parseAndSaveCredentials(`{"username":"alice"}`); err == nil {
+			t.Error("expected error when auth_token is missing")
+		}
+		if _, err := parseAndSaveCredentials(`{"auth_token":"secret"}`); err == nil {
+			t.Error("expected error when username is missing")
+		}
+		if ConfigExists() {
+			t.Error("config should not be written when required fields are missing")
+		}
+	})
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -77,4 +77,30 @@ func TestParseAndSaveCredentials(t *testing.T) {
 			t.Error("config should not be written when required fields are missing")
 		}
 	})
+
+	t.Run("rejects whitespace-only required fields", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+
+		if _, err := parseAndSaveCredentials(`{"username":"   ","auth_token":"secret"}`); err == nil {
+			t.Error("expected error for whitespace-only username")
+		}
+		if _, err := parseAndSaveCredentials(`{"username":"alice","auth_token":"\t"}`); err == nil {
+			t.Error("expected error for whitespace-only auth_token")
+		}
+		if ConfigExists() {
+			t.Error("config should not be written for whitespace-only fields")
+		}
+	})
+
+	t.Run("trims surrounding whitespace from saved fields", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+
+		config, err := parseAndSaveCredentials(`{"username":"  alice  ","auth_token":" secret "}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if config.Username != "alice" || config.AuthToken != "secret" {
+			t.Errorf("got %+v, want trimmed username=alice auth_token=secret", config)
+		}
+	})
 }

--- a/charge.go
+++ b/charge.go
@@ -59,7 +59,7 @@ func handleChargeCommand() {
 
 	// Load config
 	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/deadline_cmd.go
+++ b/deadline_cmd.go
@@ -50,7 +50,7 @@ func handleDeadlineCommand() {
 	}
 
 	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/filtered.go
+++ b/filtered.go
@@ -115,7 +115,7 @@ func sortGoalsByDisplayedLosedate(goals []Goal, losedateFor func(Goal) int64) {
 func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool, bareminFor func(Goal) string, losedateFor func(Goal) int64) {
 	// Load config
 	if !ConfigExists() {
-		fmt.Println("Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/list.go
+++ b/list.go
@@ -10,7 +10,7 @@ import (
 func handleListCommand() {
 	// Load config
 	if !ConfigExists() {
-		fmt.Println("Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func printHelp() {
 	fmt.Println("  buzz schedule                     Display goal deadline distribution throughout a 24-hour day")
 	fmt.Println("  buzz uncle [-y|--yes] <goalslug>  Instantly derail a goal that is in the red, paying the pledge")
 	fmt.Println("                                    -y, --yes: Skip the confirmation prompt")
+	fmt.Println("  buzz auth login                   Authenticate by pasting your Beeminder API credentials")
 	fmt.Println("  buzz help                         Show this help message")
 	fmt.Println("")
 	fmt.Println("GLOBAL OPTIONS:")
@@ -141,6 +142,9 @@ func main() {
 		case "uncle":
 			handleUncleCommand()
 			return
+		case "auth":
+			handleAuthCommand()
+			return
 		case "help", "-h", "--help":
 			printHelp()
 			return
@@ -149,7 +153,7 @@ func main() {
 			return
 		default:
 			fmt.Printf("Unknown command: %s\n", os.Args[1])
-			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, help, version")
+			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, auth, help, version")
 			fmt.Println("Run 'buzz --help' for more information.")
 			os.Exit(1)
 		}
@@ -175,7 +179,7 @@ func main() {
 // commands use it.
 func loadConfigAndGoals() (*Config, Client, []Goal, error) {
 	if !ConfigExists() {
-		return nil, nil, nil, fmt.Errorf("no configuration found. Please run 'buzz' first to authenticate")
+		return nil, nil, nil, fmt.Errorf("no configuration found. Please run 'buzz auth login' to authenticate")
 	}
 
 	config, err := LoadConfig()

--- a/refresh.go
+++ b/refresh.go
@@ -23,7 +23,7 @@ func handleRefreshCommand() {
 
 	// Load config
 	if !ConfigExists() {
-		fmt.Println("Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/review.go
+++ b/review.go
@@ -17,7 +17,7 @@ import (
 func handleReviewCommand() {
 	// Load config
 	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/uncle.go
+++ b/uncle.go
@@ -42,7 +42,7 @@ func handleUncleCommand() {
 	skipConfirm := *yes || *yesShort
 
 	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 

--- a/view.go
+++ b/view.go
@@ -64,7 +64,7 @@ func handleViewCommand() {
 
 	// Load config
 	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz' first to authenticate.")
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

Adds an explicit `buzz auth login` command and repoints all subcommand "not authenticated" errors to it, while keeping the interactive TUI's auto-onboarding intact.

Previously, `buzz` (no args) was the only entry point that would interactively prompt for credentials; every subcommand just errored with "Please run 'buzz' first to authenticate" — ambiguous, and there was no dedicated, discoverable way to (re)authenticate.

## What changed

- **New `buzz auth login` command** (`auth_cmd.go`) — reads credentials interactively from stdin so the auth token stays out of shell history. Piped input (`buzz auth login < creds.json`) works too, for scripting. Also handles `buzz auth help` and unknown subcommands.
- **Shared `parseAndSaveCredentials` helper** (`auth.go`) — extracted from the TUI auth model so the TUI screen and the new command accept identical input and report identical errors. The TUI still auto-prompts on first run.
- **Repointed error messages** — all subcommands (`today`, `next`, `list`, `add`, `view`, `review`, `charge`, `deadline`, `schedule`, `uncle`, `refresh`) now say "Please run 'buzz auth login' to authenticate."
- **Help text & README** updated.

## Behavior

| Command | Unauthenticated behavior |
|---|---|
| `buzz` (TUI) | Auto-prompts for credentials (unchanged) |
| `buzz auth login` | Interactive credential entry (new) |
| `buzz today`, `buzz next`, … | Error → "Please run 'buzz auth login' to authenticate." |

## Testing

- New `auth_test.go` covers `parseAndSaveCredentials` (valid, whitespace-trimmed, empty, invalid JSON, missing fields), with `HOME` redirected to a temp dir so the real `~/.buzzrc` is untouched.
- Manually verified the built binary: `auth` (no subcommand) → help+exit 1; `today` with no config → points to auth login; `auth login` with piped creds → writes `~/.buzzrc`; unknown subcommand → error+exit 1.
- `go build`, `go vet`, `gofmt` all clean.

Note: pre-existing failures in `TestParseDuration` (integer overflow) and `TestExtractTimeSlots` (timezone-dependent — pass under `TZ=UTC`) exist on `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `buzz auth login` command for interactive credential setup, supporting both interactive prompts and piped input; confirms credentials saved locally.

* **Documentation**
  * Updated authentication docs with a clear step-by-step first-run flow and credential format guidance.

* **Improvements**
  * Unified error messages across commands to point users to `buzz auth login`.

* **Tests**
  * Added tests covering credential parsing, validation, whitespace handling, and config persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->