### PR TITLE
feat(review): add goal progress chart to buzz review (#170)

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -28,6 +28,9 @@ type Goal struct {
 	Deadline    int                   `json:"deadline"`   // Seconds by which deadline differs from midnight
 	Yaw         int                   `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
 	Dir         int                   `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
+	Kyoom       bool                  `json:"kyoom"`      // Whether the goal is cumulative (datapoints auto-sum into a running total)
+	Tmin        string                `json:"tmin"`       // Earliest date shown on the goal's graph (YYYY-MM-DD)
+	Tmax        string                `json:"tmax"`       // Latest date shown on the goal's graph (YYYY-MM-DD)
 	Curval      *float64              `json:"curval"`     // Most recent datapoint value
 	Goalval     *float64              `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
 	Mathishard  []*float64            `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)

--- a/chart.go
+++ b/chart.go
@@ -162,6 +162,11 @@ func processDatapoints(goal Goal, startTime, endTime time.Time) []timedValue {
 	return processed
 }
 
+// processCumulative builds the in-window plot series for a cumulative (kyoom)
+// goal: it sums every datapoint in chronological order so each in-window point
+// carries the running total, prepends a synthetic anchor at the window start
+// holding the total reached just before it, and returns nil when no datapoints
+// fall inside the window (so a pure carry-over never draws a dataless line).
 func processCumulative(goal Goal, startTime, endTime time.Time) []timedValue {
 	sorted := make([]Datapoint, len(goal.Datapoints))
 	copy(sorted, goal.Datapoints)

--- a/chart.go
+++ b/chart.go
@@ -116,7 +116,10 @@ func chartTimeframe(goal Goal, now time.Time) (start, end time.Time) {
 	if err != nil {
 		return start, now
 	}
-	end = end.Add(24*time.Hour - time.Second)
+	// Extend to the last second of the Tmax calendar day. Build it as the start
+	// of the next day minus one second (not +24h) so DST transitions — where a
+	// local day is 23h or 25h — don't spill into the next day or clip late ones.
+	end = time.Date(end.Year(), end.Month(), end.Day()+1, 0, 0, 0, 0, end.Location()).Add(-time.Second)
 	return start, end
 }
 

--- a/chart.go
+++ b/chart.go
@@ -67,10 +67,13 @@ func renderGoalChart(goal Goal, width int) string {
 	timeframeInfo := fmt.Sprintf("Timeframe: %s to %s", startTime.Format("Jan 2"), endTime.Format("Jan 2, 2006"))
 	chart.WriteString(chartStyle.Render(timeframeInfo) + "\n\n")
 
-	graphOutput := asciigraph.PlotMany([][]float64{datapointValues, roadValues},
+	// Plot the road first and the datapoints second: asciigraph lets a later
+	// series overwrite an earlier one in shared cells, so this keeps the
+	// datapoints (blue) drawn on top of the road (red) wherever they coincide.
+	graphOutput := asciigraph.PlotMany([][]float64{roadValues, datapointValues},
 		asciigraph.Height(chartHeight),
 		asciigraph.Width(chartWidth),
-		asciigraph.SeriesColors(asciigraph.Blue, asciigraph.Red),
+		asciigraph.SeriesColors(asciigraph.Red, asciigraph.Blue),
 		asciigraph.Caption("Blue: datapoints, Red: bright red line"),
 	)
 

--- a/chart.go
+++ b/chart.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"math"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -9,6 +11,10 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/guptarohit/asciigraph"
 )
+
+// ansiPattern strips SGR colour codes so we can measure asciigraph's output in
+// visible columns when aligning the x-axis beneath it.
+var ansiPattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 // chart dimensions
 const (
@@ -70,15 +76,24 @@ func renderGoalChart(goal Goal, width int) string {
 	// Plot the road first and the datapoints second: asciigraph lets a later
 	// series overwrite an earlier one in shared cells, so this keeps the
 	// datapoints (blue) drawn on top of the road (red) wherever they coincide.
+	// The caption is rendered ourselves (below) so the date axis can sit
+	// directly under the plot, above it.
 	graphOutput := asciigraph.PlotMany([][]float64{roadValues, datapointValues},
 		asciigraph.Height(chartHeight),
 		asciigraph.Width(chartWidth),
 		asciigraph.SeriesColors(asciigraph.Red, asciigraph.Blue),
-		asciigraph.Caption("Blue: datapoints, Red: bright red line"),
 	)
 
 	chart.WriteString(graphOutput)
 	chart.WriteString("\n")
+
+	// Date axis aligned to the plot columns (asciigraph has no native x-axis).
+	if axis := renderXAxis(startTime, endTime, plotGutterWidth(graphOutput), chartWidth); axis != "" {
+		chart.WriteString(axis + "\n")
+	}
+
+	captionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 2)
+	chart.WriteString(captionStyle.Render("Blue: datapoints, Red: bright red line") + "\n")
 
 	return chart.String()
 }
@@ -236,6 +251,87 @@ func datapointSeries(processed []timedValue, startTime, endTime time.Time, chart
 	}
 
 	return values
+}
+
+// plotGutterWidth returns the visible column index of asciigraph's y-axis
+// (the `┤`/`┼` rune), which is exactly one column left of the plot area. Those
+// axis runes appear only in the gutter, never in the plotted line, so the
+// first one on any row marks the boundary. Returns -1 if not found.
+func plotGutterWidth(graph string) int {
+	for _, line := range strings.Split(graph, "\n") {
+		plain := ansiPattern.ReplaceAllString(line, "")
+		for i, r := range []rune(plain) {
+			if r == '┤' || r == '┼' {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// renderXAxis builds a date axis (a tick row and a label row) aligned beneath a
+// chartWidth-wide plot whose first column sits at gutter+1. Ticks are spaced to
+// fit the width; the first label is left-aligned to its tick, the last
+// right-aligned, the rest centred, and any label that would collide with the
+// previous one is dropped. Returns "" when the gutter couldn't be located.
+func renderXAxis(start, end time.Time, gutter, chartWidth int) string {
+	if gutter < 0 || chartWidth < 2 {
+		return ""
+	}
+
+	plotStart := gutter + 1
+	total := plotStart + chartWidth
+
+	// One tick per ~18 columns, clamped so labels ("Jan 2") have room.
+	ticks := chartWidth/18 + 1
+	if ticks < 2 {
+		ticks = 2
+	}
+	if ticks > 6 {
+		ticks = 6
+	}
+
+	tickRow := make([]rune, total)
+	labelRow := make([]rune, total)
+	for i := range tickRow {
+		tickRow[i] = ' '
+		labelRow[i] = ' '
+	}
+
+	span := end.Sub(start)
+	lastLabelEnd := -1
+	for i := 0; i < ticks; i++ {
+		f := float64(i) / float64(ticks-1)
+		col := plotStart + int(math.Round(f*float64(chartWidth-1)))
+		if col >= total {
+			col = total - 1
+		}
+		tickRow[col] = '┬'
+
+		label := []rune(start.Add(time.Duration(float64(span) * f)).Format("Jan 2"))
+		var pos int
+		switch i {
+		case 0:
+			pos = col // left-align under the first tick
+		case ticks - 1:
+			pos = col - len(label) + 1 // right-align under the last tick
+		default:
+			pos = col - len(label)/2 // centre on the tick
+		}
+		if pos < 0 {
+			pos = 0
+		}
+		if pos+len(label) > total {
+			pos = total - len(label)
+		}
+		if pos <= lastLabelEnd {
+			continue // would collide with the previous label
+		}
+		copy(labelRow[pos:], label)
+		lastLabelEnd = pos + len(label) - 1
+	}
+
+	return strings.TrimRight(string(tickRow), " ") + "\n" + strings.TrimRight(string(labelRow), " ")
 }
 
 // getRoadValuesForTimeframe samples the bright red line at numPoints evenly

--- a/chart.go
+++ b/chart.go
@@ -84,12 +84,17 @@ func renderGoalChart(goal Goal, width int) string {
 		asciigraph.SeriesColors(asciigraph.Red, asciigraph.Blue),
 	)
 
-	chart.WriteString(graphOutput)
+	// Indent the plot and date axis by 2 to match the padding the header,
+	// caption, and review details use, so the chart isn't left-shifted from
+	// the rest of the review UI. The gutter is measured on the un-indented
+	// output, then plot and axis are shifted together.
+	gutter := plotGutterWidth(graphOutput)
+	chart.WriteString(indentLines(graphOutput, 2))
 	chart.WriteString("\n")
 
 	// Date axis aligned to the plot columns (asciigraph has no native x-axis).
-	if axis := renderXAxis(startTime, endTime, plotGutterWidth(graphOutput), chartWidth); axis != "" {
-		chart.WriteString(axis + "\n")
+	if axis := renderXAxis(startTime, endTime, gutter, chartWidth); axis != "" {
+		chart.WriteString(indentLines(axis, 2) + "\n")
 	}
 
 	captionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 2)
@@ -180,7 +185,11 @@ func processCumulative(goal Goal, startTime, endTime time.Time) []timedValue {
 		// Datapoints after endTime are ignored.
 	}
 
-	if len(processed) == 0 && startSum == 0 {
+	// No datapoints inside the window means nothing to chart — even if earlier
+	// datapoints pushed the running total above zero. (renderGoalChart's
+	// contract is to return empty when none fall inside the window; a lone
+	// carry-over anchor would otherwise draw a flat, dataless line.)
+	if len(processed) == 0 {
 		return nil
 	}
 
@@ -254,6 +263,19 @@ func datapointSeries(processed []timedValue, startTime, endTime time.Time, chart
 	}
 
 	return values
+}
+
+// indentLines prefixes n spaces to each non-empty line. Used to align the plot
+// and date axis with the 2-space padding the surrounding review UI uses.
+func indentLines(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		if ln != "" {
+			lines[i] = pad + ln
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // plotGutterWidth returns the visible column index of asciigraph's y-axis

--- a/chart.go
+++ b/chart.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/guptarohit/asciigraph"
+)
+
+// chart dimensions
+const (
+	chartHeight   = 10
+	minChartWidth = 40
+	maxChartWidth = 80
+)
+
+// renderGoalChart renders an ASCII chart of a goal's recent progress: the
+// goal's datapoints (blue) against its bright red line (red), over the graph
+// window the Beeminder API reports (tmin..tmax), falling back to the last 30
+// days. It returns "" when there is nothing chartable (no datapoints, or none
+// inside the window).
+func renderGoalChart(goal Goal, width int) string {
+	if len(goal.Datapoints) == 0 {
+		return ""
+	}
+
+	startTime, endTime := chartTimeframe(goal, time.Now())
+
+	processed := processDatapoints(goal, startTime, endTime)
+	if len(processed) == 0 {
+		return ""
+	}
+
+	chartWidth := width - 10 // leave room for padding and axis labels
+	if chartWidth < minChartWidth {
+		chartWidth = minChartWidth
+	}
+	if chartWidth > maxChartWidth {
+		chartWidth = maxChartWidth
+	}
+
+	roadValues := getRoadValuesForTimeframe(goal, startTime, endTime, chartWidth)
+	datapointValues := datapointSeries(processed, startTime, endTime, chartWidth)
+
+	var chart strings.Builder
+	chart.WriteString("\n")
+
+	chartStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("12")).
+		Padding(0, 2)
+
+	goalType := "Do More"
+	if goal.Yaw == -1 {
+		goalType = "Do Less"
+	}
+	cumulativeStr := ""
+	if goal.Kyoom {
+		cumulativeStr = " (Cumulative)"
+	}
+
+	header := fmt.Sprintf("Goal Progress Chart - %s%s", goalType, cumulativeStr)
+	chart.WriteString(chartStyle.Render(header) + "\n")
+
+	timeframeInfo := fmt.Sprintf("Timeframe: %s to %s", startTime.Format("Jan 2"), endTime.Format("Jan 2, 2006"))
+	chart.WriteString(chartStyle.Render(timeframeInfo) + "\n\n")
+
+	graphOutput := asciigraph.PlotMany([][]float64{datapointValues, roadValues},
+		asciigraph.Height(chartHeight),
+		asciigraph.Width(chartWidth),
+		asciigraph.SeriesColors(asciigraph.Blue, asciigraph.Red),
+		asciigraph.Caption("Blue: datapoints, Red: bright red line"),
+	)
+
+	chart.WriteString(graphOutput)
+	chart.WriteString("\n")
+
+	return chart.String()
+}
+
+// chartTimeframe resolves the [start, end] window to chart from the goal's
+// tmin/tmax (parsed in the user's local zone), falling back to the last 30
+// days when those are missing or unparseable. tmax is a calendar day, not an
+// instant, so it is extended to the end of that day — otherwise a datapoint
+// logged late on the tmax day (in local time) would fall outside the window.
+func chartTimeframe(goal Goal, now time.Time) (start, end time.Time) {
+	if goal.Tmin == "" || goal.Tmax == "" {
+		return now.AddDate(0, 0, -30), now
+	}
+
+	start, err := time.ParseInLocation("2006-01-02", goal.Tmin, time.Local)
+	if err != nil {
+		start = now.AddDate(0, 0, -30)
+	}
+	end, err = time.ParseInLocation("2006-01-02", goal.Tmax, time.Local)
+	if err != nil {
+		return start, now
+	}
+	end = end.Add(24*time.Hour - time.Second)
+	return start, end
+}
+
+// timedValue is a datapoint reduced to the two things the chart cares about:
+// when it landed and the value to plot (the raw value, or the running total
+// for cumulative goals).
+type timedValue struct {
+	timestamp int64
+	value     float64
+}
+
+// processDatapoints reduces a goal's datapoints to the series to plot within
+// [startTime, endTime], sorted by time.
+//
+// For cumulative (kyoom) goals the plotted value is the running total, so the
+// sum is accumulated across ALL datapoints (including those before the window)
+// and a synthetic anchor is prepended at startTime carrying the total reached
+// just before the window — otherwise the in-window line would start from zero
+// instead of where the goal actually stood.
+func processDatapoints(goal Goal, startTime, endTime time.Time) []timedValue {
+	if goal.Kyoom {
+		return processCumulative(goal, startTime, endTime)
+	}
+
+	var processed []timedValue
+	for _, dp := range goal.Datapoints {
+		dpTime := time.Unix(dp.Timestamp, 0)
+		if !dpTime.Before(startTime) && !dpTime.After(endTime) {
+			processed = append(processed, timedValue{timestamp: dp.Timestamp, value: dp.Value})
+		}
+	}
+	sort.Slice(processed, func(i, j int) bool {
+		return processed[i].timestamp < processed[j].timestamp
+	})
+	return processed
+}
+
+func processCumulative(goal Goal, startTime, endTime time.Time) []timedValue {
+	sorted := make([]Datapoint, len(goal.Datapoints))
+	copy(sorted, goal.Datapoints)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp < sorted[j].Timestamp
+	})
+
+	sum := 0.0
+	startSum := 0.0
+	var processed []timedValue
+	for _, dp := range sorted {
+		dpTime := time.Unix(dp.Timestamp, 0)
+		switch {
+		case dpTime.Before(startTime):
+			sum += dp.Value
+			startSum = sum
+		case !dpTime.After(endTime):
+			sum += dp.Value
+			processed = append(processed, timedValue{timestamp: dp.Timestamp, value: sum})
+		}
+		// Datapoints after endTime are ignored.
+	}
+
+	if len(processed) == 0 && startSum == 0 {
+		return nil
+	}
+
+	// Prepend an anchor at the window start carrying the running total so far,
+	// so the line begins where the goal actually stood rather than at zero.
+	return append([]timedValue{{timestamp: startTime.Unix(), value: startSum}}, processed...)
+}
+
+// datapointSeries maps processed datapoints onto chartWidth evenly-spaced
+// columns and fills the gaps: each datapoint lands in the column matching its
+// position in the timeframe, columns before the first / after the last hold
+// that endpoint's value, and interior gaps are linearly interpolated so the
+// plotted line is continuous.
+func datapointSeries(processed []timedValue, startTime, endTime time.Time, chartWidth int) []float64 {
+	values := make([]float64, chartWidth)
+	hasDatapoint := make([]bool, chartWidth)
+	duration := endTime.Sub(startTime).Seconds()
+
+	for _, dp := range processed {
+		col := 0
+		if duration > 0 {
+			progress := time.Unix(dp.timestamp, 0).Sub(startTime).Seconds() / duration
+			col = int(progress * float64(chartWidth-1))
+		}
+		if col < 0 {
+			col = 0
+		}
+		if col >= chartWidth {
+			col = chartWidth - 1
+		}
+		// processed is time-sorted, so a later datapoint correctly overwrites
+		// an earlier one sharing a column.
+		values[col] = dp.value
+		hasDatapoint[col] = true
+	}
+
+	firstDP, lastDP := -1, -1
+	for i := 0; i < chartWidth; i++ {
+		if hasDatapoint[i] {
+			if firstDP == -1 {
+				firstDP = i
+			}
+			lastDP = i
+		}
+	}
+	if firstDP < 0 {
+		return values
+	}
+
+	for i := 0; i < firstDP; i++ {
+		values[i] = values[firstDP]
+	}
+	for i := lastDP + 1; i < chartWidth; i++ {
+		values[i] = values[lastDP]
+	}
+
+	prevDP := firstDP
+	for i := firstDP + 1; i <= lastDP; i++ {
+		if !hasDatapoint[i] {
+			continue
+		}
+		if i > prevDP+1 {
+			startVal := values[prevDP]
+			endVal := values[i]
+			for j := prevDP + 1; j < i; j++ {
+				ratio := float64(j-prevDP) / float64(i-prevDP)
+				values[j] = startVal + ratio*(endVal-startVal)
+			}
+		}
+		prevDP = i
+	}
+
+	return values
+}
+
+// getRoadValuesForTimeframe samples the bright red line at numPoints evenly
+// distributed instants across [startTime, endTime] — one per chart column.
+func getRoadValuesForTimeframe(goal Goal, startTime, endTime time.Time, numPoints int) []float64 {
+	values := make([]float64, numPoints)
+	if len(goal.Roadall) == 0 {
+		return values
+	}
+	if numPoints == 1 {
+		values[0] = getRoadValueAtTime(goal, startTime)
+		return values
+	}
+
+	duration := endTime.Sub(startTime)
+	for i := 0; i < numPoints; i++ {
+		t := startTime.Add(time.Duration(float64(duration) * float64(i) / float64(numPoints-1)))
+		values[i] = getRoadValueAtTime(goal, t)
+	}
+	return values
+}
+
+// getRoadValueAtTime interpolates the bright red line's value at time t.
+//
+// Beeminder's roadall is a piecewise schedule: the first row is the anchor
+// (t, v set, r nil), and each subsequent row has exactly one of v/r null —
+// either the value at that t, or the rate (per runits) used to get there. To
+// interpolate we walk forward, materialising each row's value from the prior
+// anchor and the row's rate when the row's own value is missing.
+func getRoadValueAtTime(goal Goal, t time.Time) float64 {
+	if len(goal.Roadall) < 2 {
+		return 0
+	}
+
+	target := float64(t.Unix())
+
+	// Resolve the anchor (row 0): must have t and v set.
+	first := goal.Roadall[0]
+	if len(first) < 3 || first[0] == nil || first[1] == nil {
+		return 0
+	}
+	prevT := *first[0]
+	prevV := *first[1]
+
+	// Before the road starts: extrapolate backwards along the first segment's
+	// slope so the chart can still draw a value.
+	if target < prevT {
+		slope, ok := segmentSlopePerSecond(goal, 1, prevT, prevV)
+		if !ok {
+			return prevV
+		}
+		return prevV + slope*(target-prevT)
+	}
+
+	for i := 1; i < len(goal.Roadall); i++ {
+		cur := goal.Roadall[i]
+		if len(cur) < 3 || cur[0] == nil {
+			return prevV
+		}
+		curT := *cur[0]
+
+		// Per the Beeminder spec a non-anchor row has exactly one of v/r set.
+		// Both nil or both set is ambiguous — bail at the prior anchor rather
+		// than guess an interpretation (matches slope.go's validation).
+		if (cur[1] == nil) == (cur[2] == nil) {
+			return prevV
+		}
+
+		var curV float64
+		switch {
+		case cur[1] != nil:
+			curV = *cur[1]
+		case cur[2] != nil:
+			// ratePerDay passes unknown runits through unchanged, so a
+			// per-week rate would be misread as per-day. Bail rather than
+			// draw a dimensionally-wrong road.
+			if !isKnownRunits(goal.Runits) {
+				return prevV
+			}
+			rps := ratePerDay(*cur[2], goal.Runits) / 86400.0
+			curV = prevV + rps*(curT-prevT)
+		}
+
+		if target <= curT {
+			if curT == prevT {
+				return curV
+			}
+			frac := (target - prevT) / (curT - prevT)
+			return prevV + frac*(curV-prevV)
+		}
+
+		prevT = curT
+		prevV = curV
+	}
+
+	// Past the end of the road: hold the last materialised value.
+	return prevV
+}
+
+// segmentSlopePerSecond returns the slope (gunits/second) of the roadall
+// segment ending at index i, given the prior anchor (prevT, prevV). Used to
+// extrapolate before the start of the road. ok is false when the segment is
+// missing, malformed, ambiguous, or expressed in runits we can't translate.
+func segmentSlopePerSecond(goal Goal, i int, prevT, prevV float64) (float64, bool) {
+	if i >= len(goal.Roadall) {
+		return 0, false
+	}
+	cur := goal.Roadall[i]
+	if len(cur) < 3 || cur[0] == nil {
+		return 0, false
+	}
+	// Ambiguous rows (both v/r nil or both set) are malformed per the spec —
+	// bail rather than pick an interpretation. Mirrors getRoadValueAtTime.
+	if (cur[1] == nil) == (cur[2] == nil) {
+		return 0, false
+	}
+	if cur[2] != nil {
+		if !isKnownRunits(goal.Runits) {
+			return 0, false
+		}
+		return ratePerDay(*cur[2], goal.Runits) / 86400.0, true
+	}
+	dt := *cur[0] - prevT
+	if dt == 0 {
+		return 0, false
+	}
+	return (*cur[1] - prevV) / dt, true
+}

--- a/chart_test.go
+++ b/chart_test.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// roadallRow builds a Beeminder-style roadall row. Pass nil for v or r to
+// leave that column unset (rows past the anchor have exactly one of v/r).
+func roadallRow(t float64, v, r *float64) []*float64 {
+	tp := t
+	return []*float64{&tp, v, r}
+}
+
+func fptr(f float64) *float64 { return &f }
+
+func TestRenderGoalChartWithNoDatapoints(t *testing.T) {
+	goal := Goal{
+		Slug:       "test-goal",
+		Datapoints: []Datapoint{},
+	}
+
+	if chart := renderGoalChart(goal, 80); chart != "" {
+		t.Error("Expected empty chart for goal with no datapoints")
+	}
+}
+
+func TestRenderGoalChartWithDatapoints(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+
+	goal := Goal{
+		Slug: "test-goal",
+		Yaw:  1, // Do more
+		Datapoints: []Datapoint{
+			{Timestamp: yesterday.Unix(), Value: 5.0},
+			{Timestamp: now.Unix(), Value: 10.0},
+		},
+		Tmin: yesterday.Format("2006-01-02"),
+		Tmax: now.Format("2006-01-02"),
+		Roadall: [][]*float64{
+			roadallRow(float64(yesterday.Unix()), fptr(0.0), nil),
+			roadallRow(float64(now.Unix()), fptr(5.0), nil),
+		},
+	}
+
+	chart := renderGoalChart(goal, 80)
+	if chart == "" {
+		t.Fatal("Expected non-empty chart for goal with datapoints")
+	}
+	if !strings.Contains(chart, "Goal Progress Chart") {
+		t.Error("Expected chart to contain 'Goal Progress Chart'")
+	}
+	if !strings.Contains(chart, "Do More") {
+		t.Error("Expected chart to contain 'Do More'")
+	}
+	if !strings.Contains(chart, "datapoints") && !strings.Contains(chart, "bright red line") {
+		t.Error("Expected chart to contain caption")
+	}
+}
+
+func TestRenderGoalChartCumulative(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+
+	goal := Goal{
+		Slug:  "test-goal",
+		Yaw:   1, // Do more
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: yesterday.Unix(), Value: 5.0},
+			{Timestamp: now.Unix(), Value: 3.0},
+		},
+		Tmin: yesterday.Format("2006-01-02"),
+		Tmax: now.Format("2006-01-02"),
+	}
+
+	chart := renderGoalChart(goal, 80)
+	if chart == "" {
+		t.Fatal("Expected non-empty chart for cumulative goal")
+	}
+	if !strings.Contains(chart, "Cumulative") {
+		t.Error("Expected chart to indicate cumulative goal")
+	}
+}
+
+func TestRenderGoalChartDoLess(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+
+	goal := Goal{
+		Slug: "test-goal",
+		Yaw:  -1, // Do less
+		Datapoints: []Datapoint{
+			{Timestamp: yesterday.Unix(), Value: 10.0},
+			{Timestamp: now.Unix(), Value: 5.0},
+		},
+		Tmin: yesterday.Format("2006-01-02"),
+		Tmax: now.Format("2006-01-02"),
+	}
+
+	chart := renderGoalChart(goal, 80)
+	if chart == "" {
+		t.Fatal("Expected non-empty chart for do less goal")
+	}
+	if !strings.Contains(chart, "Do Less") {
+		t.Error("Expected chart to indicate 'Do Less' goal")
+	}
+}
+
+func TestRenderGoalChartIncludesEndOfTmaxDay(t *testing.T) {
+	// Regression: Tmax is a date, not an instant, so a datapoint logged late
+	// on the user's local Tmax day must still fall inside the chart window.
+	tmax := time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local)
+	dpTime := time.Date(2024, 1, 15, 23, 30, 0, 0, time.Local)
+
+	goal := Goal{
+		Slug: "boundary",
+		Yaw:  1,
+		Tmin: tmax.AddDate(0, 0, -7).Format("2006-01-02"),
+		Tmax: tmax.Format("2006-01-02"),
+		Datapoints: []Datapoint{
+			{Timestamp: dpTime.Unix(), Value: 1.0},
+		},
+	}
+
+	if chart := renderGoalChart(goal, 80); chart == "" {
+		t.Error("expected datapoint at 23:30 local on Tmax to be included; chart is empty")
+	}
+}
+
+func TestRenderGoalChartWithFallbackTimeframe(t *testing.T) {
+	now := time.Now()
+	thirtyDaysAgo := now.AddDate(0, 0, -30)
+
+	goal := Goal{
+		Slug: "test-goal",
+		Yaw:  1,
+		Datapoints: []Datapoint{
+			{Timestamp: thirtyDaysAgo.Unix(), Value: 5.0},
+			{Timestamp: now.Unix(), Value: 10.0},
+		},
+		// No Tmin/Tmax - should use fallback
+	}
+
+	if chart := renderGoalChart(goal, 80); chart == "" {
+		t.Error("Expected non-empty chart even without tmin/tmax")
+	}
+}
+
+func TestGetRoadValueAtTime(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Anchor at v=0, then a rate-only segment 10 days later at 1/day; day 5
+	// should interpolate to ~5.
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), nil, fptr(1.0)),
+		},
+	}
+
+	if value := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, 5)); value < 4.9 || value > 5.1 {
+		t.Errorf("Expected value around 5.0, got %f", value)
+	}
+}
+
+func TestGetRoadValuesForTimeframe(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := baseTime.AddDate(0, 0, 10)
+
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(endTime.Unix()), fptr(10.0), nil),
+		},
+	}
+
+	values := getRoadValuesForTimeframe(goal, baseTime, endTime, 11)
+	if len(values) != 11 {
+		t.Fatalf("Expected 11 values, got %d", len(values))
+	}
+	if values[0] < -0.5 || values[0] > 0.5 {
+		t.Errorf("Expected first value around 0, got %f", values[0])
+	}
+	if values[10] < 9.5 || values[10] > 10.5 {
+		t.Errorf("Expected last value around 10, got %f", values[10])
+	}
+}
+
+func TestGetRoadValueAtTimeShortRoad(t *testing.T) {
+	// Fewer than 2 rows is unusable — short-circuit to 0 rather than deref.
+	if v := getRoadValueAtTime(Goal{}, time.Now()); v != 0 {
+		t.Errorf("empty roadall: expected 0, got %f", v)
+	}
+	single := Goal{Roadall: [][]*float64{roadallRow(0, fptr(5.0), nil)}}
+	if v := getRoadValueAtTime(single, time.Now()); v != 0 {
+		t.Errorf("single-row roadall: expected 0, got %f", v)
+	}
+}
+
+func TestGetRoadValueAtTimePastEndOfRoad(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), fptr(10.0), nil),
+		},
+	}
+	if got := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, 20)); got < 9.9 || got > 10.1 {
+		t.Errorf("past end of road: expected ~10, got %f", got)
+	}
+}
+
+func TestGetRoadValueAtTimeBeforeAnchorAmbiguousRow(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Row 1 has both v and r set (malformed). The before-anchor branch must
+	// bail rather than extrapolate from one interpretation.
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), fptr(10.0), fptr(1.0)),
+		},
+	}
+	if got := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, -5)); got != 0 {
+		t.Errorf("before-anchor ambiguous row: expected 0 (anchor value), got %f", got)
+	}
+}
+
+func TestGetRoadValueAtTimeBeforeAnchorUnknownRunits(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Backward extrapolation with runits we can't translate must bail to the
+	// anchor value rather than apply a dimensionally-wrong slope.
+	goal := Goal{
+		Runits: "lightyears",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), nil, fptr(1.0)),
+		},
+	}
+	if got := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, -5)); got != 0 {
+		t.Errorf("before-anchor unknown runits: expected 0 (anchor value), got %f", got)
+	}
+}
+
+func TestGetRoadValueAtTimeBeforeAnchor(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), nil, fptr(1.0)),
+		},
+	}
+	// Five days before the anchor → extrapolate at -1/day → ~-5.
+	if got := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, -5)); got < -5.1 || got > -4.9 {
+		t.Errorf("before anchor extrapolation: expected ~-5, got %f", got)
+	}
+}
+
+func TestGetRoadValueAtTimeUnknownRunits(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Rate-only segment with unrecognised runits → bail rather than treat the
+	// rate as gunits/day.
+	goal := Goal{
+		Runits: "lightyears",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), nil, fptr(1.0)),
+		},
+	}
+	if got := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, 5)); got != 0 {
+		t.Errorf("unknown runits: expected 0 (bail), got %f", got)
+	}
+}
+
+func TestGetRoadValueAtTimeAmbiguousRow(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Non-anchor row with both v and r set is ambiguous; bail to the prior
+	// anchor (0) rather than guess.
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(baseTime.AddDate(0, 0, 10).Unix()), fptr(10.0), fptr(1.0)),
+		},
+	}
+	if got := getRoadValueAtTime(goal, baseTime.AddDate(0, 0, 5)); got != 0 {
+		t.Errorf("ambiguous row: expected prior anchor value 0, got %f", got)
+	}
+}
+
+func TestGetRoadValuesForTimeframeSinglePoint(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := baseTime.AddDate(0, 0, 10)
+	goal := Goal{
+		Runits: "d",
+		Roadall: [][]*float64{
+			roadallRow(float64(baseTime.Unix()), fptr(0.0), nil),
+			roadallRow(float64(endTime.Unix()), fptr(10.0), nil),
+		},
+	}
+	// numPoints==1 must not divide by (numPoints-1); it returns a single
+	// sample at startTime.
+	values := getRoadValuesForTimeframe(goal, baseTime.AddDate(0, 0, 5), endTime, 1)
+	if len(values) != 1 {
+		t.Fatalf("expected 1 value, got %d", len(values))
+	}
+	if values[0] < 4.9 || values[0] > 5.1 {
+		t.Errorf("numPoints=1 sample: expected ~5, got %f", values[0])
+	}
+}
+
+func TestGetRoadValuesForTimeframeEmpty(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := baseTime.AddDate(0, 0, 10)
+
+	goal := Goal{Roadall: [][]*float64{}} // No road data
+
+	values := getRoadValuesForTimeframe(goal, baseTime, endTime, 10)
+	if len(values) != 10 {
+		t.Fatalf("Expected 10 values, got %d", len(values))
+	}
+	for i, v := range values {
+		if v != 0 {
+			t.Errorf("Expected value at index %d to be 0, got %f", i, v)
+		}
+	}
+}

