### PR TITLE
feat(api): add `buzz api` raw Beeminder API passthrough (#227)

### DIFF
--- a/api.go
+++ b/api.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -114,14 +115,16 @@ func runAPICommand(args []string, client Client, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	params := make(map[string]string)
+	// Accumulate with Add so repeated keys (e.g. -d tags=a -d tags=b) are all
+	// preserved rather than overwriting one another.
+	params := url.Values{}
 	for _, kv := range data {
 		key, val, found := strings.Cut(kv, "=")
 		if !found || key == "" {
 			fmt.Fprintf(stderr, "Error: Invalid --data %q (expected key=value)\n", kv)
 			return 1
 		}
-		params[key] = val
+		params.Add(key, val)
 	}
 
 	status, body, err := client.APIRequest(context.Background(), method, path, params)

--- a/api.go
+++ b/api.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const apiUsage = `Usage: buzz api [-X|--method <METHOD>] [-d|--data <key=value>]... <path>
+
+Make an authenticated request to the Beeminder API using your buzz
+credentials. <path> is relative to the API root, e.g. "users/me.json"
+or "users/me/goals/<slug>.json". The auth_token is added automatically.
+
+Options:
+  -X, --method <METHOD>   HTTP method: GET (default), POST, PUT, PATCH, DELETE
+  -d, --data <key=value>  Request parameter (repeatable). Sent as query
+                          parameters for GET/DELETE, form body otherwise.
+
+Examples:
+  buzz api users/me.json
+  buzz api users/me/goals/read.json
+  buzz api -X POST -d value=1 -d "comment=via buzz" users/me/goals/read/datapoints.json`
+
+// keyValueFlag collects repeatable -d/--data "key=value" pairs.
+type keyValueFlag []string
+
+func (k *keyValueFlag) String() string { return strings.Join(*k, ", ") }
+
+func (k *keyValueFlag) Set(v string) error {
+	*k = append(*k, v)
+	return nil
+}
+
+// handleAPICommand makes a raw, authenticated request to the Beeminder API.
+func handleAPICommand() {
+	if !ConfigExists() {
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
+		os.Exit(1)
+	}
+
+	config, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to load config: %s\n", redactError(err))
+		os.Exit(1)
+	}
+
+	client := NewHTTPClient(config)
+	os.Exit(runAPICommand(os.Args[2:], client, os.Stdout, os.Stderr))
+}
+
+// runAPICommand is the testable core of `buzz api`. It returns the process exit
+// code and writes all output to the provided writers.
+func runAPICommand(args []string, client Client, stdout, stderr io.Writer) int {
+	apiFlags := flag.NewFlagSet("api", flag.ContinueOnError)
+	// Silence the flag package's own error/usage output; we print our own
+	// message and richer apiUsage on both --help and parse errors.
+	apiFlags.SetOutput(io.Discard)
+	apiFlags.Usage = func() {}
+
+	var method string
+	apiFlags.StringVar(&method, "method", "GET", "HTTP method")
+	apiFlags.StringVar(&method, "X", "GET", "HTTP method (shorthand)")
+
+	var data keyValueFlag
+	apiFlags.Var(&data, "data", "Request parameter key=value (repeatable)")
+	apiFlags.Var(&data, "d", "Request parameter (shorthand)")
+
+	// Allow flags on either side of the positional <path>, mirroring the view
+	// command: re-parse from the remainder until only non-flag args are left.
+	var positional []string
+	remaining := args
+	for len(remaining) > 0 {
+		if err := apiFlags.Parse(remaining); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				fmt.Fprintln(stdout, apiUsage)
+				return 0
+			}
+			fmt.Fprintf(stderr, "Error parsing flags: %s\n", redactError(err))
+			fmt.Fprintln(stderr, apiUsage)
+			return 2
+		}
+		rest := apiFlags.Args()
+		if len(rest) == 0 {
+			break
+		}
+		positional = append(positional, rest[0])
+		remaining = rest[1:]
+	}
+
+	if len(positional) != 1 {
+		if len(positional) == 0 {
+			fmt.Fprintln(stderr, "Error: Missing required <path> argument")
+		} else {
+			fmt.Fprintf(stderr, "Error: Too many arguments: %v\n", positional[1:])
+		}
+		fmt.Fprintln(stderr, apiUsage)
+		return 1
+	}
+	path := positional[0]
+
+	method = strings.ToUpper(strings.TrimSpace(method))
+	switch method {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	default:
+		fmt.Fprintf(stderr, "Error: Unsupported method %q (use GET, POST, PUT, PATCH, or DELETE)\n", method)
+		return 1
+	}
+
+	params := make(map[string]string)
+	for _, kv := range data {
+		key, val, found := strings.Cut(kv, "=")
+		if !found || key == "" {
+			fmt.Fprintf(stderr, "Error: Invalid --data %q (expected key=value)\n", kv)
+			return 1
+		}
+		params[key] = val
+	}
+
+	status, body, err := client.APIRequest(context.Background(), method, path, params)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %s\n", redactError(err))
+		return 1
+	}
+
+	// Pretty-print JSON responses; fall back to the raw body otherwise.
+	var pretty bytes.Buffer
+	if len(body) > 0 && json.Indent(&pretty, body, "", "  ") == nil {
+		fmt.Fprintln(stdout, pretty.String())
+	} else if len(body) > 0 {
+		fmt.Fprintln(stdout, strings.TrimRight(string(body), "\n"))
+	}
+
+	// Surface non-2xx responses with a nonzero exit code while still printing
+	// the body above, so error details from the API remain visible.
+	if status < 200 || status >= 300 {
+		fmt.Fprintf(stderr, "API returned status %d\n", status)
+		return 1
+	}
+
+	return 0
+}

