### PR TITLE
fix(render): drop corepack enable from docs build command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,9 @@ services:
     name: buzz-docs
     # The Starlight docs site lives in the website/ subfolder.
     rootDir: website
-    buildCommand: corepack enable && pnpm install --frozen-lockfile && pnpm run build
+    # Render auto-detects pnpm from pnpm-lock.yaml and provides it on PATH, so
+    # there's no need for `corepack enable` (which fails on the read-only /usr/bin).
+    buildCommand: pnpm install --frozen-lockfile && pnpm run build
     staticPublishPath: dist
     # Auto-deploy on every push to the default branch.
     autoDeploy: true


### PR DESCRIPTION
## Problem

The first Render deploy of the docs site (from `main` after #275 merged) failed:

```
==> Running build command 'corepack enable && pnpm install --frozen-lockfile && pnpm run build'...
Internal Error: EROFS: read-only file system, unlink '/usr/bin/pnpm'
    at async EnableCommand.generatePosixLink (.../corepack.cjs)
==> Build failed 😞
```

`corepack enable` tries to symlink `pnpm` into `/usr/bin`, which is read-only on Render's build image.

## Fix

Drop `corepack enable` from the build command. Render already auto-detects pnpm from `pnpm-lock.yaml` and puts it on `PATH` (the deploy log shows `Installing dependencies with pnpm...` before the build command even runs), so it was both unnecessary and fatal.

New build command:

```
pnpm install --frozen-lockfile && pnpm run build
```

Merging this to `main` will trigger a fresh deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)