### PR TITLE
fix: make date handling and schedule tests timezone-resilient

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -395,8 +395,10 @@ func validateDatapointInput(inputDate, inputValue string) string {
 		return "Value cannot be empty"
 	}
 
-	// Parse and validate date
-	date, err := time.Parse("2006-01-02", inputDate)
+	// Parse and validate date. Interpret the calendar date in local time so the
+	// comparison below against the local time.Now() is timezone-consistent
+	// (parsing without a location would assume UTC and shift the boundary).
+	date, err := time.ParseInLocation("2006-01-02", inputDate, time.Local)
 	if err != nil {
 		return "Invalid date format (use YYYY-MM-DD)"
 	}
@@ -513,8 +515,10 @@ func handleEnterKey(m model) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Parse date to get timestamp
-		date, _ := time.Parse("2006-01-02", m.appModel.inputDate)
+		// Parse date to get timestamp. Interpret the entered calendar date in
+		// local time (matching validateDatapointInput) so the datapoint lands on
+		// the day the user intended rather than being shifted by the UTC offset.
+		date, _ := time.ParseInLocation("2006-01-02", m.appModel.inputDate, time.Local)
 		timestamp := fmt.Sprintf("%d", date.Unix())
 
 		// Set submitting state and submit datapoint asynchronously

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -9,23 +9,25 @@ import (
 
 // TestExtractTimeSlots tests the extraction and grouping of time slots from goals
 func TestExtractTimeSlots(t *testing.T) {
-	// Create test goals with different deadline times
+	// Create test goals with different deadline times. extractTimeSlots converts
+	// losedate to local time, so the fixtures are built in time.Local too; this
+	// keeps the asserted hour/minute correct regardless of the machine's timezone.
 	goals := []Goal{
 		{
 			Slug:     "goal1",
-			Losedate: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC).Unix(),
+			Losedate: time.Date(2024, 1, 15, 10, 30, 0, 0, time.Local).Unix(),
 		},
 		{
 			Slug:     "goal2",
-			Losedate: time.Date(2024, 1, 16, 10, 30, 0, 0, time.UTC).Unix(), // Same time as goal1
+			Losedate: time.Date(2024, 1, 16, 10, 30, 0, 0, time.Local).Unix(), // Same time as goal1
 		},
 		{
 			Slug:     "goal3",
-			Losedate: time.Date(2024, 1, 17, 15, 45, 0, 0, time.UTC).Unix(),
+			Losedate: time.Date(2024, 1, 17, 15, 45, 0, 0, time.Local).Unix(),
 		},
 		{
 			Slug:     "goal4",
-			Losedate: time.Date(2024, 1, 18, 6, 0, 0, 0, time.UTC).Unix(),
+			Losedate: time.Date(2024, 1, 18, 6, 0, 0, 0, time.Local).Unix(),
 		},
 	}
 
@@ -90,18 +92,20 @@ func TestExtractTimeSlotsEmpty(t *testing.T) {
 
 // TestExtractTimeSlotsAcrossDates tests that goals on different dates with same time are grouped together
 func TestExtractTimeSlotsAcrossDates(t *testing.T) {
+	// Fixtures built in time.Local so the asserted slot time is timezone-independent
+	// (extractTimeSlots groups by the deadline's local hour/minute).
 	goals := []Goal{
 		{
 			Slug:     "goal1",
-			Losedate: time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC).Unix(),
+			Losedate: time.Date(2024, 1, 15, 14, 30, 0, 0, time.Local).Unix(),
 		},
 		{
 			Slug:     "goal2",
-			Losedate: time.Date(2024, 2, 20, 14, 30, 0, 0, time.UTC).Unix(), // Different date, same time
+			Losedate: time.Date(2024, 2, 20, 14, 30, 0, 0, time.Local).Unix(), // Different date, same time
 		},
 		{
 			Slug:     "goal3",
-			Losedate: time.Date(2024, 3, 10, 14, 30, 0, 0, time.UTC).Unix(), // Different date, same time
+			Losedate: time.Date(2024, 3, 10, 14, 30, 0, 0, time.Local).Unix(), // Different date, same time
 		},
 	}
 


### PR DESCRIPTION
## Problem

Running the test suite outside UTC surfaces failures that pass on CI/UTC machines but break for contributors in other timezones. Two distinct timezone bugs were involved — one of them in production code.

## Changes

### Production fix — `handlers.go`
`validateDatapointInput` parsed the entered date with `time.Parse("2006-01-02", …)`, which assumes **UTC midnight**, then compared it against the **local** `time.Now()`:

```go
date, err := time.Parse("2006-01-02", inputDate)   // UTC
...
if date.After(time.Now().AddDate(0, 0, 1)) {       // local
```

This made the "date cannot be more than 1 day in the future" boundary shift by the machine's UTC offset (`TestValidateDatapointInput/date_tomorrow_is_valid` failed at positive offsets). `handleEnterKey` had the same UTC parse and used `date.Unix()` as the submitted datapoint timestamp, which could land the datapoint on the **wrong day** for users west/east of UTC.

Both call sites now use `time.ParseInLocation("2006-01-02", inputDate, time.Local)` so a user-entered calendar date is interpreted in local time — consistent with the `time.Now()` comparison and with what the user intends.

### Test fix — `schedule_test.go`
`extractTimeSlots` correctly converts each goal's `Losedate` to **local** time before grouping by hour/minute. The fixtures, however, were built with `time.UTC`, so the asserted slot times (`06:00`, `10:30`, `15:45`, `14:30`) only held when the machine ran in UTC. Fixtures now use `time.Local` to match production behavior, with explanatory comments.

## Verification

Full suite run under `TZ` from **UTC−11 to UTC+14** (`UTC`, `America/Chicago`, `Asia/Kolkata`, `Pacific/Kiritimati`, `Pacific/Pago_Pago`) — the previously timezone-fragile tests now pass everywhere.

## Out of scope

`TestParseDuration/{very_large_hours,very_large_weeks}` also fail locally, but they fail **identically in every timezone** (an integer-overflow handling issue in `ParseDuration`, unrelated to timezones). Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed timezone handling to ensure calendar dates and datapoints are consistently processed using your local timezone instead of UTC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/buzz/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->