### PR TITLE
fix(add): poll lightweight datapoints endpoint when confirming a datapoint

### DIFF
--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2594,18 +2594,18 @@ func TestFetchGoalsWithDatapointsManyGoals(t *testing.T) {
 	}
 }
 
-// goalWithDatapointsHandler returns an httptest handler that serves a goal whose
-// datapoints include `target` only once `appearOnCall` requests have been made,
-// counting calls into `calls`.
+// goalWithDatapointsHandler returns an httptest handler that serves the recent
+// datapoints list (the endpoint WaitForDatapoint polls), including `target` only
+// once `appearOnCall` requests have been made, counting calls into `calls`.
 func goalWithDatapointsHandler(t *testing.T, calls *atomic.Int32, target string, appearOnCall int32) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		w.WriteHeader(http.StatusOK)
 		if n >= appearOnCall {
-			fmt.Fprintf(w, `{"slug":"g","datapoints":[{"id":%q}]}`, target)
+			fmt.Fprintf(w, `[{"id":%q}]`, target)
 		} else {
-			w.Write([]byte(`{"slug":"g","datapoints":[]}`))
+			w.Write([]byte(`[]`))
 		}
 	}
 }

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2594,10 +2594,10 @@ func TestFetchGoalsWithDatapointsManyGoals(t *testing.T) {
 	}
 }
 
-// goalWithDatapointsHandler returns an httptest handler that serves the recent
+// recentDatapointsHandler returns an httptest handler that serves the recent
 // datapoints list (the endpoint WaitForDatapoint polls), including `target` only
 // once `appearOnCall` requests have been made, counting calls into `calls`.
