### PR TITLE
feat: add ratchet command to remove goal safety buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ buzz ratchet mygoal 3        # Leave 3 days of buffer
 buzz ratchet --yes mygoal 0  # Ratchet to zero buffer, skip confirmation
 ```
 
-Removes safety buffer from a goal so that only `<days>` of buffer remain between today and the bright red line. The command shows the current and target buffer and asks for confirmation before making the change.
+Removes safety buffer from a goal so that at most `<days>` of buffer remain between today and the bright red line. If the goal already has `<days>` or fewer days of buffer, Beeminder leaves it unchanged (see the note below). The command shows the current and target buffer and asks for confirmation before making the change.
 
 - `<goalslug>`: The slug of the goal to ratchet
 - `<days>`: The number of days of safety buffer to leave on the goal (must be a non-negative whole number)

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Changes the daily deadline for a Beeminder goal. The command shows the current a
 **buzz ratchet** - Remove safety buffer from a goal:
 
 ```bash
-buzz ratchet [--yes] <goalslug> <days>
+buzz ratchet [-y|--yes] <goalslug> <days>
 
 # Examples:
 buzz ratchet mygoal 3        # Leave 3 days of buffer

--- a/README.md
+++ b/README.md
@@ -325,6 +325,24 @@ Changes the daily deadline for a Beeminder goal. The command shows the current a
 - `<time>`: The new deadline time in 12-hour (`3:00 PM`) or 24-hour (`15:00`) format
 - `--yes`, `-y`: Skip the confirmation prompt (useful for scripting)
 