--- a/api_test.go
+++ b/api_test.go
@@ -70,6 +70,28 @@ func TestAPIRequestLeadingSlashAndExistingQuery(t *testing.T) {
 	}
 }
 
+// TestAPIRequestAuthTokenAlwaysWins verifies that a caller-supplied auth_token
+// param cannot override the configured credential.
+func TestAPIRequestAuthTokenAlwaysWins(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	if _, _, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json", map[string]string{"auth_token": "attacker"}); err != nil {
+		t.Fatalf("APIRequest returned error: %v", err)
+	}
+	if !strings.Contains(gotQuery, "auth_token=secret") {
+		t.Errorf("expected stored auth_token to win, got query: %s", gotQuery)
+	}
+	if strings.Contains(gotQuery, "attacker") {
+		t.Errorf("caller-supplied auth_token leaked into request: %s", gotQuery)
+	}
+}
+
 // TestAPIRequestPOSTBody verifies that POST sends auth_token and params in the
 // urlencoded form body, not the query string.
 func TestAPIRequestPOSTBody(t *testing.T) {

--- a/api_test.go
+++ b/api_test.go
@@ -93,6 +93,57 @@ func TestAPIRequestAuthTokenAlwaysWins(t *testing.T) {
 	}
 }
 
+// TestAPIRequestPathCannotOverrideAuthToken verifies that an auth_token embedded
+// in the path's query string cannot smuggle in a second token — the stored
+// credential is the only one sent.
+func TestAPIRequestPathCannotOverrideAuthToken(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	if _, _, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json?auth_token=attacker", nil); err != nil {
+		t.Fatalf("APIRequest returned error: %v", err)
+	}
+	if strings.Contains(gotQuery, "attacker") {
+		t.Errorf("path-embedded auth_token leaked into request: %s", gotQuery)
+	}
+	if strings.Count(gotQuery, "auth_token=") != 1 || !strings.Contains(gotQuery, "auth_token=secret") {
+		t.Errorf("expected exactly one auth_token=secret, got query: %s", gotQuery)
+	}
+}
+
+// TestAPIRequestDELETEUsesQuery verifies that DELETE (like GET) carries params
+// in the query string and sends no body or content-type.
+func TestAPIRequestDELETEUsesQuery(t *testing.T) {
+	var gotQuery, gotBody, gotContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	if _, _, err := client.APIRequest(context.Background(), http.MethodDelete, "users/me/goals/read/datapoints/123.json", url.Values{"foo": {"bar"}}); err != nil {
+		t.Fatalf("APIRequest returned error: %v", err)
+	}
+	if !strings.Contains(gotQuery, "foo=bar") || !strings.Contains(gotQuery, "auth_token=secret") {
+		t.Errorf("expected foo and auth_token in query, got: %s", gotQuery)
+	}
+	if gotBody != "" {
+		t.Errorf("expected empty body for DELETE, got: %s", gotBody)
+	}
+	if gotContentType != "" {
+		t.Errorf("expected no content-type for DELETE, got: %s", gotContentType)
+	}
+}
+
 // TestAPIRequestPOSTBody verifies that POST sends auth_token and params in the
 // urlencoded form body, not the query string.
 func TestAPIRequestPOSTBody(t *testing.T) {
@@ -216,10 +267,22 @@ func TestRunAPICommand(t *testing.T) {
 			wantStderr: "Unsupported method",
 		},
 		{
-			name:       "invalid data",
+			name:       "invalid data - no equals",
 			args:       []string{"-d", "novalue", "a.json"},
 			wantExit:   1,
 			wantStderr: "Invalid --data",
+		},
+		{
+			name:       "invalid data - empty key",
+			args:       []string{"-d", "=value", "a.json"},
+			wantExit:   1,
+			wantStderr: "Invalid --data",
+		},
+		{
+			name:     "empty body prints nothing and exits 0",
+			args:     []string{"a.json"},
+			fn:       func(m, p string, params url.Values) (int, []byte, error) { return 200, []byte{}, nil },
+			wantExit: 0,
 		},
 		{
 			name:       "client error",

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestAPIRequestGET verifies that GET requests carry auth_token and params in
+// the query string and return the status code and body verbatim.
+func TestAPIRequestGET(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"username":"alice"}`)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	status, body, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json", map[string]string{"associations": "true"})
+	if err != nil {
+		t.Fatalf("APIRequest returned error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("expected status 200, got %d", status)
+	}
+	if string(body) != `{"username":"alice"}` {
+		t.Errorf("unexpected body: %s", body)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("expected GET, got %s", gotMethod)
+	}
+	if gotPath != "/api/v1/users/me.json" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(gotQuery, "auth_token=secret") {
+		t.Errorf("auth_token missing from query: %s", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "associations=true") {
+		t.Errorf("param missing from query: %s", gotQuery)
+	}
+}
+
+// TestAPIRequestLeadingSlashAndExistingQuery verifies that a leading slash is
+// tolerated and that auth_token is appended to a path that already has a query.
+func TestAPIRequestLeadingSlashAndExistingQuery(t *testing.T) {
+	var gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	if _, _, err := client.APIRequest(context.Background(), http.MethodGet, "/users/me.json?skinny=true", nil); err != nil {
+		t.Fatalf("APIRequest returned error: %v", err)
+	}
+	if gotPath != "/api/v1/users/me.json" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(gotQuery, "skinny=true") || !strings.Contains(gotQuery, "auth_token=secret") {
+		t.Errorf("expected both skinny and auth_token in query, got: %s", gotQuery)
+	}
+}
+
+// TestAPIRequestPOSTBody verifies that POST sends auth_token and params in the
+// urlencoded form body, not the query string.
+func TestAPIRequestPOSTBody(t *testing.T) {
+	var gotQuery, gotBody, gotContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	if _, _, err := client.APIRequest(context.Background(), http.MethodPost, "users/me/goals/read/datapoints.json", map[string]string{"value": "1"}); err != nil {
+		t.Fatalf("APIRequest returned error: %v", err)
+	}
+	if gotQuery != "" {
+		t.Errorf("expected empty query for POST, got: %s", gotQuery)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("unexpected content type: %s", gotContentType)
+	}
+	if !strings.Contains(gotBody, "auth_token=secret") || !strings.Contains(gotBody, "value=1") {
+		t.Errorf("expected auth_token and value in body, got: %s", gotBody)
+	}
+}
+
+// TestAPIRequestNon2xxNotError verifies that a non-2xx status is returned to the
+// caller rather than turned into an error.
+func TestAPIRequestNon2xxNotError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "not found")
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
+	status, body, err := client.APIRequest(context.Background(), http.MethodGet, "users/nope.json", nil)
+	if err != nil {
+		t.Fatalf("expected no error for 404, got: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", status)
+	}
+	if string(body) != "not found" {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+// TestRunAPICommand exercises the command core against a fake client.
+func TestRunAPICommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		fn           func(method, path string, params map[string]string) (int, []byte, error)
+		wantExit     int
+		wantStdout   string // substring; empty means don't check
+		wantStderr   string // substring; empty means don't check
+		wantMethod   string // asserted inside fn when set
+		wantPath     string
+		wantParamKey string
+		wantParamVal string
+	}{
+		{
+			name:       "simple GET pretty-prints JSON",
+			args:       []string{"users/me.json"},
+			fn:         func(m, p string, params map[string]string) (int, []byte, error) { return 200, []byte(`{"a":1}`), nil },
+			wantExit:   0,
+			wantStdout: "\"a\": 1",
+			wantMethod: "GET",
+			wantPath:   "users/me.json",
+		},
+		{
+			name: "POST with data passes method and params",
+			args: []string{"-X", "post", "-d", "value=1", "users/me/goals/read/datapoints.json"},
+			fn: func(m, p string, params map[string]string) (int, []byte, error) {
+				return 200, []byte(`{}`), nil
+			},
+			wantExit:     0,
+			wantMethod:   "POST",
+			wantPath:     "users/me/goals/read/datapoints.json",
+			wantParamKey: "value",
+			wantParamVal: "1",
+		},
+		{
+			name: "non-JSON body printed raw",
+			args: []string{"something.txt"},
+			fn: func(m, p string, params map[string]string) (int, []byte, error) {
+				return 200, []byte("plain text"), nil
+			},
+			wantExit:   0,
+			wantStdout: "plain text",
+		},
+		{
+			name: "non-2xx exits nonzero but prints body",
+			args: []string{"users/nope.json"},
+			fn: func(m, p string, params map[string]string) (int, []byte, error) {
+				return 404, []byte(`{"error":"x"}`), nil
+			},
+			wantExit:   1,
+			wantStdout: "\"error\": \"x\"",
+			wantStderr: "status 404",
+		},
+		{
+			name:       "missing path",
+			args:       []string{},
+			wantExit:   1,
+			wantStderr: "Missing required <path>",
+		},
+		{
+			name:       "too many positionals",
+			args:       []string{"a.json", "b.json"},
+			wantExit:   1,
+			wantStderr: "Too many arguments",
+		},
+		{
+			name:       "invalid method",
+			args:       []string{"-X", "BOGUS", "a.json"},
+			wantExit:   1,
+			wantStderr: "Unsupported method",
+		},
+		{
+			name:       "invalid data",
+			args:       []string{"-d", "novalue", "a.json"},
+			wantExit:   1,
+			wantStderr: "Invalid --data",
+		},
+		{
+			name:       "client error",
+			args:       []string{"a.json"},
+			fn:         func(m, p string, params map[string]string) (int, []byte, error) { return 0, nil, io.ErrUnexpectedEOF },
+			wantExit:   1,
+			wantStderr: "Error:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawMethod, sawPath string
+			var sawParams map[string]string
+			client := &FakeClient{}
+			if tt.fn != nil {
+				client.APIRequestFunc = func(method, path string, params map[string]string) (int, []byte, error) {
+					sawMethod, sawPath, sawParams = method, path, params
+					return tt.fn(method, path, params)
+				}
+			}
+
+			var stdout, stderr strings.Builder
+			exit := runAPICommand(tt.args, client, &stdout, &stderr)
+
+			if exit != tt.wantExit {
+				t.Errorf("exit = %d, want %d (stderr: %s)", exit, tt.wantExit, stderr.String())
+			}
+			if tt.wantStdout != "" && !strings.Contains(stdout.String(), tt.wantStdout) {
+				t.Errorf("stdout %q does not contain %q", stdout.String(), tt.wantStdout)
+			}
+			if tt.wantStderr != "" && !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Errorf("stderr %q does not contain %q", stderr.String(), tt.wantStderr)
+			}
+			if tt.wantMethod != "" && sawMethod != tt.wantMethod {
+				t.Errorf("method = %q, want %q", sawMethod, tt.wantMethod)
+			}
+			if tt.wantPath != "" && sawPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", sawPath, tt.wantPath)
+			}
+			if tt.wantParamKey != "" && sawParams[tt.wantParamKey] != tt.wantParamVal {
+				t.Errorf("param %q = %q, want %q", tt.wantParamKey, sawParams[tt.wantParamKey], tt.wantParamVal)
+			}
+		})
+	}
+}
+
+// TestRunAPICommandHelp verifies that --help prints usage and exits 0.
+func TestRunAPICommandHelp(t *testing.T) {
+	var stdout, stderr strings.Builder
+	exit := runAPICommand([]string{"--help"}, &FakeClient{}, &stdout, &stderr)
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	if !strings.Contains(stdout.String(), "Usage: buzz api") {
+		t.Errorf("expected usage on stdout, got: %s", stdout.String())
+	}
+}

--- a/api_test.go
+++ b/api_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -23,7 +24,7 @@ func TestAPIRequestGET(t *testing.T) {
 	defer server.Close()
 
 	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
-	status, body, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json", map[string]string{"associations": "true"})
+	status, body, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json", url.Values{"associations": {"true"}})
 	if err != nil {
 		t.Fatalf("APIRequest returned error: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestAPIRequestAuthTokenAlwaysWins(t *testing.T) {
 	defer server.Close()
 
 	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
-	if _, _, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json", map[string]string{"auth_token": "attacker"}); err != nil {
+	if _, _, err := client.APIRequest(context.Background(), http.MethodGet, "users/me.json", url.Values{"auth_token": {"attacker"}}); err != nil {
 		t.Fatalf("APIRequest returned error: %v", err)
 	}
 	if !strings.Contains(gotQuery, "auth_token=secret") {
@@ -106,7 +107,7 @@ func TestAPIRequestPOSTBody(t *testing.T) {
 	defer server.Close()
 
 	client := NewHTTPClient(&Config{Username: "alice", AuthToken: "secret", BaseURL: server.URL})
-	if _, _, err := client.APIRequest(context.Background(), http.MethodPost, "users/me/goals/read/datapoints.json", map[string]string{"value": "1"}); err != nil {
+	if _, _, err := client.APIRequest(context.Background(), http.MethodPost, "users/me/goals/read/datapoints.json", url.Values{"value": {"1"}}); err != nil {
 		t.Fatalf("APIRequest returned error: %v", err)
 	}
 	if gotQuery != "" {
@@ -147,7 +148,7 @@ func TestRunAPICommand(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         []string
-		fn           func(method, path string, params map[string]string) (int, []byte, error)
+		fn           func(method, path string, params url.Values) (int, []byte, error)
 		wantExit     int
 		wantStdout   string // substring; empty means don't check
 		wantStderr   string // substring; empty means don't check
@@ -159,7 +160,7 @@ func TestRunAPICommand(t *testing.T) {
 		{
 			name:       "simple GET pretty-prints JSON",
 			args:       []string{"users/me.json"},
-			fn:         func(m, p string, params map[string]string) (int, []byte, error) { return 200, []byte(`{"a":1}`), nil },
+			fn:         func(m, p string, params url.Values) (int, []byte, error) { return 200, []byte(`{"a":1}`), nil },
 			wantExit:   0,
 			wantStdout: "\"a\": 1",
 			wantMethod: "GET",
@@ -168,7 +169,7 @@ func TestRunAPICommand(t *testing.T) {
 		{
 			name: "POST with data passes method and params",
 			args: []string{"-X", "post", "-d", "value=1", "users/me/goals/read/datapoints.json"},
-			fn: func(m, p string, params map[string]string) (int, []byte, error) {
+			fn: func(m, p string, params url.Values) (int, []byte, error) {
 				return 200, []byte(`{}`), nil
 			},
 			wantExit:     0,
@@ -180,7 +181,7 @@ func TestRunAPICommand(t *testing.T) {
 		{
 			name: "non-JSON body printed raw",
 			args: []string{"something.txt"},
-			fn: func(m, p string, params map[string]string) (int, []byte, error) {
+			fn: func(m, p string, params url.Values) (int, []byte, error) {
 				return 200, []byte("plain text"), nil
 			},
 			wantExit:   0,
@@ -189,7 +190,7 @@ func TestRunAPICommand(t *testing.T) {
 		{
 			name: "non-2xx exits nonzero but prints body",
 			args: []string{"users/nope.json"},
-			fn: func(m, p string, params map[string]string) (int, []byte, error) {
+			fn: func(m, p string, params url.Values) (int, []byte, error) {
 				return 404, []byte(`{"error":"x"}`), nil
 			},
 			wantExit:   1,
@@ -223,7 +224,7 @@ func TestRunAPICommand(t *testing.T) {
 		{
 			name:       "client error",
 			args:       []string{"a.json"},
-			fn:         func(m, p string, params map[string]string) (int, []byte, error) { return 0, nil, io.ErrUnexpectedEOF },
+			fn:         func(m, p string, params url.Values) (int, []byte, error) { return 0, nil, io.ErrUnexpectedEOF },
 			wantExit:   1,
 			wantStderr: "Error:",
 		},
@@ -232,10 +233,10 @@ func TestRunAPICommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var sawMethod, sawPath string
-			var sawParams map[string]string
+			var sawParams url.Values
 			client := &FakeClient{}
 			if tt.fn != nil {
-				client.APIRequestFunc = func(method, path string, params map[string]string) (int, []byte, error) {
+				client.APIRequestFunc = func(method, path string, params url.Values) (int, []byte, error) {
 					sawMethod, sawPath, sawParams = method, path, params
 					return tt.fn(method, path, params)
 				}
@@ -259,10 +260,32 @@ func TestRunAPICommand(t *testing.T) {
 			if tt.wantPath != "" && sawPath != tt.wantPath {
 				t.Errorf("path = %q, want %q", sawPath, tt.wantPath)
 			}
-			if tt.wantParamKey != "" && sawParams[tt.wantParamKey] != tt.wantParamVal {
-				t.Errorf("param %q = %q, want %q", tt.wantParamKey, sawParams[tt.wantParamKey], tt.wantParamVal)
+			if tt.wantParamKey != "" && sawParams.Get(tt.wantParamKey) != tt.wantParamVal {
+				t.Errorf("param %q = %q, want %q", tt.wantParamKey, sawParams.Get(tt.wantParamKey), tt.wantParamVal)
 			}
 		})
+	}
+}
+
+// TestRunAPICommandRepeatedData verifies that repeating -d with the same key
+// preserves every value rather than dropping earlier ones.
+func TestRunAPICommandRepeatedData(t *testing.T) {
+	var sawParams url.Values
+	client := &FakeClient{
+		APIRequestFunc: func(method, path string, params url.Values) (int, []byte, error) {
+			sawParams = params
+			return 200, []byte(`{}`), nil
+		},
+	}
+
+	var stdout, stderr strings.Builder
+	exit := runAPICommand([]string{"-d", "tags=a", "-d", "tags=b", "x.json"}, client, &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr.String())
+	}
+	got := sawParams["tags"]
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("expected tags=[a b], got %v", got)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -29,6 +29,13 @@ type Client interface {
 	// Beeminder account (e.g. "America/New_York"), or an empty string if the
 	// account has none set.
 	FetchUserTimezone(ctx context.Context) (string, error)
+	// APIRequest performs a raw, authenticated request against the Beeminder
+	// API. path is relative to the API root (e.g. "users/me.json"); a leading
+	// slash is optional. The configured auth_token is added automatically.
+	// params are sent as query parameters for GET/DELETE and as a urlencoded
+	// form body otherwise. A non-2xx status is NOT returned as an error —
+	// callers inspect the returned status code and body themselves.
+	APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error)
 	FetchGoal(ctx context.Context, goalSlug string) (*Goal, error)
 	FetchGoalWithDatapoints(ctx context.Context, goalSlug string) (*Goal, error)
 	FetchGoalRawJSON(ctx context.Context, goalSlug string, includeDatapoints bool) (json.RawMessage, error)
@@ -144,6 +151,49 @@ func (c *HTTPClient) FetchUserTimezone(ctx context.Context) (string, error) {
 	}
 
 	return result.Timezone, nil
+}
+
+// APIRequest performs a raw, authenticated request against the Beeminder API.
+// See the Client interface for the contract. The auth_token is injected into
+// the query string for GET/DELETE and into the form body for methods that
+// carry one (POST/PUT/PATCH).
+func (c *HTTPClient) APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error) {
+	values := url.Values{}
+	values.Set("auth_token", c.config.AuthToken)
+	for k, v := range params {
+		values.Set(k, v)
+	}
+
+	apiURL := fmt.Sprintf("%s/api/v1/%s", c.baseURL(), strings.TrimPrefix(path, "/"))
+
+	var reqBody io.Reader
+	contentType := ""
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		reqBody = strings.NewReader(values.Encode())
+		contentType = "application/x-www-form-urlencoded"
+	default:
+		// GET/DELETE: carry everything in the query string, preserving any
+		// query the caller already included in path.
+		sep := "?"
+		if strings.Contains(apiURL, "?") {
+			sep = "&"
+		}
+		apiURL += sep + values.Encode()
+	}
+
+	resp, err := c.doRequest(ctx, method, apiURL, reqBody, contentType)
+	if err != nil {
+		return 0, nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return resp.StatusCode, nil, fmt.Errorf("failed to read response body: %w", readErr)
+	}
+
+	return resp.StatusCode, body, nil
 }
 
 // GetLastDatapointValue fetches the last datapoint value for a goal.

--- a/client.go
+++ b/client.go
@@ -33,9 +33,10 @@ type Client interface {
 	// API. path is relative to the API root (e.g. "users/me.json"); a leading
 	// slash is optional. The configured auth_token is added automatically.
 	// params are sent as query parameters for GET/DELETE and as a urlencoded
-	// form body otherwise. A non-2xx status is NOT returned as an error —
-	// callers inspect the returned status code and body themselves.
-	APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error)
+	// form body otherwise; url.Values preserves repeated keys. A non-2xx status
+	// is NOT returned as an error — callers inspect the returned status code and
+	// body themselves.
+	APIRequest(ctx context.Context, method, path string, params url.Values) (int, []byte, error)
 	FetchGoal(ctx context.Context, goalSlug string) (*Goal, error)
 	FetchGoalWithDatapoints(ctx context.Context, goalSlug string) (*Goal, error)
 	FetchGoalRawJSON(ctx context.Context, goalSlug string, includeDatapoints bool) (json.RawMessage, error)
@@ -157,10 +158,12 @@ func (c *HTTPClient) FetchUserTimezone(ctx context.Context) (string, error) {
 // See the Client interface for the contract. The auth_token is injected into
 // the query string for GET/DELETE and into the form body for methods that
 // carry one (POST/PUT/PATCH).
-func (c *HTTPClient) APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error) {
+func (c *HTTPClient) APIRequest(ctx context.Context, method, path string, params url.Values) (int, []byte, error) {
 	values := url.Values{}
-	for k, v := range params {
-		values.Set(k, v)
+	for k, vs := range params {
+		for _, v := range vs {
+			values.Add(k, v)
+		}
 	}
 	// Set auth_token last so the stored credential always wins, even if the
 	// caller passed an auth_token param — honoring the "injected automatically"

--- a/client.go
+++ b/client.go
@@ -159,36 +159,39 @@ func (c *HTTPClient) FetchUserTimezone(ctx context.Context) (string, error) {
 // the query string for GET/DELETE and into the form body for methods that
 // carry one (POST/PUT/PATCH).
 func (c *HTTPClient) APIRequest(ctx context.Context, method, path string, params url.Values) (int, []byte, error) {
-	values := url.Values{}
+	u, err := url.Parse(fmt.Sprintf("%s/api/v1/%s", c.baseURL(), strings.TrimPrefix(path, "/")))
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid API path: %w", err)
+	}
+
+	// Start from any query already embedded in path, then layer caller params on
+	// top (caller wins per key). Parsing rather than string-concatenating means
+	// a path like "...?auth_token=x" can't smuggle in a duplicate auth_token.
+	values := u.Query()
 	for k, vs := range params {
+		values.Del(k)
 		for _, v := range vs {
 			values.Add(k, v)
 		}
 	}
-	// Set auth_token last so the stored credential always wins, even if the
-	// caller passed an auth_token param — honoring the "injected automatically"
-	// contract.
+	// Set auth_token last so the stored credential always wins over anything in
+	// the path or params — honoring the "injected automatically" contract.
 	values.Set("auth_token", c.config.AuthToken)
-
-	apiURL := fmt.Sprintf("%s/api/v1/%s", c.baseURL(), strings.TrimPrefix(path, "/"))
 
 	var reqBody io.Reader
 	contentType := ""
 	switch method {
 	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		// Carry everything (including auth_token) in the form body.
+		u.RawQuery = ""
 		reqBody = strings.NewReader(values.Encode())
 		contentType = "application/x-www-form-urlencoded"
 	default:
-		// GET/DELETE: carry everything in the query string, preserving any
-		// query the caller already included in path.
-		sep := "?"
-		if strings.Contains(apiURL, "?") {
-			sep = "&"
-		}
-		apiURL += sep + values.Encode()
+		// GET/DELETE: carry everything in the query string.
+		u.RawQuery = values.Encode()
 	}
 
-	resp, err := c.doRequest(ctx, method, apiURL, reqBody, contentType)
+	resp, err := c.doRequest(ctx, method, u.String(), reqBody, contentType)
 	if err != nil {
 		return 0, nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/client.go
+++ b/client.go
@@ -159,10 +159,13 @@ func (c *HTTPClient) FetchUserTimezone(ctx context.Context) (string, error) {
 // carry one (POST/PUT/PATCH).
 func (c *HTTPClient) APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error) {
 	values := url.Values{}
-	values.Set("auth_token", c.config.AuthToken)
 	for k, v := range params {
 		values.Set(k, v)
 	}
+	// Set auth_token last so the stored credential always wins, even if the
+	// caller passed an auth_token param — honoring the "injected automatically"
+	// contract.
+	values.Set("auth_token", c.config.AuthToken)
 
 	apiURL := fmt.Sprintf("%s/api/v1/%s", c.baseURL(), strings.TrimPrefix(path, "/"))
 

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"time"
 )
 
@@ -26,7 +27,7 @@ import (
 type FakeClient struct {
 	FetchGoalsFunc                  func() ([]Goal, error)
 	FetchUserTimezoneFunc           func() (string, error)
-	APIRequestFunc                  func(method, path string, params map[string]string) (int, []byte, error)
+	APIRequestFunc                  func(method, path string, params url.Values) (int, []byte, error)
 	FetchGoalFunc                   func(goalSlug string) (*Goal, error)
 	FetchGoalWithDatapointsFunc     func(goalSlug string) (*Goal, error)
 	FetchGoalRawJSONFunc            func(goalSlug string, includeDatapoints bool) (json.RawMessage, error)
@@ -61,7 +62,7 @@ func (c *FakeClient) FetchUserTimezone(ctx context.Context) (string, error) {
 	return c.FetchUserTimezoneFunc()
 }
 
-func (c *FakeClient) APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error) {
+func (c *FakeClient) APIRequest(ctx context.Context, method, path string, params url.Values) (int, []byte, error) {
 	if c.APIRequestFunc == nil {
 		return 0, nil, errFakeNotConfigured
 	}

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -26,6 +26,7 @@ import (
 type FakeClient struct {
 	FetchGoalsFunc                  func() ([]Goal, error)
 	FetchUserTimezoneFunc           func() (string, error)
+	APIRequestFunc                  func(method, path string, params map[string]string) (int, []byte, error)
 	FetchGoalFunc                   func(goalSlug string) (*Goal, error)
 	FetchGoalWithDatapointsFunc     func(goalSlug string) (*Goal, error)
 	FetchGoalRawJSONFunc            func(goalSlug string, includeDatapoints bool) (json.RawMessage, error)
@@ -58,6 +59,13 @@ func (c *FakeClient) FetchUserTimezone(ctx context.Context) (string, error) {
 		return "", errFakeNotConfigured
 	}
 	return c.FetchUserTimezoneFunc()
+}
+
+func (c *FakeClient) APIRequest(ctx context.Context, method, path string, params map[string]string) (int, []byte, error) {
+	if c.APIRequestFunc == nil {
+		return 0, nil, errFakeNotConfigured
+	}
+	return c.APIRequestFunc(method, path, params)
 }
 
 func (c *FakeClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, error) {

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func printHelp() {
 	fmt.Println("  buzz ratchet [-y|--yes] <goalslug> <days>")
 	fmt.Println("                                    Remove safety buffer, leaving <days> of buffer on the goal")
 	fmt.Println("                                    -y, --yes: Skip the confirmation prompt")
+	fmt.Println("  buzz api [-X <method>] [-d <key=value>]... <path>")
+	fmt.Println("                                    Make a raw authenticated Beeminder API request")
+	fmt.Println("                                    e.g. buzz api users/me.json")
 	fmt.Println("  buzz auth login                   Authenticate by pasting your Beeminder API credentials")
 	fmt.Println("  buzz help                         Show this help message")
 	fmt.Println("")
@@ -147,6 +150,9 @@ func main() {
 		case "ratchet":
 			handleRatchetCommand()
 			return
+		case "api":
+			handleAPICommand()
+			return
 		case "auth":
 			handleAuthCommand()
 			return
@@ -158,7 +164,7 @@ func main() {
 			return
 		default:
 			fmt.Printf("Unknown command: %s\n", os.Args[1])
-			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, ratchet, auth, help, version")
+			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, ratchet, api, auth, help, version")
 			fmt.Println("Run 'buzz --help' for more information.")
 			os.Exit(1)
 		}


### PR DESCRIPTION
Closes #227.

Adds `buzz api`, a raw passthrough to the Beeminder API that authenticates with your stored buzz credentials — so you can hit any endpoint without hand-building URLs or pasting your `auth_token`.

```
buzz api users/me.json
buzz api users/me/goals/read.json
buzz api -X POST -d value=1 -d "comment=via buzz" users/me/goals/read/datapoints.json
```

## Behavior
- `<path>` is relative to the API root (leading slash optional); an existing query string is preserved.
- `-X/--method` selects the HTTP method (GET default; POST/PUT/PATCH/DELETE supported, case-insensitive).
- `-d/--data key=value` is repeatable; sent as query params for GET/DELETE and as a urlencoded form body otherwise.
- `auth_token` is injected automatically (and redacted from any error output).
- JSON responses are pretty-printed; non-JSON bodies print raw. A non-2xx status exits nonzero **but still prints the body**, so API error messages stay visible.

## Implementation
- New `Client.APIRequest(ctx, method, path, params)` returning `(status, body, err)` — a non-2xx status is *not* an error, leaving interpretation to the caller.
- Command core extracted to `runAPICommand(args, client, stdout, stderr) int` for testability; `handleAPICommand` only loads config and builds the client.
- Wired into dispatch, help text, and the unknown-command list.

## Tests
- `APIRequest` via httptest: GET puts auth_token+params in the query; POST puts them in the form body; leading slash + existing query handled; non-2xx returned (not errored).
- `runAPICommand` table tests against the fake client: JSON pretty-print, POST method/param passthrough, raw-body fallback, non-2xx exit code, and all the validation/error paths; plus `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `buzz api` command to make raw authenticated API requests from the CLI
  * Supports HTTP methods (GET, POST, PUT, PATCH, DELETE) via `--method`/`-X`
  * Accepts repeatable `--data`/`-d` key=value parameters and preserves repeated keys
  * Pretty-prints JSON responses when possible; prints raw body otherwise
  * Returns non‑zero exit codes for errors and non‑2xx HTTP responses; includes usage/help text for the command
<!-- end of auto-generated comment: release notes by coderabbit.ai -->