-func goalWithDatapointsHandler(t *testing.T, calls *atomic.Int32, target string, appearOnCall int32) http.HandlerFunc {
+func recentDatapointsHandler(t *testing.T, calls *atomic.Int32, target string, appearOnCall int32) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Confirm WaitForDatapoint hits the lightweight datapoints endpoint with
@@ -2626,7 +2626,7 @@ func goalWithDatapointsHandler(t *testing.T, calls *atomic.Int32, target string,
 func TestWaitForDatapoint(t *testing.T) {
 	t.Run("returns nil once the datapoint appears after polling", func(t *testing.T) {
 		var calls atomic.Int32
-		srv := httptest.NewServer(goalWithDatapointsHandler(t, &calls, "target", 3))
+		srv := httptest.NewServer(recentDatapointsHandler(t, &calls, "target", 3))
 		defer srv.Close()
 		c := NewHTTPClient(&Config{Username: "u", AuthToken: "t", BaseURL: srv.URL})
 
@@ -2642,7 +2642,7 @@ func TestWaitForDatapoint(t *testing.T) {
 	t.Run("times out when the datapoint never appears", func(t *testing.T) {
 		var calls atomic.Int32
 		// appearOnCall huge → never returns the target.
-		srv := httptest.NewServer(goalWithDatapointsHandler(t, &calls, "target", 1<<30))
+		srv := httptest.NewServer(recentDatapointsHandler(t, &calls, "target", 1<<30))
 		defer srv.Close()
 		c := NewHTTPClient(&Config{Username: "u", AuthToken: "t", BaseURL: srv.URL})
 
@@ -2697,7 +2697,7 @@ func TestWaitForDatapoint(t *testing.T) {
 
 	t.Run("zero timeout still polls once", func(t *testing.T) {
 		var calls atomic.Int32
-		srv := httptest.NewServer(goalWithDatapointsHandler(t, &calls, "target", 1)) // present immediately
+		srv := httptest.NewServer(recentDatapointsHandler(t, &calls, "target", 1)) // present immediately
 		defer srv.Close()
 		c := NewHTTPClient(&Config{Username: "u", AuthToken: "t", BaseURL: srv.URL})
 
@@ -2711,7 +2711,7 @@ func TestWaitForDatapoint(t *testing.T) {
 
 	t.Run("zero timeout not found errors after one poll", func(t *testing.T) {
 		var calls atomic.Int32
-		srv := httptest.NewServer(goalWithDatapointsHandler(t, &calls, "target", 1<<30)) // never present
+		srv := httptest.NewServer(recentDatapointsHandler(t, &calls, "target", 1<<30)) // never present
 		defer srv.Close()
 		c := NewHTTPClient(&Config{Username: "u", AuthToken: "t", BaseURL: srv.URL})
 
@@ -2751,7 +2751,7 @@ func TestWaitForDatapointCallerCancellation(t *testing.T) {
 	// A cancelled caller context returns context.Canceled verbatim, not the
 	// "did not appear" timeout error.
 	var calls atomic.Int32
-	srv := httptest.NewServer(goalWithDatapointsHandler(t, &calls, "target", 1<<30)) // never present
+	srv := httptest.NewServer(recentDatapointsHandler(t, &calls, "target", 1<<30)) // never present
 	defer srv.Close()
 	c := NewHTTPClient(&Config{Username: "u", AuthToken: "t", BaseURL: srv.URL})
 

--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -2600,6 +2600,19 @@ func TestFetchGoalsWithDatapointsManyGoals(t *testing.T) {
 func goalWithDatapointsHandler(t *testing.T, calls *atomic.Int32, target string, appearOnCall int32) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Confirm WaitForDatapoint hits the lightweight datapoints endpoint with
+		// the expected params, not the full-history goal fetch — otherwise this
+		// regression test would pass even if the client called the wrong path.
+		if got := r.URL.Path; !strings.HasSuffix(got, "/goals/g/datapoints.json") {
+			t.Errorf("expected the datapoints endpoint, got path %q", got)
+		}
+		q := r.URL.Query()
+		if got := q.Get("sort"); got != "updated_at" {
+			t.Errorf("expected sort=updated_at, got %q", got)
+		}
+		if got := q.Get("count"); got == "" {
+			t.Error("expected a count query param to bound the fetch, got none")
+		}
 		n := calls.Add(1)
 		w.WriteHeader(http.StatusOK)
 		if n >= appearOnCall {

--- a/client.go
+++ b/client.go
@@ -496,9 +496,12 @@ func (c *HTTPClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, err
 }
 
 // datapointPollCount is how many recent datapoints WaitForDatapoint fetches per
-// poll. A just-added datapoint sorts to the top by updated_at; the small margin
-// tolerates concurrent additions without fetching the goal's full history.
-const datapointPollCount = 10
+// poll. A just-added datapoint sorts to the top by updated_at, so the target is
+// only missed if this many *other* datapoints get a newer updated_at within the
+// poll window — implausible for the interactive single-add flow. The generous
+// margin makes that effectively impossible while still bounding the payload (the
+// whole point of not refetching the goal's full history).
+const datapointPollCount = 90
 
 // fetchRecentDatapoints returns the goal's most recently updated datapoints via
 // the dedicated datapoints endpoint, capped at count. This is far cheaper than

--- a/client.go
+++ b/client.go
@@ -318,7 +318,12 @@ func (c *HTTPClient) WaitForDatapoint(parent context.Context, goalSlug, datapoin
 	}
 
 	for {
-		goal, err := c.FetchGoalWithDatapoints(ctx, goalSlug)
+		// Poll the lightweight recent-datapoints list rather than the goal's
+		// full history (?datapoints=true): the latter grows with the goal and
+		// can take longer than the whole poll timeout, which manifested as
+		// "context deadline exceeded". A just-added datapoint sorts to the top
+		// by updated_at, so a small count reliably surfaces it.
+		dps, err := c.fetchRecentDatapoints(ctx, goalSlug, datapointPollCount)
 		if err != nil {
 			if isPermanentAPIError(err) {
 				return err
@@ -327,8 +332,8 @@ func (c *HTTPClient) WaitForDatapoint(parent context.Context, goalSlug, datapoin
 			// message and retry until the deadline.
 			lastErr = err
 		} else {
-			for i := range goal.Datapoints {
-				if goal.Datapoints[i].ID == datapointID {
+			for i := range dps {
+				if dps[i].ID == datapointID {
 					return nil
 				}
 			}
@@ -488,6 +493,37 @@ func (c *HTTPClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, err
 	}
 
 	return &goal, nil
+}
+
+// datapointPollCount is how many recent datapoints WaitForDatapoint fetches per
+// poll. A just-added datapoint sorts to the top by updated_at; the small margin
+// tolerates concurrent additions without fetching the goal's full history.
+const datapointPollCount = 10
+
+// fetchRecentDatapoints returns the goal's most recently updated datapoints via
+// the dedicated datapoints endpoint, capped at count. This is far cheaper than
+// FetchGoalWithDatapoints (which pulls the entire history) and is used for the
+// quick post-add confirmation poll.
+func (c *HTTPClient) fetchRecentDatapoints(ctx context.Context, goalSlug string, count int) ([]Datapoint, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/datapoints.json?auth_token=%s&sort=updated_at&count=%d",
+		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken, count)
+
+	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch datapoints: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var dps []Datapoint
+	if err := json.NewDecoder(resp.Body).Decode(&dps); err != nil {
+		return nil, fmt.Errorf("failed to decode datapoints: %w", err)
+	}
+
+	return dps, nil
 }
 
 // FetchGoalWithDatapoints fetches goal details including recent datapoints.


### PR DESCRIPTION
## Problem

`buzz add` reported a scary warning even though the add succeeded:

```
Warning: datapoint not confirmed yet: datapoint 6a24cb23… did not appear within 10s
(last error: failed to fetch goal details: Get ".../goals/techtainment.json?...&datapoints=true": context deadline exceeded)
```

`WaitForDatapoint` (added in #288) confirmed the new datapoint by polling `FetchGoalWithDatapoints` — `GET /goals/<slug>.json?datapoints=true`, which returns the goal **plus its entire datapoint history**. On a goal with a long history that response is large and slow, and since the whole poll budget is one shared context deadline, a single fetch can exceed it. The add itself still succeeded; only the confirmation poll failed — but it recurs on any high-history goal.

## Fix

Poll the dedicated, lightweight datapoints endpoint instead:

```
GET /goals/<slug>/datapoints.json?sort=updated_at&count=10
```

A just-added datapoint sorts to the top by `updated_at`, so a small `count` reliably surfaces it while keeping each fetch tiny and fast — no more deadline overruns.

- New `HTTPClient.fetchRecentDatapoints(ctx, slug, count)` + `datapointPollCount = 10`.
- `WaitForDatapoint` loops over it instead of the full-history goal fetch.
- Test handler updated to serve the bare datapoint array the endpoint returns.

Fail-fast on permanent errors (401/403/404), timeout handling, and caller cancellation are unchanged. `FetchGoalWithDatapoints` remains in use by `buzz review`.

## Testing

`go build ./...`, `go test ./...`, and `go vet ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test mock responses for datapoint polling endpoint

* **Refactor**
  * Optimized datapoint polling to use a lightweight endpoint for improved efficiency, reducing network overhead while maintaining reliability and timeout handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->