--- a/chart_test.go
+++ b/chart_test.go
@@ -446,3 +446,40 @@ func TestRenderGoalChartCumulativeAllBeforeWindow(t *testing.T) {
 		t.Errorf("expected empty chart when no datapoints fall in the window, got:\n%s", chart)
 	}
 }
+
+func TestProcessCumulativeValues(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 2)
+
+	check := func(name string, got []timedValue, want []float64) {
+		if len(got) != len(want) {
+			t.Fatalf("%s: got %d values, want %d", name, len(got), len(want))
+		}
+		for i, w := range want {
+			if got[i].value != w {
+				t.Errorf("%s: value[%d] = %v, want %v", name, i, got[i].value, w)
+			}
+		}
+	}
+
+	// Two datapoints inside the window, nothing before it: the anchor carries 0,
+	// then the running total reaches 5, then 8.
+	check("in-window", processCumulative(Goal{
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: start.Unix(), Value: 5},
+			{Timestamp: start.AddDate(0, 0, 1).Unix(), Value: 3},
+		},
+	}, start, end), []float64{0, 5, 8})
+
+	// A datapoint before the window feeds the carry-over anchor (10) but isn't
+	// itself plotted; in-window points continue the running total: 15, then 18.
+	check("carry-over", processCumulative(Goal{
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: start.AddDate(0, 0, -1).Unix(), Value: 10},
+			{Timestamp: start.Unix(), Value: 5},
+			{Timestamp: start.AddDate(0, 0, 1).Unix(), Value: 3},
+		},
+	}, start, end), []float64{10, 15, 18})
+}

