### PR TITLE
fix(schedule): use Beeminder account timezone for deadlines (#214)

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,10 @@ const httpClientTimeout = 30 * time.Second
 // further interface changes — that wiring is tracked in a follow-up.
 type Client interface {
 	FetchGoals(ctx context.Context) ([]Goal, error)
+	// FetchUserTimezone returns the IANA timezone configured on the user's
+	// Beeminder account (e.g. "America/New_York"), or an empty string if the
+	// account has none set.
+	FetchUserTimezone(ctx context.Context) (string, error)
 	FetchGoal(ctx context.Context, goalSlug string) (*Goal, error)
 	FetchGoalWithDatapoints(ctx context.Context, goalSlug string) (*Goal, error)
 	FetchGoalRawJSON(ctx context.Context, goalSlug string, includeDatapoints bool) (json.RawMessage, error)
@@ -113,6 +117,33 @@ func (c *HTTPClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 	}
 
 	return goals, nil
+}
+
+// FetchUserTimezone fetches the IANA timezone configured on the user's
+// Beeminder account from the user endpoint. Returns an empty string (no error)
+// if the account has no timezone set.
+func (c *HTTPClient) FetchUserTimezone(ctx context.Context) (string, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/users/%s.json?auth_token=%s",
+		c.baseURL(), c.config.Username, c.config.AuthToken)
+
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Timezone string `json:"timezone"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode user: %w", err)
+	}
+
+	return result.Timezone, nil
 }
 
 // GetLastDatapointValue fetches the last datapoint value for a goal.

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -25,6 +25,7 @@ import (
 // explicit context-capture field when the need arises.
 type FakeClient struct {
 	FetchGoalsFunc                  func() ([]Goal, error)
+	FetchUserTimezoneFunc           func() (string, error)
 	FetchGoalFunc                   func(goalSlug string) (*Goal, error)
 	FetchGoalWithDatapointsFunc     func(goalSlug string) (*Goal, error)
 	FetchGoalRawJSONFunc            func(goalSlug string, includeDatapoints bool) (json.RawMessage, error)
@@ -50,6 +51,13 @@ func (c *FakeClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 		return nil, errFakeNotConfigured
 	}
 	return c.FetchGoalsFunc()
+}
+
+func (c *FakeClient) FetchUserTimezone(ctx context.Context) (string, error) {
+	if c.FetchUserTimezoneFunc == nil {
+		return "", errFakeNotConfigured
+	}
+	return c.FetchUserTimezoneFunc()
 }
 
 func (c *FakeClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, error) {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 	"os"
 
+	// Embed the IANA timezone database so time.LoadLocation works on systems
+	// without system tzdata (e.g. Windows, minimal containers). The schedule
+	// command relies on this to render deadlines in the account timezone.
+	_ "time/tzdata"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"

--- a/schedule.go
+++ b/schedule.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -22,7 +23,7 @@ type timeSlot struct {
 // handleScheduleCommand displays a visual representation of goal deadline distribution throughout a 24-hour day
 func handleScheduleCommand() {
 	// Load config and goals
-	_, _, goals, err := loadConfigAndGoals()
+	_, client, goals, err := loadConfigAndGoals()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
 		os.Exit(1)
@@ -33,8 +34,12 @@ func handleScheduleCommand() {
 		return
 	}
 
+	// Deadlines are defined in the user's Beeminder account timezone, so render
+	// them there rather than in the local machine timezone.
+	loc := scheduleLocation(context.Background(), client)
+
 	// Extract time-of-day from each goal's deadline
-	timeSlots := extractTimeSlots(goals)
+	timeSlots := extractTimeSlots(goals, loc)
 
 	// Generate hourly density data
 	hourCounts := make([]int, 24)
@@ -52,14 +57,32 @@ func handleScheduleCommand() {
 	fmt.Print(getUpdateMessage())
 }
 
-// extractTimeSlots extracts time-of-day from all goal deadlines and groups them
-func extractTimeSlots(goals []Goal) []timeSlot {
+// scheduleLocation resolves the timezone used to render goal deadlines. It
+// prefers the Beeminder account timezone (fetched from the API) so deadline
+// times match what the user sees on beeminder.com, falling back to the local
+// machine timezone if the account timezone is unavailable or unparseable.
+func scheduleLocation(ctx context.Context, client Client) *time.Location {
+	tz, err := client.FetchUserTimezone(ctx)
+	if err != nil || tz == "" {
+		return time.Local
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.Local
+	}
+	return loc
+}
+
+// extractTimeSlots extracts time-of-day from all goal deadlines and groups them.
+// Deadlines are rendered in loc, which should be the user's Beeminder account
+// timezone.
+func extractTimeSlots(goals []Goal, loc *time.Location) []timeSlot {
 	// Map to group goals by their time of day (hour:minute)
 	slotMap := make(map[string]*timeSlot)
 
 	for _, goal := range goals {
-		// Convert losedate to local time and extract hour/minute
-		t := time.Unix(goal.Losedate, 0).In(time.Local)
+		// Convert losedate to the account timezone and extract hour/minute
+		t := time.Unix(goal.Losedate, 0).In(loc)
 		hour := t.Hour()
 		minute := t.Minute()
 

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,9 +10,9 @@ import (
 
 // TestExtractTimeSlots tests the extraction and grouping of time slots from goals
 func TestExtractTimeSlots(t *testing.T) {
-	// Create test goals with different deadline times. extractTimeSlots converts
-	// losedate to local time, so the fixtures are built in time.Local too; this
-	// keeps the asserted hour/minute correct regardless of the machine's timezone.
+	// Create test goals with different deadline times. The fixtures are built in
+	// time.Local and rendered with time.Local below, so the asserted hour/minute
+	// stays correct regardless of the machine's timezone.
 	goals := []Goal{
 		{
 			Slug:     "goal1",
@@ -31,7 +32,7 @@ func TestExtractTimeSlots(t *testing.T) {
 		},
 	}
 
-	slots := extractTimeSlots(goals)
+	slots := extractTimeSlots(goals, time.Local)
 
 	// Should have 3 time slots (goal1 and goal2 share the same time)
 	if len(slots) != 3 {
@@ -83,7 +84,7 @@ func TestExtractTimeSlots(t *testing.T) {
 // TestExtractTimeSlotsEmpty tests extractTimeSlots with no goals
 func TestExtractTimeSlotsEmpty(t *testing.T) {
 	var goals []Goal
-	slots := extractTimeSlots(goals)
+	slots := extractTimeSlots(goals, time.Local)
 
 	if len(slots) != 0 {
 		t.Errorf("Expected 0 time slots for empty goals, got %d", len(slots))
@@ -92,8 +93,9 @@ func TestExtractTimeSlotsEmpty(t *testing.T) {
 
 // TestExtractTimeSlotsAcrossDates tests that goals on different dates with same time are grouped together
 func TestExtractTimeSlotsAcrossDates(t *testing.T) {
-	// Fixtures built in time.Local so the asserted slot time is timezone-independent
-	// (extractTimeSlots groups by the deadline's local hour/minute).
+	// Fixtures built in time.Local and rendered with time.Local below, so the
+	// asserted slot time is timezone-independent (extractTimeSlots groups by the
+	// deadline's hour/minute in the provided location).
 	goals := []Goal{
 		{
 			Slug:     "goal1",
@@ -109,7 +111,7 @@ func TestExtractTimeSlotsAcrossDates(t *testing.T) {
 		},
 	}
 
-	slots := extractTimeSlots(goals)
+	slots := extractTimeSlots(goals, time.Local)
 
 	// Should have 1 time slot (all goals at 14:30)
 	if len(slots) != 1 {
@@ -124,6 +126,69 @@ func TestExtractTimeSlotsAcrossDates(t *testing.T) {
 	// Verify the time
 	if slots[0].hour != 14 || slots[0].minute != 30 {
 		t.Errorf("Expected slot at 14:30, got %02d:%02d", slots[0].hour, slots[0].minute)
+	}
+}
+
+// TestExtractTimeSlotsUsesProvidedLocation verifies that a goal's deadline is
+// rendered in the supplied location, so the same absolute instant yields a
+// different hour/minute across timezones (issue #214).
+func TestExtractTimeSlotsUsesProvidedLocation(t *testing.T) {
+	// A fixed absolute instant: noon UTC on 2024-01-15.
+	instant := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+	goals := []Goal{{Slug: "goal1", Losedate: instant}}
+
+	utcSlots := extractTimeSlots(goals, time.UTC)
+	if len(utcSlots) != 1 || utcSlots[0].hour != 12 || utcSlots[0].minute != 0 {
+		t.Fatalf("UTC: expected one slot at 12:00, got %+v", utcSlots)
+	}
+
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("America/New_York tzdata unavailable: %v", err)
+	}
+	// New York is UTC-5 in January, so noon UTC is 07:00 local.
+	nySlots := extractTimeSlots(goals, ny)
+	if len(nySlots) != 1 || nySlots[0].hour != 7 || nySlots[0].minute != 0 {
+		t.Fatalf("America/New_York: expected one slot at 07:00, got %+v", nySlots)
+	}
+}
+
+// TestScheduleLocation verifies that scheduleLocation prefers the account
+// timezone and falls back to time.Local on error, empty, or unparseable input.
+func TestScheduleLocation(t *testing.T) {
+	if _, err := time.LoadLocation("America/New_York"); err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		tz      string
+		tzErr   error
+		wantLoc string // empty means expect time.Local
+	}{
+		{name: "account timezone used", tz: "America/New_York", wantLoc: "America/New_York"},
+		{name: "empty falls back to local", tz: ""},
+		{name: "error falls back to local", tzErr: errFakeNotConfigured},
+		{name: "unparseable falls back to local", tz: "Not/AZone"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &FakeClient{
+				FetchUserTimezoneFunc: func() (string, error) { return tt.tz, tt.tzErr },
+			}
+			loc := scheduleLocation(context.Background(), client)
+			want := tt.wantLoc
+			if want == "" {
+				if loc != time.Local {
+					t.Errorf("expected time.Local, got %s", loc)
+				}
+				return
+			}
+			if loc.String() != want {
+				t.Errorf("expected %s, got %s", want, loc)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #214.

`buzz schedule` rendered goal deadlines in the local machine timezone (`time.Local`), which is wrong when the user's Beeminder account is configured with a different timezone — deadlines could land in the wrong hour slot.

## Changes
- **`client.go`** — new `FetchUserTimezone(ctx)` on the `Client` interface + `HTTPClient`, reading the `timezone` field from the user endpoint.
- **`schedule.go`** — `handleScheduleCommand` resolves the account timezone via a new `scheduleLocation` helper and threads a `*time.Location` into `extractTimeSlots`. Falls back to `time.Local` when the timezone is empty, the fetch errors, or the zone is unparseable, so the command never breaks.
- **`main.go`** — blank-imports `time/tzdata` so `time.LoadLocation` works on systems without system tzdata (Windows, minimal containers). ~450KB binary cost.
- **Tests** — fake client gets the new method; `TestExtractTimeSlotsUsesProvidedLocation` proves the same instant renders at different hours per zone, and `TestScheduleLocation` covers all four fallback paths.

## Design note
The timezone is fetched live each `schedule` run rather than persisted into `~/.buzzrc` (as the issue floated). One extra request, but always current and no stale state to manage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal deadlines now display in your configured Beeminder account timezone instead of system time, improving scheduling accuracy across regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->