### PR TITLE
perf(review): lazy-load goal details so the TUI opens instantly

### DIFF
--- a/review.go
+++ b/review.go
@@ -186,11 +186,18 @@ func (m reviewModel) View() string {
 		return "No goals to review.\n\nPress q to quit."
 	}
 
-	// Prefer the lazily-fetched full goal (datapoints + road) once it's loaded;
-	// until then render the summary fields from the bulk goal list.
+	// Start from the bulk summary goal, then merge in only the fields the
+	// per-goal detail fetch adds (datapoints + the chart's road/window inputs).
+	// Merging rather than replacing keeps the summary fields (title, limsum,
+	// deadline, …) intact even if a detail response is ever sparse.
 	goal := m.goals[m.current]
 	if d, ok := m.details[goal.Slug]; ok {
-		goal = *d
+		goal.Datapoints = d.Datapoints
+		goal.Roadall = d.Roadall
+		goal.Tmin = d.Tmin
+		goal.Tmax = d.Tmax
+		goal.Kyoom = d.Kyoom
+		goal.Yaw = d.Yaw
 	}
 
 	// Create the goal details view

--- a/review.go
+++ b/review.go
@@ -31,8 +31,11 @@ func handleReviewCommand() {
 
 	client := NewHTTPClient(config)
 
-	// Fetch goals with their recent datapoints
-	goals, err := client.FetchGoalsWithDatapoints(context.Background())
+	// Fetch just the goal list (one request) so the TUI opens immediately. Each
+	// goal's datapoints and road are loaded lazily on demand as the user views
+	// it (see fetchGoalDetailsCmd), instead of fetching every goal up front —
+	// which took ~50s for accounts with many goals.
+	goals, err := client.FetchGoals(context.Background())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to fetch goals: %s\n", redactError(err))
 		os.Exit(1)
@@ -57,6 +60,8 @@ func handleReviewCommand() {
 // reviewModel holds the state for the review command
 type reviewModel struct {
 	goals   []Goal
+	details map[string]*Goal // lazily-fetched full goals (datapoints, road, …) keyed by slug
+	loading bool             // a detail fetch for the current goal is in flight
 	config  *Config
 	current int    // current goal index
 	width   int    // terminal width
@@ -68,13 +73,49 @@ type reviewModel struct {
 func initialReviewModel(goals []Goal, config *Config) reviewModel {
 	return reviewModel{
 		goals:   goals,
+		details: make(map[string]*Goal),
 		config:  config,
 		current: 0,
+		// Init dispatches the first goal's details fetch, so show the loading
+		// indicator from the very first frame.
+		loading: len(goals) > 0,
 	}
 }
 
+// goalDetailsMsg carries the result of a lazy per-goal details fetch.
+type goalDetailsMsg struct {
+	slug string
+	goal *Goal
+	err  error
+}
+
+// fetchGoalDetailsCmd fetches one goal's full details (datapoints + road) in the
+// background so the TUI opens immediately and navigation stays responsive.
+func fetchGoalDetailsCmd(config *Config, slug string) tea.Cmd {
+	return func() tea.Msg {
+		goal, err := NewHTTPClient(config).FetchGoalWithDatapoints(context.Background(), slug)
+		return goalDetailsMsg{slug: slug, goal: goal, err: err}
+	}
+}
+
+// ensureDetails returns a command to fetch the current goal's details if they
+// aren't cached yet, updating the loading flag accordingly.
+func (m *reviewModel) ensureDetails() tea.Cmd {
+	if len(m.goals) == 0 {
+		m.loading = false
+		return nil
+	}
+	slug := m.goals[m.current].Slug
+	if _, ok := m.details[slug]; ok {
+		m.loading = false
+		return nil
+	}
+	m.loading = true
+	return fetchGoalDetailsCmd(m.config, slug)
+}
+
 func (m reviewModel) Init() tea.Cmd {
-	return nil
+	return m.ensureDetails()
 }
 
 func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -82,6 +123,24 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		return m, nil
+
+	case goalDetailsMsg:
+		// Cache the result regardless of which goal is now current (the user
+		// may have navigated on). Only touch loading/err for the current goal.
+		isCurrent := len(m.goals) > 0 && msg.slug == m.goals[m.current].Slug
+		if msg.err != nil {
+			if isCurrent {
+				m.loading = false
+				m.err = fmt.Sprintf("Failed to load goal details: %s", redactError(msg.err))
+			}
+			return m, nil
+		}
+		m.details[msg.slug] = msg.goal
+		if isCurrent {
+			m.loading = false
+			m.err = ""
+		}
 		return m, nil
 
 	case tea.KeyMsg:
@@ -95,7 +154,7 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.current++
 			}
 			m.err = ""
-			return m, nil
+			return m, m.ensureDetails()
 
 		case "left", "h", "p", "k":
 			// Previous goal
@@ -103,7 +162,7 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.current--
 			}
 			m.err = ""
-			return m, nil
+			return m, m.ensureDetails()
 
 		case "o", "enter":
 			// Open current goal in browser
@@ -127,7 +186,12 @@ func (m reviewModel) View() string {
 		return "No goals to review.\n\nPress q to quit."
 	}
 
+	// Prefer the lazily-fetched full goal (datapoints + road) once it's loaded;
+	// until then render the summary fields from the bulk goal list.
 	goal := m.goals[m.current]
+	if d, ok := m.details[goal.Slug]; ok {
+		goal = *d
+	}
 
 	// Create the goal details view
 	var view string
@@ -179,6 +243,14 @@ func (m reviewModel) View() string {
 	// no datapoints or none inside the charted window.
 	if chart := renderGoalChart(goal, m.width); chart != "" {
 		view += chart
+	}
+
+	// Loading indicator while this goal's datapoints/chart are being fetched.
+	if m.loading {
+		loadingStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Padding(0, 2)
+		view += loadingStyle.Render("Loading datapoints…") + "\n"
 	}
 
 	// Error message section (if any)

--- a/review.go
+++ b/review.go
@@ -49,8 +49,15 @@ func handleReviewCommand() {
 	// Sort goals alphabetically by slug as specified
 	SortGoalsBySlug(goals)
 
+	// Long-lived context cancelled when the TUI exits, so in-flight lazy detail
+	// fetches don't outlive the program (per the client.go context contract).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Launch the interactive review TUI
-	p := tea.NewProgram(initialReviewModel(goals, config), tea.WithAltScreen())
+	model := initialReviewModel(goals, config)
+	model.ctx = ctx
+	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
 		os.Exit(1)
@@ -59,27 +66,35 @@ func handleReviewCommand() {
 
 // reviewModel holds the state for the review command
 type reviewModel struct {
-	goals   []Goal
-	details map[string]*Goal // lazily-fetched full goals (datapoints, road, …) keyed by slug
-	loading bool             // a detail fetch for the current goal is in flight
-	config  *Config
-	current int    // current goal index
-	width   int    // terminal width
-	height  int    // terminal height
-	err     string // error message to display
+	goals    []Goal
+	details  map[string]*Goal    // lazily-fetched full goals (datapoints, road, …) keyed by slug
+	inFlight map[string]struct{} // slugs with a detail fetch currently in flight (dedup)
+	loading  bool                // a detail fetch for the current goal is in flight
+	ctx      context.Context     // cancelled when the TUI exits; cancels in-flight fetches
+	config   *Config
+	current  int    // current goal index
+	width    int    // terminal width
+	height   int    // terminal height
+	err      string // error message to display
 }
 
-// initialReviewModel creates a new review model
+// initialReviewModel creates a new review model. The first goal's details fetch
+// is dispatched by Init; because Init can't persist model state (it returns only
+// a Cmd), the constructor pre-marks that goal as in-flight and loading here.
 func initialReviewModel(goals []Goal, config *Config) reviewModel {
-	return reviewModel{
-		goals:   goals,
-		details: make(map[string]*Goal),
-		config:  config,
-		current: 0,
-		// Init dispatches the first goal's details fetch, so show the loading
-		// indicator from the very first frame.
-		loading: len(goals) > 0,
+	m := reviewModel{
+		goals:    goals,
+		details:  make(map[string]*Goal),
+		inFlight: make(map[string]struct{}),
+		ctx:      context.Background(), // overridden with a cancellable ctx by handleReviewCommand
+		config:   config,
+		current:  0,
+		loading:  len(goals) > 0,
 	}
+	if len(goals) > 0 {
+		m.inFlight[goals[0].Slug] = struct{}{}
+	}
+	return m
 }
 
 // goalDetailsMsg carries the result of a lazy per-goal details fetch.
@@ -90,16 +105,19 @@ type goalDetailsMsg struct {
 }
 
 // fetchGoalDetailsCmd fetches one goal's full details (datapoints + road) in the
-// background so the TUI opens immediately and navigation stays responsive.
-func fetchGoalDetailsCmd(config *Config, slug string) tea.Cmd {
+// background so the TUI opens immediately and navigation stays responsive. The
+// context lets the fetch be cancelled when the user quits.
+func fetchGoalDetailsCmd(ctx context.Context, config *Config, slug string) tea.Cmd {
 	return func() tea.Msg {
-		goal, err := NewHTTPClient(config).FetchGoalWithDatapoints(context.Background(), slug)
+		goal, err := NewHTTPClient(config).FetchGoalWithDatapoints(ctx, slug)
 		return goalDetailsMsg{slug: slug, goal: goal, err: err}
 	}
 }
 
 // ensureDetails returns a command to fetch the current goal's details if they
-// aren't cached yet, updating the loading flag accordingly.
+// aren't already cached or in flight, updating the loading flag accordingly.
+// Deduping on inFlight stops rapid navigation (away and back before a fetch
+// resolves) from firing a second request for the same goal.
 func (m *reviewModel) ensureDetails() tea.Cmd {
 	if len(m.goals) == 0 {
 		m.loading = false
@@ -111,11 +129,19 @@ func (m *reviewModel) ensureDetails() tea.Cmd {
 		return nil
 	}
 	m.loading = true
-	return fetchGoalDetailsCmd(m.config, slug)
+	if _, ok := m.inFlight[slug]; ok {
+		return nil // already fetching this goal; just keep showing the spinner
+	}
+	m.inFlight[slug] = struct{}{}
+	return fetchGoalDetailsCmd(m.ctx, m.config, slug)
 }
 
 func (m reviewModel) Init() tea.Cmd {
-	return m.ensureDetails()
+	// The constructor already marked goals[0] in-flight; just dispatch its fetch.
+	if len(m.goals) == 0 {
+		return nil
+	}
+	return fetchGoalDetailsCmd(m.ctx, m.config, m.goals[0].Slug)
 }
 
 func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -126,6 +152,8 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case goalDetailsMsg:
+		// This fetch is no longer in flight.
+		delete(m.inFlight, msg.slug)
 		// Cache the result regardless of which goal is now current (the user
 		// may have navigated on). Only touch loading/err for the current goal.
 		isCurrent := len(m.goals) > 0 && msg.slug == m.goals[m.current].Slug

--- a/review_test.go
+++ b/review_test.go
@@ -60,11 +60,23 @@ func TestReviewModelInit(t *testing.T) {
 		AuthToken: "testtoken",
 	}
 
+	// With goals present, Init dispatches the lazy fetch of the first goal's
+	// details, so it returns a command (not nil).
 	m := initialReviewModel(goals, config)
-	cmd := m.Init()
+	if cmd := m.Init(); cmd == nil {
+		t.Error("Expected Init() to return a details-fetch command when goals exist")
+	}
+	if !m.loading {
+		t.Error("Expected loading=true on init when goals exist")
+	}
 
-	if cmd != nil {
-		t.Error("Expected Init() to return nil")
+	// With no goals, there's nothing to fetch.
+	empty := initialReviewModel(nil, config)
+	if cmd := empty.Init(); cmd != nil {
+		t.Error("Expected Init() to return nil when there are no goals")
+	}
+	if empty.loading {
+		t.Error("Expected loading=false on init when there are no goals")
 	}
 }
 
@@ -1084,5 +1096,81 @@ func TestGoalDetailsFieldOrderMinimal(t *testing.T) {
 			t.Errorf("%q appears out of order\n%s", label, out)
 		}
 		prev = idx
+	}
+}
+
+func TestReviewGoalDetailsMsgCachesAndClearsLoading(t *testing.T) {
+	m := initialReviewModel([]Goal{{Slug: "g1"}, {Slug: "g2"}}, &Config{Username: "u"})
+	m.err = "stale error"
+
+	fetched := &Goal{Slug: "g1", Title: "Hydrated"}
+	updated, _ := m.Update(goalDetailsMsg{slug: "g1", goal: fetched})
+	m = updated.(reviewModel)
+
+	if m.loading {
+		t.Error("expected loading=false after the current goal's details arrive")
+	}
+	if got, ok := m.details["g1"]; !ok || got.Title != "Hydrated" {
+		t.Errorf("expected details[g1] cached as the fetched goal, got %+v (present=%v)", got, ok)
+	}
+	if m.err != "" {
+		t.Errorf("expected err cleared on success, got %q", m.err)
+	}
+}
+
+func TestReviewGoalDetailsMsgError(t *testing.T) {
+	m := initialReviewModel([]Goal{{Slug: "g1"}}, &Config{Username: "u"})
+
+	updated, _ := m.Update(goalDetailsMsg{slug: "g1", err: fmt.Errorf("boom")})
+	m = updated.(reviewModel)
+
+	if m.loading {
+		t.Error("expected loading=false even on fetch error")
+	}
+	if !strings.Contains(m.err, "Failed to load goal details") {
+		t.Errorf("expected err to mention the failure, got %q", m.err)
+	}
+}
+
+func TestReviewGoalDetailsMsgForNonCurrentGoalDoesNotClearLoading(t *testing.T) {
+	// A late result for a goal the user already navigated away from should be
+	// cached but must not clear the loading state of the current goal.
+	m := initialReviewModel([]Goal{{Slug: "g1"}, {Slug: "g2"}}, &Config{Username: "u"})
+	m.current = 1 // viewing g2, still loading it
+	m.loading = true
+
+	updated, _ := m.Update(goalDetailsMsg{slug: "g1", goal: &Goal{Slug: "g1"}})
+	m = updated.(reviewModel)
+
+	if _, ok := m.details["g1"]; !ok {
+		t.Error("expected g1 details to be cached even though it's not current")
+	}
+	if !m.loading {
+		t.Error("expected loading to stay true: g2 (current) is still loading")
+	}
+}
+
+func TestReviewNavigationTriggersFetchOnlyWhenUncached(t *testing.T) {
+	m := initialReviewModel([]Goal{{Slug: "g1"}, {Slug: "g2"}}, &Config{Username: "u"})
+	m.details["g1"] = &Goal{Slug: "g1"} // g1 cached, g2 not
+
+	// Navigate to g2 (uncached) → loading + a fetch command.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(reviewModel)
+	if m.current != 1 {
+		t.Fatalf("expected to move to g2 (index 1), got %d", m.current)
+	}
+	if !m.loading || cmd == nil {
+		t.Errorf("expected loading=true and a fetch command for uncached g2 (loading=%v, cmd=%v)", m.loading, cmd != nil)
+	}
+
+	// Navigate back to g1 (cached) → no loading, no command.
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(reviewModel)
+	if m.current != 0 {
+		t.Fatalf("expected to move back to g1 (index 0), got %d", m.current)
+	}
+	if m.loading || cmd != nil {
+		t.Errorf("expected no loading/command for cached g1 (loading=%v, cmd=%v)", m.loading, cmd != nil)
 	}
 }

--- a/review_test.go
+++ b/review_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -1211,5 +1212,55 @@ func TestReviewNavigateAwayAndBackDoesNotRefetch(t *testing.T) {
 	}
 	if m.loading {
 		t.Error("expected loading=false after g1 (current) resolved")
+	}
+}
+
+func TestReviewViewMergesDetailFieldsOntoSummaryGoal(t *testing.T) {
+	// Bulk summary goal: has summary fields but no datapoints/road. The cached
+	// detail goal deliberately has an EMPTY Title to prove View keeps the
+	// summary's Title (merge, not replace) while pulling in datapoints + road.
+	rate := 0.5
+	goals := []Goal{{
+		Slug:     "g",
+		Title:    "Bulk Title",
+		Limsum:   "+1 in 2 days",
+		Pledge:   5.0,
+		Rate:     &rate,
+		Runits:   "d",
+		Losedate: 4102444800,
+	}}
+
+	now := time.Now()
+	detail := &Goal{
+		Slug:  "g",
+		Yaw:   1,
+		Title: "", // empty on purpose: must NOT overwrite the summary title
+		Datapoints: []Datapoint{
+			{Timestamp: now.AddDate(0, 0, -2).Unix(), Value: 1},
+			{Timestamp: now.AddDate(0, 0, -1).Unix(), Value: 2},
+		},
+		Roadall: [][]*float64{
+			roadallRow(float64(now.AddDate(0, 0, -30).Unix()), fptr(0.0), nil),
+			roadallRow(float64(now.Unix()), fptr(5.0), nil),
+		},
+	}
+
+	m := initialReviewModel(goals, &Config{Username: "u"})
+	m.details["g"] = detail
+	m.loading = false
+	m.width = 100
+
+	out := m.View()
+
+	// Summary field survives the merge (came from the bulk goal, not the detail).
+	if !strings.Contains(out, "Bulk Title") {
+		t.Errorf("expected summary Title preserved after merge\n%s", out)
+	}
+	// Detail-only data is merged in and rendered.
+	if !strings.Contains(out, "Recent datapoints") {
+		t.Errorf("expected merged datapoints to render\n%s", out)
+	}
+	if !strings.Contains(out, "Goal Progress Chart") {
+		t.Errorf("expected chart (from merged road + datapoints) to render\n%s", out)
 	}
 }

--- a/review_test.go
+++ b/review_test.go
@@ -1174,3 +1174,42 @@ func TestReviewNavigationTriggersFetchOnlyWhenUncached(t *testing.T) {
 		t.Errorf("expected no loading/command for cached g1 (loading=%v, cmd=%v)", m.loading, cmd != nil)
 	}
 }
+
+func TestReviewNavigateAwayAndBackDoesNotRefetch(t *testing.T) {
+	// goals[0] (g1) is marked in-flight by the constructor (Init dispatches it).
+	m := initialReviewModel([]Goal{{Slug: "g1"}, {Slug: "g2"}}, &Config{Username: "u"})
+	if _, ok := m.inFlight["g1"]; !ok {
+		t.Fatal("expected g1 marked in-flight after construction")
+	}
+
+	// Navigate to g2 (uncached, not in flight) → dispatch a fetch for it.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(reviewModel)
+	if cmd == nil {
+		t.Fatal("expected a fetch command for uncached g2")
+	}
+	if _, ok := m.inFlight["g2"]; !ok {
+		t.Error("expected g2 marked in-flight after navigating to it")
+	}
+
+	// Navigate back to g1 before its first fetch resolves. It's still in flight,
+	// so no second request should be dispatched — just keep the spinner.
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(reviewModel)
+	if cmd != nil {
+		t.Error("expected NO second fetch for g1 while its first fetch is in flight")
+	}
+	if !m.loading {
+		t.Error("expected loading=true while g1 is still being fetched")
+	}
+
+	// When g1's single fetch finally resolves, it clears in-flight and loading.
+	updated, _ = m.Update(goalDetailsMsg{slug: "g1", goal: &Goal{Slug: "g1"}})
+	m = updated.(reviewModel)
+	if _, ok := m.inFlight["g1"]; ok {
+		t.Error("expected g1 cleared from in-flight after its fetch resolved")
+	}
+	if m.loading {
+		t.Error("expected loading=false after g1 (current) resolved")
+	}
+}


### PR DESCRIPTION
## Problem
`buzz review` called `FetchGoalsWithDatapoints` in `handleReviewCommand`, fetching **every** goal's datapoints up front (one `?datapoints=true` request per goal) before launching the TUI. For accounts with many goals that's a long blank-screen wait.

**Measured on a 63-goal account: 52.8s of nothing before the first frame.** This got worse to notice once the goal-progress chart (#170) landed, since the chart lives behind that wait.

## Fix
Lazy-load:
- `handleReviewCommand` now calls `FetchGoals` (the bulk list, one request, ~3s) and opens the TUI immediately, rendering each goal's summary fields (rate, limsum, deadline, pledge, …) right away.
- Each goal's **datapoints + road chart** are fetched on demand as the user views it (`fetchGoalDetailsCmd`), cached by slug so revisits are instant.
- A `Loading datapoints…` indicator shows while a fetch is in flight. Fetch failures are non-fatal (the summary still shows).

Only goals you actually look at get a detail fetch (~1s each), instead of all of them up front.

## Measured impact
| | Before | After |
|---|---|---|
| Startup (first frame) | **52.8s** | **2.9s** |
| Per-goal detail | (all up front) | ~1s, lazy, only for viewed goals (cached) |

## Verification
- Timed `FetchGoals` (2.9s) vs `FetchGoalsWithDatapoints` (52.8s) against live data.
- Ran `buzz review` live: TUI opens immediately with summary fields, shows `Loading datapoints…`, then the datapoints + chart appear after the lazy fetch.
- Unit tests cover the new state machine: Init dispatches the first fetch, `goalDetailsMsg` caches + clears loading (and an out-of-order result for a non-current goal doesn't clear it), errors set a message, and navigation triggers a fetch only for uncached goals.
- Full suite, `go vet`, `gofmt` clean.

## Notes
- `FetchGoalsWithDatapoints` is left in place (still has its own tests); it's just no longer used by `review`.
- Possible follow-up: prefetch the adjacent goals so left/right navigation is instant too. Kept on-demand here for simplicity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review TUI starts faster by deferring detailed goal data
  * Goal details load on-demand as users navigate, with a loading indicator
  * In-memory caching for goal details for instant return to previously viewed goals

* **Tests**
  * Added coverage for detail caching, error handling, navigation fetch behavior, in-flight deduplication, and view merging of details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->