### PR TITLE
docs: point buzz --help footer at the docs site

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func printHelp() {
 	fmt.Println("  -h, --help                        Show this help message")
 	fmt.Println("  -v, --version                     Show version information")
 	fmt.Println("")
-	fmt.Println("For more information, visit: https://github.com/pinepeakdigital/buzz")
+	fmt.Println("For more information, visit: https://buzz.nathanarthur.com")
 }
 
 func printVersion() {


### PR DESCRIPTION
## Summary

The documentation site is now live at [buzz.nathanarthur.com](https://buzz.nathanarthur.com) (verified: DNS resolves via Cloudflare, HTTP 200, serving the Starlight docs). This updates the `buzz --help` footer in `main.go` to point there instead of the GitHub repo, so the CLI and README reference the same canonical docs URL.

```diff
- fmt.Println("For more information, visit: https://github.com/pinepeakdigital/buzz")
+ fmt.Println("For more information, visit: https://buzz.nathanarthur.com")
```

Verified `go build`, `go vet`, and `buzz --help` output locally.

Closes #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)