--- a/chart_test.go
+++ b/chart_test.go
@@ -483,3 +483,59 @@ func TestProcessCumulativeValues(t *testing.T) {
 		},
 	}, start, end), []float64{10, 15, 18})
 }
+
+func TestProcessDatapointsNonCumulative(t *testing.T) {
+	start := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 5)
+
+	// Non-cumulative goal: only in-window points, sorted ascending, raw values.
+	goal := Goal{
+		Datapoints: []Datapoint{
+			{Timestamp: start.AddDate(0, 0, 3).Unix(), Value: 30},  // in window, later
+			{Timestamp: start.AddDate(0, 0, -2).Unix(), Value: 99}, // before window → excluded
+			{Timestamp: start.AddDate(0, 0, 1).Unix(), Value: 10},  // in window, earlier
+			{Timestamp: end.AddDate(0, 0, 2).Unix(), Value: 88},    // after window → excluded
+		},
+	}
+
+	got := processDatapoints(goal, start, end)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 in-window datapoints, got %d", len(got))
+	}
+	if got[0].timestamp >= got[1].timestamp {
+		t.Error("expected datapoints sorted ascending by timestamp")
+	}
+	if got[0].value != 10 || got[1].value != 30 {
+		t.Errorf("expected raw (un-summed) values [10 30], got [%v %v]", got[0].value, got[1].value)
+	}
+}
+
+func TestDatapointSeriesInterpolation(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 10)
+
+	// Endpoints at the first/last columns; interior columns linearly interpolated.
+	got := datapointSeries([]timedValue{
+		{timestamp: start.Unix(), value: 0},
+		{timestamp: end.Unix(), value: 100},
+	}, start, end, 11)
+	if len(got) != 11 {
+		t.Fatalf("expected 11 columns, got %d", len(got))
+	}
+	if got[0] != 0 || got[10] != 100 {
+		t.Errorf("endpoints: got[0]=%v got[10]=%v, want 0 and 100", got[0], got[10])
+	}
+	if got[5] < 49.9 || got[5] > 50.1 {
+		t.Errorf("midpoint interpolation: got[5]=%v, want ~50", got[5])
+	}
+
+	// A single datapoint fills the whole row with its value (no gaps, no NaN).
+	single := datapointSeries([]timedValue{
+		{timestamp: start.AddDate(0, 0, 5).Unix(), value: 7},
+	}, start, end, 11)
+	for i, v := range single {
+		if v != 7 {
+			t.Errorf("single datapoint flat-fill: col %d = %v, want 7", i, v)
+		}
+	}
+}

