### PR TITLE
fix(version): don't report updates for unstamped dev builds (#233)

### DIFF
--- a/version.go
+++ b/version.go
@@ -121,9 +121,12 @@ func compareVersions(currentVersion, newVersion string) bool {
 	currentVersion = strings.TrimPrefix(currentVersion, "v")
 	newVersion = strings.TrimPrefix(newVersion, "v")
 
-	// Handle dev version - always consider any release as newer
+	// An unstamped "dev" build has no real version to compare against, so don't
+	// claim an update is available: the check would always fire and the message
+	// ("dev → vX.Y.Z, run brew upgrade") is misleading even when the user already
+	// has the latest (issue #233). Release builds stamp main.version via ldflags.
 	if currentVersion == "dev" {
-		return newVersion != "dev"
+		return false
 	}
 
 	// If versions are identical, no update available

--- a/version_check_test.go
+++ b/version_check_test.go
@@ -35,10 +35,12 @@ func TestCompareVersions(t *testing.T) {
 			expected:       false,
 		},
 		{
+			// An unstamped dev build must not claim an update (issue #233): it
+			// can't know its real version or point at the right upgrade path.
 			name:           "dev version with newer release",
 			currentVersion: "dev",
 			newVersion:     "v0.30.0",
-			expected:       true,
+			expected:       false,
 		},
 		{
 			name:           "dev version same",


### PR DESCRIPTION
## Problem
A brew-installed `buzz` reports version `dev` and shows a **perpetual** false update notice, even right after installing the latest:

```
$ brew install narthur/tap/buzz   # installs v0.60.0
$ buzz next
ℹ️  Update available: dev → v0.60.0
   Run: brew upgrade narthur/tap/buzz
$ buzz --version
buzz version dev
```

## Root cause
Two layers:
1. The Homebrew formula builds from source with `ldflags: "-s -w"` and **no `-X main.version=…`**, so the binary's `version` stays `"dev"`. *(Fixed separately in the `narthur/homebrew-tap` formula — see companion PR.)*
2. In this repo, `compareVersions("dev", anything)` returned `true`, so a `dev` build always claims an update.

## This change
Make a `dev` build report **no** update: it can't know its real version or the right upgrade path, so the "dev → vX.Y.Z, run brew upgrade" message is misleading (and fires forever). Release binaries — which stamp `main.version` via `scripts/build.sh` ldflags — are unaffected. This also guards any unstamped source build (`go build`/`go install` without ldflags), not just brew.

## Tests
- Updated the `compareVersions` table: `dev` + a newer release now expects `false`.
- Full suite, `go vet`, `gofmt` clean.

## Companion fix (separate repo)
A formula PR to `narthur/homebrew-tap` adds `-X main.version=v#{version}` so `buzz --version` is also accurate for brew installs. With that, the version compares equal and no nag shows; this PR additionally ensures *unstamped* builds never nag.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect update notifications for development builds that would display misleading upgrade prompts.

* **Tests**
  * Updated test cases to verify development builds no longer claim available updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->