### PR TITLE
fix(deadline): detect ParseDuration overflow for very large values (#271)

### DIFF
--- a/deadline.go
+++ b/deadline.go
@@ -93,24 +93,32 @@ func ParseDuration(durationStr string) (time.Duration, bool) {
 		return 0, false
 	}
 
-	// Convert to duration based on unit
-	var duration time.Duration
+	// Convert to nanoseconds based on unit, as float64 so we can detect
+	// overflow before the lossy float64→int64 conversion below.
+	var ns float64
 	switch unit {
 	case 'm', 'M':
-		duration = time.Duration(num * float64(time.Minute))
+		ns = num * float64(time.Minute)
 	case 'h', 'H':
-		duration = time.Duration(num * float64(time.Hour))
+		ns = num * float64(time.Hour)
 	case 'd', 'D':
-		duration = time.Duration(num * 24 * float64(time.Hour))
+		ns = num * 24 * float64(time.Hour)
 	case 'w', 'W':
-		duration = time.Duration(num * 7 * 24 * float64(time.Hour))
+		ns = num * 7 * 24 * float64(time.Hour)
 	default:
 		return 0, false
 	}
 
-	// Check for overflow: time.Duration is int64 nanoseconds
-	// Maximum duration is ~290 years (math.MaxInt64 nanoseconds)
-	// If the result is negative, it overflowed
+	// Check for overflow: time.Duration is int64 nanoseconds (max ~290 years).
+	// A float64 above math.MaxInt64 saturates to a positive math.MaxInt64 on
+	// conversion rather than wrapping negative, so we must reject it here.
+	if ns >= float64(math.MaxInt64) {
+		return 0, false
+	}
+
+	duration := time.Duration(ns)
+
+	// Backstop: if the result is still negative, it overflowed.
 	if duration < 0 {
 		return 0, false
 	}


### PR DESCRIPTION
## Problem
`ParseDuration` returned `(MaxInt64, true)` for durations that overflow `time.Duration` (e.g. `1e10h`, `999999w`) instead of rejecting them. The overflow guard only caught the wrap-to-negative case, but a `float64` above `math.MaxInt64` **saturates** to a positive `math.MaxInt64` on conversion rather than wrapping negative — so `duration < 0` was never true.

This left two currently-failing tests on `main`: `TestParseDuration/very_large_hours_(overflow_test)` and `TestParseDuration/very_large_weeks`.

## Fix
Compute the nanosecond product as `float64` and reject it when it reaches `float64(math.MaxInt64)` before the lossy `float64`→`int64` conversion. The existing negative check stays as a backstop.

## Verification
- `ParseDuration("1e10h")` and `ParseDuration("999999w")` now return `(0, false)`.
- Valid large-but-in-range durations still parse.
- `TestParseDuration` passes; full suite green; `gofmt`/`go vet` clean.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duration parsing to better handle edge cases and prevent overflow conditions during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->