### PR TITLE
fix: include response body in CreateDatapointWithDaystamp error

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,11 @@ func (c *HTTPClient) CreateDatapointWithDaystamp(ctx context.Context, goalSlug, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("API returned status %d", resp.StatusCode)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("API returned status %d (failed to read body: %w)", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

`CreateDatapointWithDaystamp` discarded the response body on non-200 responses, returning only the status code. This makes it impossible for callers to distinguish a Beeminder duplicate-datapoint 422 (which returns `"duplicate datapoint"` in the body) from any other 422 error.

## Change

Read and append the response body to the error message, matching the pattern already used by `CreateCharge` and `UpdateGoalDeadline`.

Error messages will now look like:
```
API returned status 422: "duplicate datapoint"
```
instead of just:
```
API returned status 422
```

Conversation: https://app.warp.dev/conversation/b1dbf255-598d-45f8-a6c4-250eda8a8a0b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for failed API requests by including response body details, providing better diagnostic information for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->