### PR TITLE
docs: add attribution footer to docs site

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -10,6 +10,9 @@ export default defineConfig({
 			title: 'buzz',
 			description:
 				'A terminal user interface and CLI for Beeminder, built with Bubble Tea.',
+			components: {
+				Footer: './src/components/Footer.astro',
+			},
 			social: [
 				{
 					icon: 'github',

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,0 +1,30 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro';
+---
+
+<Default><slot /></Default>
+
+<footer class="buzz-attribution">
+	<p>
+		buzz is built by <a href="https://nathanarthur.com">Nathan Arthur</a> and
+		<a href="https://pinepeakdigital.com">Pine Peak Digital</a>.
+	</p>
+</footer>
+
+<style>
+	.buzz-attribution {
+		margin-top: 1.5rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--sl-color-gray-5);
+		font-size: var(--sl-text-sm);
+		color: var(--sl-color-gray-3);
+	}
+
+	.buzz-attribution p {
+		margin: 0;
+	}
+
+	.buzz-attribution a {
+		color: var(--sl-color-text-accent);
+	}
+</style>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -4,12 +4,12 @@ import Default from '@astrojs/starlight/components/Footer.astro';
 
 <Default><slot /></Default>
 
-<footer class="buzz-attribution">
+<div class="buzz-attribution">
 	<p>
 		buzz is built by <a href="https://nathanarthur.com">Nathan Arthur</a> and
 		<a href="https://pinepeakdigital.com">Pine Peak Digital</a>.
 	</p>
-</footer>
+</div>
 
 <style>
 	.buzz-attribution {


### PR DESCRIPTION
## Summary
Adds a footer line to every page of the docs site crediting the people behind buzz.

The new footer reads:

> buzz is built by [Nathan Arthur](https://nathanarthur.com) and [Pine Peak Digital](https://pinepeakdigital.com).

## Implementation
- Overrides Starlight's `Footer` component (`website/src/components/Footer.astro`), rendering the default footer first and appending the attribution beneath it, so existing footer content (edit links, prev/next nav, etc.) is preserved.
- Wires the override into `astro.config.mjs` via Starlight's `components` map.
- Styling uses Starlight's theme CSS variables so it adapts to light/dark mode.

Appears on every page including the splash homepage. Verified by building (`pnpm build`) and confirming the markup and both links render in the generated HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customized footer component to the website featuring a dedicated attribution section with styling and acknowledgment links. The enhanced footer now includes branding elements and proper spacing alongside the standard footer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->