--- a/chart_test.go
+++ b/chart_test.go
@@ -401,3 +401,28 @@ func TestRenderGoalChartHasDateAxis(t *testing.T) {
 		t.Error("expected an x-axis tick row in the rendered chart")
 	}
 }
+
+func TestChartTimeframeTmaxAcrossDSTFallBack(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("tz data unavailable")
+	}
+	orig := time.Local
+	time.Local = loc
+	defer func() { time.Local = orig }()
+
+	// 2023-11-05 is a 25h day in New York (DST ends 02:00). The old
+	// midnight+24h-1s math landed at 22:59:59 local, wrongly excluding a
+	// datapoint logged at 23:30 that same day.
+	g := Goal{Tmin: "2023-10-29", Tmax: "2023-11-05"}
+	_, end := chartTimeframe(g, time.Now())
+
+	dp := time.Date(2023, 11, 5, 23, 30, 0, 0, loc)
+	if dp.After(end) {
+		t.Errorf("23:30 on a 25h DST day excluded: end=%s dp=%s", end, dp)
+	}
+	// End must stay within the Tmax calendar day, not spill into the next.
+	if end.Day() != 5 {
+		t.Errorf("end spilled past the Tmax day: %s", end)
+	}
+}

--- a/chart_test.go
+++ b/chart_test.go
@@ -331,3 +331,73 @@ func TestGetRoadValuesForTimeframeEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderXAxisAlignment(t *testing.T) {
+	start := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	gutter, chartWidth := 7, 80
+
+	axis := renderXAxis(start, end, gutter, chartWidth)
+	if axis == "" {
+		t.Fatal("expected a non-empty axis")
+	}
+	lines := strings.Split(axis, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected tick row + label row, got %d lines", len(lines))
+	}
+	tickRow, labelRow := lines[0], lines[1]
+
+	// Measure tick positions in runes ('┬' is multi-byte, so byte offsets lie).
+	ticks := []rune(tickRow)
+	first, last := -1, -1
+	for i, r := range ticks {
+		if r == '┬' {
+			if first < 0 {
+				first = i
+			}
+			last = i
+		}
+	}
+	// First tick sits at the first plot column (gutter+1); last at the last.
+	if first != gutter+1 {
+		t.Errorf("first tick at col %d, want %d", first, gutter+1)
+	}
+	if last != gutter+chartWidth {
+		t.Errorf("last tick at col %d, want %d", last, gutter+chartWidth)
+	}
+	// Endpoints' dates appear, in order.
+	if !strings.Contains(labelRow, "May 7") {
+		t.Errorf("label row missing start date: %q", labelRow)
+	}
+	if !strings.Contains(labelRow, "Jun 6") {
+		t.Errorf("label row missing end date: %q", labelRow)
+	}
+	// Nothing spills into the y-axis gutter.
+	if strings.TrimSpace(labelRow[:gutter+1]) != "" {
+		t.Errorf("label row writes into the gutter: %q", labelRow[:gutter+1])
+	}
+}
+
+func TestRenderXAxisNoGutter(t *testing.T) {
+	if got := renderXAxis(time.Now(), time.Now().AddDate(0, 0, 1), -1, 80); got != "" {
+		t.Errorf("expected empty axis when gutter not found, got %q", got)
+	}
+}
+
+func TestRenderGoalChartHasDateAxis(t *testing.T) {
+	now := time.Now()
+	goal := Goal{
+		Slug: "axis", Yaw: 1,
+		Datapoints: []Datapoint{
+			{Timestamp: now.AddDate(0, 0, -20).Unix(), Value: 1},
+			{Timestamp: now.Unix(), Value: 5},
+		},
+	}
+	chart := renderGoalChart(goal, 100)
+	if chart == "" {
+		t.Fatal("expected a chart")
+	}
+	if !strings.Contains(chart, "┬") {
+		t.Error("expected an x-axis tick row in the rendered chart")
+	}
+}