+**buzz ratchet** - Remove safety buffer from a goal:
+
+```bash
+buzz ratchet [--yes] <goalslug> <days>
+
+# Examples:
+buzz ratchet mygoal 3        # Leave 3 days of buffer
+buzz ratchet --yes mygoal 0  # Ratchet to zero buffer, skip confirmation
+```
+
+Removes safety buffer from a goal so that only `<days>` of buffer remain between today and the bright red line. The command shows the current and target buffer and asks for confirmation before making the change.
+
+- `<goalslug>`: The slug of the goal to ratchet
+- `<days>`: The number of days of safety buffer to leave on the goal (must be a non-negative whole number)
+- `--yes`, `-y`: Skip the confirmation prompt (useful for scripting)
+
+Ratcheting only ever tightens a goal — Beeminder ignores requests that would add buffer, so this cannot be used to give yourself more breathing room.
+
 **buzz schedule** - Display goal deadline distribution throughout a 24-hour day:
 
 ```bash

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2291,7 +2291,9 @@ func TestRatchetGoalWithMockServer(t *testing.T) {
 				t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 			}
 
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			if r.FormValue("auth_token") != "testtoken" {
 				t.Errorf("Expected auth_token 'testtoken', got %s", r.FormValue("auth_token"))
 			}

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2278,6 +2278,107 @@ func TestCallUncleWithMockServer(t *testing.T) {
 	})
 }
 
+// TestRatchetGoalWithMockServer tests RatchetGoal against a mock HTTP server.
+func TestRatchetGoalWithMockServer(t *testing.T) {
+	t.Run("successful ratchet", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("Expected POST request, got %s", r.Method)
+			}
+
+			expectedPath := "/api/v1/users/testuser/goals/testgoal/ratchet.json"
+			if r.URL.Path != expectedPath {
+				t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+			}
+
+			r.ParseForm()
+			if r.FormValue("auth_token") != "testtoken" {
+				t.Errorf("Expected auth_token 'testtoken', got %s", r.FormValue("auth_token"))
+			}
+			if r.FormValue("ratchet") != "3" {
+				t.Errorf("Expected ratchet 3, got %s", r.FormValue("ratchet"))
+			}
+
+			goal := Goal{Slug: "testgoal", Safebuf: 3}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(goal)
+		}))
+		defer mockServer.Close()
+
+		config := &Config{
+			Username:  "testuser",
+			AuthToken: "testtoken",
+			BaseURL:   mockServer.URL,
+		}
+
+		goal, err := NewHTTPClient(config).RatchetGoal(context.Background(), "testgoal", 3)
+		if err != nil {
+			t.Fatalf("RatchetGoal failed: %v", err)
+		}
+		if goal == nil || goal.Slug != "testgoal" {
+			t.Fatalf("Unexpected goal: %+v", goal)
+		}
+		if goal.Safebuf != 3 {
+			t.Errorf("Expected safebuf 3, got %d", goal.Safebuf)
+		}
+	})
+
+	t.Run("goal slug URL encoding", func(t *testing.T) {
+		rawSlug := "my goal"
+		escapedSlug := "my%20goal"
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			expectedPath := "/api/v1/users/testuser/goals/" + escapedSlug + "/ratchet.json"
+			if r.URL.EscapedPath() != expectedPath {
+				t.Errorf("Expected path %s, got %s", expectedPath, r.URL.EscapedPath())
+			}
+
+			goal := Goal{Slug: rawSlug}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(goal)
+		}))
+		defer mockServer.Close()
+
+		config := &Config{
+			Username:  "testuser",
+			AuthToken: "testtoken",
+			BaseURL:   mockServer.URL,
+		}
+
+		goal, err := NewHTTPClient(config).RatchetGoal(context.Background(), rawSlug, 1)
+		if err != nil {
+			t.Fatalf("RatchetGoal failed: %v", err)
+		}
+		if goal == nil || goal.Slug != rawSlug {
+			t.Fatalf("Unexpected goal: %+v", goal)
+		}
+	})
+
+	t.Run("API error", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("internal error"))
+		}))
+		defer mockServer.Close()
+
+		config := &Config{
+			Username:  "testuser",
+			AuthToken: "testtoken",
+			BaseURL:   mockServer.URL,
+		}
+
+		goal, err := NewHTTPClient(config).RatchetGoal(context.Background(), "testgoal", 0)
+		if err == nil {
+			t.Error("Expected error for non-200 status, got nil")
+		}
+		if goal != nil {
+			t.Errorf("Expected nil goal on error, got: %+v", goal)
+		}
+		if !strings.Contains(err.Error(), "API returned status 500") {
+			t.Errorf("Expected error message about status 500, got: %v", err)
+		}
+	})
+}
+
 // TestHTTPClientCancellation verifies that a cancelled context propagates
 // into the in-flight HTTP request. The mock server signals `started` as soon
 // as it begins handling, then blocks until `released`; the test cancels the

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2370,7 +2370,7 @@ func TestRatchetGoalWithMockServer(t *testing.T) {
 
 		goal, err := NewHTTPClient(config).RatchetGoal(context.Background(), "testgoal", 0)
 		if err == nil {
-			t.Error("Expected error for non-200 status, got nil")
+			t.Fatal("Expected error for non-200 status, got nil")
 		}
 		if goal != nil {
 			t.Errorf("Expected nil goal on error, got: %+v", goal)

--- a/client.go
+++ b/client.go
@@ -34,6 +34,7 @@ type Client interface {
 	CreateCharge(ctx context.Context, amount float64, note string, dryrun bool) (*Charge, error)
 	CreateGoal(ctx context.Context, slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error)
 	CallUncle(ctx context.Context, goalSlug string) (*Goal, error)
+	RatchetGoal(ctx context.Context, goalSlug string, ratchet int) (*Goal, error)
 	UpdateGoalDeadline(ctx context.Context, goalSlug string, deadline int) (*Goal, error)
 	RefreshGoal(ctx context.Context, goalSlug string) (bool, error)
 }
@@ -227,6 +228,39 @@ func (c *HTTPClient) CallUncle(ctx context.Context, goalSlug string) (*Goal, err
 	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(""), "application/x-www-form-urlencoded")
 	if err != nil {
 		return nil, fmt.Errorf("failed to call uncle: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", readErr)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var goal Goal
+	if err := json.Unmarshal(body, &goal); err != nil {
+		return nil, fmt.Errorf("failed to decode goal: %w", err)
+	}
+	return &goal, nil
+}
+
+// RatchetGoal removes safety buffer from a goal, leaving exactly `ratchet` days
+// of buffer between today and the bright red line. Beeminder ignores requests
+// that would *add* buffer, so this can only ever tighten a goal.
+func (c *HTTPClient) RatchetGoal(ctx context.Context, goalSlug string, ratchet int) (*Goal, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/ratchet.json",
+		c.baseURL(), c.config.Username, url.PathEscape(goalSlug))
+
+	data := url.Values{}
+	data.Set("auth_token", c.config.AuthToken)
+	data.Set("ratchet", fmt.Sprintf("%d", ratchet))
+
+	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
+	if err != nil {
+		return nil, fmt.Errorf("failed to ratchet goal: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/client.go
+++ b/client.go
@@ -247,9 +247,10 @@ func (c *HTTPClient) CallUncle(ctx context.Context, goalSlug string) (*Goal, err
 	return &goal, nil
 }
 
-// RatchetGoal removes safety buffer from a goal, leaving exactly `ratchet` days
+// RatchetGoal removes safety buffer from a goal, leaving at most `ratchet` days
 // of buffer between today and the bright red line. Beeminder ignores requests
-// that would *add* buffer, so this can only ever tighten a goal.
+// that would *add* buffer, so a goal already at or below `ratchet` days is left
+// unchanged — this can only ever tighten a goal, never loosen it.
 func (c *HTTPClient) RatchetGoal(ctx context.Context, goalSlug string, ratchet int) (*Goal, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/ratchet.json",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug))

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -33,6 +33,7 @@ type FakeClient struct {
 	CreateChargeFunc                func(amount float64, note string, dryrun bool) (*Charge, error)
 	CreateGoalFunc                  func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error)
 	CallUncleFunc                   func(goalSlug string) (*Goal, error)
+	RatchetGoalFunc                 func(goalSlug string, ratchet int) (*Goal, error)
 	UpdateGoalDeadlineFunc          func(goalSlug string, deadline int) (*Goal, error)
 	RefreshGoalFunc                 func(goalSlug string) (bool, error)
 }
@@ -110,6 +111,13 @@ func (c *FakeClient) CallUncle(ctx context.Context, goalSlug string) (*Goal, err
 		return nil, errFakeNotConfigured
 	}
 	return c.CallUncleFunc(goalSlug)
+}
+
+func (c *FakeClient) RatchetGoal(ctx context.Context, goalSlug string, ratchet int) (*Goal, error) {
+	if c.RatchetGoalFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.RatchetGoalFunc(goalSlug, ratchet)
 }
 
 func (c *FakeClient) UpdateGoalDeadline(ctx context.Context, goalSlug string, deadline int) (*Goal, error) {

--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ func printHelp() {
 	fmt.Println("  buzz schedule                     Display goal deadline distribution throughout a 24-hour day")
 	fmt.Println("  buzz uncle [-y|--yes] <goalslug>  Instantly derail a goal that is in the red, paying the pledge")
 	fmt.Println("                                    -y, --yes: Skip the confirmation prompt")
+	fmt.Println("  buzz ratchet [-y|--yes] <goalslug> <days>")
+	fmt.Println("                                    Remove safety buffer, leaving <days> of buffer on the goal")
+	fmt.Println("                                    -y, --yes: Skip the confirmation prompt")
 	fmt.Println("  buzz auth login                   Authenticate by pasting your Beeminder API credentials")
 	fmt.Println("  buzz help                         Show this help message")
 	fmt.Println("")
@@ -142,6 +145,9 @@ func main() {
 		case "uncle":
 			handleUncleCommand()
 			return
+		case "ratchet":
+			handleRatchetCommand()
+			return
 		case "auth":
 			handleAuthCommand()
 			return
@@ -153,7 +159,7 @@ func main() {
 			return
 		default:
 			fmt.Printf("Unknown command: %s\n", os.Args[1])
-			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, auth, help, version")
+			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, ratchet, auth, help, version")
 			fmt.Println("Run 'buzz --help' for more information.")
 			os.Exit(1)
 		}

--- a/ratchet.go
+++ b/ratchet.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// handleRatchetCommand removes safety buffer from a goal, leaving it with a
+// specified number of days of buffer. The Beeminder ratchet endpoint only ever
+// tightens a goal: requests that would add buffer are ignored by the server.
+func handleRatchetCommand() {
+	ratchetFlags := flag.NewFlagSet("ratchet", flag.ContinueOnError)
+	ratchetFlags.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: buzz ratchet [-y|--yes] <goalslug> <days>")
+		fmt.Fprintln(os.Stderr, "  <days> is the number of days of safety buffer to leave on the goal")
+	}
+	yes := ratchetFlags.Bool("yes", false, "Skip the confirmation prompt")
+	yesShort := ratchetFlags.Bool("y", false, "Skip the confirmation prompt (shorthand)")
+	if err := ratchetFlags.Parse(os.Args[2:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			ratchetFlags.Usage()
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Error parsing flags: %s\n", err)
+		ratchetFlags.Usage()
+		os.Exit(2)
+	}
+
+	args := ratchetFlags.Args()
+	if len(args) != 2 {
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "Error: Missing required arguments")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: Too many arguments: %v\n", args[2:])
+		}
+		ratchetFlags.Usage()
+		os.Exit(1)
+	}
+
+	goalSlug := args[0]
+	days, err := strconv.Atoi(args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Invalid number of days %q: must be a whole number\n", args[1])
+		os.Exit(1)
+	}
+	if days < 0 {
+		fmt.Fprintln(os.Stderr, "Error: Number of days must not be negative")
+		os.Exit(1)
+	}
+
+	skipConfirm := *yes || *yesShort
+
+	if !ConfigExists() {
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
+		os.Exit(1)
+	}
+
+	config, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to load config: %s\n", redactError(err))
+		os.Exit(1)
+	}
+
+	client := NewHTTPClient(config)
+
+	if !skipConfirm {
+		// Fetch the current goal only when we need to show the confirmation
+		// prompt, so the --yes path doesn't pay for an extra API call that
+		// can fail before the ratchet itself runs.
+		currentGoal, err := client.FetchGoal(context.Background(), goalSlug)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to fetch goal: %s\n", redactError(err))
+			os.Exit(1)
+		}
+		fmt.Printf("Ratchet %s from %d to %d days of safety buffer? This removes buffer and cannot add it back. [y/N] ", goalSlug, currentGoal.Safebuf, days)
+		var response string
+		if _, err := fmt.Scanln(&response); err != nil {
+			// EOF or read error in non-interactive contexts — treat as "no"
+			// so we never remove buffer without an explicit affirmative.
+			fmt.Println("Cancelled.")
+			return
+		}
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Cancelled.")
+			return
+		}
+	}
+
+	goal, err := client.RatchetGoal(context.Background(), goalSlug, days)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to ratchet goal: %s\n", redactError(err))
+		os.Exit(1)
+	}
+
+	fmt.Printf("Ratcheted %s to %d days of safety buffer.\n", goal.Slug, goal.Safebuf)
+
+	fmt.Print(getUpdateMessage())
+}

--- a/ratchet.go
+++ b/ratchet.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 )
 
-// handleRatchetCommand removes safety buffer from a goal, leaving it with a
-// specified number of days of buffer. The Beeminder ratchet endpoint only ever
-// tightens a goal: requests that would add buffer are ignored by the server.
+// handleRatchetCommand removes safety buffer from a goal, leaving it with at
+// most the specified number of days of buffer. The Beeminder ratchet endpoint
+// only ever tightens a goal: requests that would add buffer are ignored by the
+// server, so a goal already at or below the target is left unchanged.
 func handleRatchetCommand() {
 	ratchetFlags := flag.NewFlagSet("ratchet", flag.ContinueOnError)
 	ratchetFlags.Usage = func() {

--- a/ratchet.go
+++ b/ratchet.go
@@ -77,7 +77,7 @@ func handleRatchetCommand() {
 			fmt.Fprintf(os.Stderr, "Error: Failed to fetch goal: %s\n", redactError(err))
 			os.Exit(1)
 		}
-		fmt.Printf("Ratchet %s from %d to %d days of safety buffer? This removes buffer and cannot add it back. [y/N] ", goalSlug, currentGoal.Safebuf, days)
+		fmt.Printf("Ratchet %s from %d to at most %d days of safety buffer? This removes buffer and cannot add it back. [y/N] ", goalSlug, currentGoal.Safebuf, days)
 		var response string
 		if _, err := fmt.Scanln(&response); err != nil {
 			// EOF or read error in non-interactive contexts — treat as "no"

--- a/ratchet.go
+++ b/ratchet.go
@@ -78,7 +78,11 @@ func handleRatchetCommand() {
 			fmt.Fprintf(os.Stderr, "Error: Failed to fetch goal: %s\n", redactError(err))
 			os.Exit(1)
 		}
-		fmt.Printf("Ratchet %s from %d to at most %d days of safety buffer? This removes buffer and cannot add it back. [y/N] ", goalSlug, currentGoal.Safebuf, days)
+		if currentGoal.Safebuf <= days {
+			fmt.Printf("%s already has %d days of safety buffer, which is at or below %d days. No buffer will be removed. Continue anyway? [y/N] ", goalSlug, currentGoal.Safebuf, days)
+		} else {
+			fmt.Printf("Ratchet %s from %d to at most %d days of safety buffer? This removes buffer and cannot add it back. [y/N] ", goalSlug, currentGoal.Safebuf, days)
+		}
 		var response string
 		if _, err := fmt.Scanln(&response); err != nil {
 			// EOF or read error in non-interactive contexts — treat as "no"


### PR DESCRIPTION
## Summary

Adds a `buzz ratchet` command wrapping Beeminder's [ratchet endpoint](https://api.beeminder.com/#ratchet).

```bash
buzz ratchet [-y|--yes] <goalslug> <days>