--- a/chart_test.go
+++ b/chart_test.go
@@ -55,7 +55,7 @@ func TestRenderGoalChartWithDatapoints(t *testing.T) {
 	if !strings.Contains(chart, "Do More") {
 		t.Error("Expected chart to contain 'Do More'")
 	}
-	if !strings.Contains(chart, "datapoints") && !strings.Contains(chart, "bright red line") {
+	if !strings.Contains(chart, "datapoints") || !strings.Contains(chart, "bright red line") {
 		t.Error("Expected chart to contain caption")
 	}
 }
@@ -424,5 +424,25 @@ func TestChartTimeframeTmaxAcrossDSTFallBack(t *testing.T) {
 	// End must stay within the Tmax calendar day, not spill into the next.
 	if end.Day() != 5 {
 		t.Errorf("end spilled past the Tmax day: %s", end)
+	}
+}
+
+func TestRenderGoalChartCumulativeAllBeforeWindow(t *testing.T) {
+	// Cumulative goal whose only datapoints predate the 30-day window. There
+	// are no in-window datapoints, so no chart should render even though the
+	// running total is non-zero (a lone carry-over anchor must not draw a line).
+	old := time.Now().AddDate(0, 0, -60).Unix()
+	goal := Goal{
+		Slug:  "stale",
+		Yaw:   1,
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: old, Value: 5.0},
+			{Timestamp: old + 3600, Value: 7.0},
+		},
+		// No Tmin/Tmax → 30-day fallback window, which excludes both points.
+	}
+	if chart := renderGoalChart(goal, 100); chart != "" {
+		t.Errorf("expected empty chart when no datapoints fall in the window, got:\n%s", chart)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -358,6 +358,14 @@ func (c *HTTPClient) FetchGoalsWithDatapoints(ctx context.Context) ([]Goal, erro
 					continue
 				}
 				goals[i].Datapoints = goalWithDatapoints.Datapoints
+				// Retain the per-goal fields the bulk list endpoint omits
+				// but the review chart needs (road, graph window, cumulative
+				// flag, good side).
+				goals[i].Roadall = goalWithDatapoints.Roadall
+				goals[i].Tmin = goalWithDatapoints.Tmin
+				goals[i].Tmax = goalWithDatapoints.Tmax
+				goals[i].Kyoom = goalWithDatapoints.Kyoom
+				goals[i].Yaw = goalWithDatapoints.Yaw
 			}
 		}()
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.1
-	github.com/guptarohit/asciigraph v0.7.3
+	github.com/guptarohit/asciigraph v0.9.0
 	github.com/muesli/termenv v0.16.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.1