# Examples:
buzz ratchet mygoal 3        # leave 3 days of buffer
buzz ratchet --yes mygoal 0  # ratchet to zero buffer, skip confirmation
```

It removes safety buffer so that only `<days>` of buffer remain between today and the bright red line. Like `deadline` and `uncle`, it fetches the goal to show a `current → target` buffer confirmation prompt before acting, unless `--yes`/`-y` is passed. Non-interactive/EOF input is treated as "no".

Ratcheting only ever **tightens** a goal — Beeminder ignores requests that would add buffer — and this is called out in both the prompt and the docs.

## Changes

- **`client.go`** — `RatchetGoal(ctx, goalSlug, ratchet)` added to the `Client` interface and implemented on `HTTPClient` (POST to `.../goals/<slug>/ratchet.json` with the `ratchet` param), following the existing `CallUncle` pattern for body reading and error surfacing.
- **`ratchet.go`** (new) — `handleRatchetCommand`: flag parsing, non-negative integer validation for `<days>`, confirmation prompt.
- **`main.go`** — wired into the command switch, `help` output, and unknown-command list.
- **`client_fake_test.go`** — `RatchetGoalFunc` added to the test double.
- **`beeminder_test.go`** — `TestRatchetGoalWithMockServer` covering success (asserts method, path, `auth_token`, `ratchet` value, returned safebuf), slug URL-encoding, and API-error handling.
- **`README.md`** — documented the command.

## Testing

- `go build ./...`, `go vet ./...`, and the new ratchet tests all pass.
- Pre-existing `TestParseDuration` overflow failures on `main` are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `buzz ratchet` command to set a goal's safety buffer to a specified number of days; supports skipping confirmation with `--yes`/`-y` and prints success output.

* **Documentation**
  * README updated with `buzz ratchet` usage, arguments, flags, and examples (including ratcheting to zero).

* **Tests**
  * Added tests validating ratchet behavior, API interaction, path-escaping, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->