+	github.com/guptarohit/asciigraph v0.7.3
 	github.com/muesli/termenv v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/guptarohit/asciigraph v0.7.3 h1:p05XDDn7cBTWiBqWb30mrwxd6oU0claAjqeytllnsPY=
+github.com/guptarohit/asciigraph v0.7.3/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/guptarohit/asciigraph v0.7.3 h1:p05XDDn7cBTWiBqWb30mrwxd6oU0claAjqeytllnsPY=
-github.com/guptarohit/asciigraph v0.7.3/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
+github.com/guptarohit/asciigraph v0.9.0 h1:MvCSRRVkT2XvU1IO6n92o7l7zqx1DiFaoszOUZQztbY=
+github.com/guptarohit/asciigraph v0.9.0/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/review.go
+++ b/review.go
@@ -175,6 +175,12 @@ func (m reviewModel) View() string {
 
 	view += detailStyle.Render(details) + "\n"
 
+	// Progress chart (datapoints vs. bright red line). Empty when the goal has
+	// no datapoints or none inside the charted window.
+	if chart := renderGoalChart(goal, m.width); chart != "" {
+		view += chart
+	}
+
 	// Error message section (if any)
 	if m.err != "" {
 		errorStyle := lipgloss.NewStyle().


### PR DESCRIPTION
Fresh reimplementation of the goal-progress chart feature (replacing the stale #173, which had drifted ~50 files behind `main` and conflicted with the recent rate-display work).

## Screenshots

`buzz review` with the progress chart — datapoints (blue) over the bright red line (red), with a date-labeled x-axis.

| Cumulative (Do More) | Non-cumulative (Do More) |
|---|---|
| ![buzz review chart — cumulative goal](https://narthur-uploads.surge.sh/ae62d34865fe.png) | ![buzz review chart — non-cumulative goal](https://narthur-uploads.surge.sh/358903e61a2a.png) |

## What it does
`buzz review` now draws an ASCII chart of each goal's recent progress beneath the existing details: the goal's **datapoints (blue)** against its **bright red line (red)**.

```
  Goal: active
  Pledge:      $5.00
  Rate:        60 minutes / day
  Goal Progress Chart - Do More (Cumulative)
  Timeframe: May 7 to Jun 6, 2026
 63989 ┤                                          ╭─────────╭─────
   ...
 62354 ┼╯
              Blue: datapoints, Red: bright red line
```

- **Timeframe**: the goal's graph window (`tmin`..`tmax`) when an end date is set, else the last 30 days. (`tmax` is null on most goals, so the 30-day window is the common path.)
- **Cumulative (`kyoom`) goals** plot the running total, with a synthetic anchor at the window start so the line begins where the goal actually stands rather than at zero.
- **Road interpolation** walks `roadall`'s piecewise schedule, materialising rate-only rows, extrapolating before the anchor, and bailing safely on ambiguous rows or untranslatable runits.

## Design notes
- Chart logic is self-contained in **`chart.go`** with a full unit suite in **`chart_test.go`** (17 tests: cumulative/non-cumulative, do-more/do-less, fallback window, tmax-day boundary, road edge cases).
- Renders **synchronously** in `review.View()` — no async loading machinery. The data is already loaded by the existing `FetchGoalsWithDatapoints`, which now simply **retains** the `roadall`/`tmin`/`tmax`/`kyoom` fields it was previously discarding. Integration footprint is a single `if` in `View()` plus the field-retention in the fetch.
- New dependency: `github.com/guptarohit/asciigraph`.

## Verification
- `go build`, full `go test ./...`, `go vet`, `gofmt` all clean.
- Ran `buzz review` against live Beeminder data: chart renders correctly for cumulative do-more goals; confirmed `roadall` present on all 63 goals and datapoints on 62.

## Known limitation (pre-existing, not introduced here)
`buzz review` already fetches every goal's datapoints up front (`FetchGoalsWithDatapoints`), which for this account (~63 goals) takes ~50s before the TUI appears. This predates the chart feature — the detail view depends on the same fetch. Worth a follow-up to lazy-load per goal, but out of scope here.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual ASCII progress charts in goal details, with timeframe bounds and cumulative/reduction handling for accurate rendering.
* **Bug Fixes**
  * Charts now appear consistently for goals fetched via bulk listing.
* **Tests**
  * Added comprehensive tests covering chart rendering, x‑axis alignment, and road/progression logic.
* **Chores**
  * Added a plotting/graphing library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
