### PR TITLE
refactor(tui): extract input forms as a deep, testable module (#246)

### DIFF
--- a/docs/adr/0001-extract-input-forms-not-bisect-appmodel.md
+++ b/docs/adr/0001-extract-input-forms-not-bisect-appmodel.md
@@ -1,0 +1,17 @@
+# Extract input forms as a deep module; do not bisect appModel into domain/UI halves
+
+**Status:** accepted
+
+In addressing #246 ("Separate UI state from domain state in appModel"), we rejected the issue's own proposed direction — splitting `appModel` into a domain struct (goals/config/selection) plus UI sub-states — because it fails the deletion test: navigation handlers inherently need `goals` *and* `cursor` *and* `width` (for column layout) *and* `scrollRow` together, so bisecting the struct only relocates fields without concentrating any complexity. Instead we extracted the real deep module: a generic `form` (a `[]field` with per-field rune filters, a focus index, and shared `handleRune`/`backspace`/`tab` behavior), with thin typed wrappers (`datapointForm`, `createGoalForm`) that embed it, add named accessors, lifecycle flags, and a `validate()`. This concentrates the char-filter ↔ deletion ↔ focus logic in one place whose small interface *is* the unit-test surface — which is the concrete cost #246 identified (interactive handlers were untestable because constructing an `appModel` required dozens of unrelated fields).
+
+## Considered options
+
+- **Bisect `appModel` into domain vs UI structs** (the issue's proposal) — rejected; shallow reorg, fights Bubble Tea idioms, and the issue itself flagged it as low-confidence.
+- **Three concrete form structs with duplicated cycling/backspace logic** — rejected; three adapters of the same pattern is a real seam asking for one deep module, not three shallow copies.
+- **Generic `form` + thin typed wrappers** — chosen.
+
+## Consequences
+
+- `appModel` still holds `goals`, `cursor`, and the UI mode booleans (`searchMode`, `showModal`, `inputMode`, `showCreateModal`, `modalGoal`). A reader expecting a clean domain/UI split after #246 will not find one — that was deliberate.
+- `search` was left as plain `appModel` state (single field, no focus/validation) rather than forced into the form abstraction.
+- The mode booleans remain a booleans-as-state-machine smell, deferred to a focused follow-up: collapse them into a `Mode` enum (#292).

--- a/form.go
+++ b/form.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// field is a single text input within a form: its current value and a filter
+// predicate deciding whether a typed character is accepted. current is the
+// field's existing value, letting a filter make context-dependent decisions
+// (e.g. accepting a character only if it extends a valid prefix of "null").
+type field struct {
+	value  string
+	filter func(char, current string) bool
+}
+
+// form is the shared behavior for multi-field text entry: a set of fields, the
+// index of the focused one, and a validation error string. handleRune,
+// backspace, and tab are the entire input-handling surface, exercised directly
+// in form_test.go without constructing the surrounding appModel.
+type form struct {
+	fields []field
+	focus  int
+	err    string
+}
+
+// handleRune applies the focused field's filter to r and appends it on success.
+// It reports whether the character was accepted.
+func (f *form) handleRune(r rune) bool {
+	if f.focus < 0 || f.focus >= len(f.fields) {
+		return false
+	}
+	fld := &f.fields[f.focus]
+	char := string(r)
+	if fld.filter(char, fld.value) {
+		fld.value += char
+		return true
+	}
+	return false
+}
+
+// backspace removes the last rune from the focused field. It trims a whole
+// rune rather than a single byte so deleting a multibyte character (the
+// comment/title/gunits fields accept any printable Unicode) leaves valid UTF-8.
+func (f *form) backspace() {
+	if f.focus < 0 || f.focus >= len(f.fields) {
+		return
+	}
+	fld := &f.fields[f.focus]
+	if len(fld.value) > 0 {
+		_, size := utf8.DecodeLastRuneInString(fld.value)
+		fld.value = fld.value[:len(fld.value)-size]
+	}
+}
+
+// val returns the value of field i, or "" if i is out of range. This keeps
+// named accessors safe to call on a zero-value form (nil fields), which the
+// view does when a modal is open but its form has not been initialized yet.
+func (f *form) val(i int) string {
+	if i < 0 || i >= len(f.fields) {
+		return ""
+	}
+	return f.fields[i].value
+}
+
+// tab moves focus to the next field, or the previous one when reverse is true,
+// wrapping around.
+func (f *form) tab(reverse bool) {
+	n := len(f.fields)
+	if n == 0 {
+		return
+	}
+	if reverse {
+		f.focus = (f.focus + n - 1) % n
+	} else {
+		f.focus = (f.focus + 1) % n
+	}
+}
+
+// Field filters. Each adapts an existing character predicate (defined in
+// handlers.go) to the field.filter signature, so behavior is identical to the
+// pre-extraction handlers.
+
+func filterSlug(char, _ string) bool            { return isAlphanumericOrDash(char) }
+func filterLetter(char, _ string) bool          { return isLetter(char) }
+func filterIntOrNull(char, cur string) bool     { return isNumericOrNull(char, cur) }
+func filterDecimalOrNull(char, cur string) bool { return isNumericWithDecimal(char, cur) }
+
+// filterPrintable accepts any single printable Unicode character.
+func filterPrintable(char, _ string) bool {
+	runes := []rune(char)
+	return len(runes) == 1 && unicode.IsPrint(runes[0])
+}
+
+// filterDate accepts digits and dashes (YYYY-MM-DD entry).
+func filterDate(char, _ string) bool {
+	return (char >= "0" && char <= "9") || char == "-"
+}
+
+// filterDecimal accepts digits, a decimal point, and a negative sign.
+func filterDecimal(char, _ string) bool {
+	return (char >= "0" && char <= "9") || char == "." || char == "-"
+}
+
+// datapointForm is the in-progress datapoint entry shown inside the goal detail
+// modal: the date/value/comment fields plus whether a submission is in flight.
+type datapointForm struct {
+	form
+	submitting bool
+}
+
+// Field indices for datapointForm.
+const (
+	dpDate = iota
+	dpValue
+	dpComment
+)
+
+// newDatapointForm builds a datapoint entry form with sensible defaults.
+// defaultValue is the pre-filled value field (typically the goal's last
+// datapoint value, or "1").
+func newDatapointForm(defaultValue string) datapointForm {
+	fields := make([]field, 3)
+	fields[dpDate] = field{value: time.Now().Format("2006-01-02"), filter: filterDate}
+	fields[dpValue] = field{value: defaultValue, filter: filterDecimal}
+	fields[dpComment] = field{value: "Added via buzz", filter: filterPrintable}
+	return datapointForm{form: form{fields: fields}}
+}
+
+func (d *datapointForm) date() string    { return d.val(dpDate) }
+func (d *datapointForm) value() string   { return d.val(dpValue) }
+func (d *datapointForm) comment() string { return d.val(dpComment) }
+
+// validate reports a validation error message, or "" when the form is valid.
+func (d *datapointForm) validate() string {
+	return validateDatapointInput(d.date(), d.value())
+}
+
+// createGoalForm is the in-progress new-goal entry shown in the create modal.
+type createGoalForm struct {
+	form
+	creating bool
+}
+
+// Field indices for createGoalForm.
+const (
+	cgSlug = iota
+	cgTitle
+	cgGoalType
+	cgGunits
+	cgGoaldate
+	cgGoalval
+	cgRate
+)
+
+// newCreateGoalForm builds a goal-creation form with the default goal type,
+// units, value, and rate pre-filled.
+func newCreateGoalForm() createGoalForm {
+	fields := make([]field, 7)
+	fields[cgSlug] = field{filter: filterSlug}
+	fields[cgTitle] = field{filter: filterPrintable}
+	fields[cgGoalType] = field{value: "hustler", filter: filterLetter}
+	fields[cgGunits] = field{value: "units", filter: filterPrintable}
+	fields[cgGoaldate] = field{filter: filterIntOrNull}
+	fields[cgGoalval] = field{value: "0", filter: filterDecimalOrNull}
+	fields[cgRate] = field{value: "1", filter: filterDecimalOrNull}
+	return createGoalForm{form: form{fields: fields}}
+}
+
+func (c *createGoalForm) slug() string     { return c.val(cgSlug) }
+func (c *createGoalForm) title() string    { return c.val(cgTitle) }
+func (c *createGoalForm) goalType() string { return c.val(cgGoalType) }
+func (c *createGoalForm) gunits() string   { return c.val(cgGunits) }
+func (c *createGoalForm) goaldate() string { return c.val(cgGoaldate) }
+func (c *createGoalForm) goalval() string  { return c.val(cgGoalval) }
+func (c *createGoalForm) rate() string     { return c.val(cgRate) }
+
+// validate reports a validation error message, or "" when the form is valid.
+func (c *createGoalForm) validate() string {
+	return validateCreateGoalInput(c.slug(), c.title(), c.goalType(), c.gunits(),
+		c.goaldate(), c.goalval(), c.rate())
+}

--- a/form_test.go
+++ b/form_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// typeInto feeds each rune of s into the form one at a time, returning the slice
+// of per-rune handled results.
+func typeInto(f *form, s string) []bool {
+	results := make([]bool, 0, len(s))
+	for _, r := range s {
+		results = append(results, f.handleRune(r))
+	}
+	return results
+}
+
+// TestFormHandleRuneAppendsAcceptedRunes verifies that handleRune appends only
+// characters the focused field's filter accepts, and reports acceptance.
+func TestFormHandleRuneAppendsAcceptedRunes(t *testing.T) {
+	f := &form{fields: []field{{filter: filterDecimal}}}
+
+	if !f.handleRune('1') {
+		t.Fatal("expected '1' to be accepted by filterDecimal")
+	}
+	if f.handleRune('a') {
+		t.Error("expected 'a' to be rejected by filterDecimal")
+	}
+	if !f.handleRune('.') {
+		t.Error("expected '.' to be accepted by filterDecimal")
+	}
+	if got := f.fields[0].value; got != "1." {
+		t.Errorf("field value = %q, want %q", got, "1.")
+	}
+}
+
+// TestFormHandleRuneRoutesToFocusedField verifies that input lands in the
+// currently focused field, not its neighbours.
+func TestFormHandleRuneRoutesToFocusedField(t *testing.T) {
+	f := &form{fields: []field{
+		{filter: filterPrintable},
+		{filter: filterPrintable},
+	}}
+
+	f.handleRune('a') // focus 0
+	f.tab(false)      // focus 1
+	f.handleRune('b')
+
+	if f.fields[0].value != "a" {
+		t.Errorf("field[0] = %q, want %q", f.fields[0].value, "a")
+	}
+	if f.fields[1].value != "b" {
+		t.Errorf("field[1] = %q, want %q", f.fields[1].value, "b")
+	}
+}
+
+// TestFormHandleRuneOutOfRangeFocus verifies handleRune is safe when focus is
+// out of range (e.g. a malformed form) and reports the rune unhandled.
+func TestFormHandleRuneOutOfRangeFocus(t *testing.T) {
+	f := &form{fields: []field{{filter: filterPrintable}}, focus: 5}
+	if f.handleRune('x') {
+		t.Error("expected out-of-range focus to reject input")
+	}
+}
+
+// TestFormBackspace verifies backspace trims the focused field and is a no-op on
+// an empty field.
+func TestFormBackspace(t *testing.T) {
+	f := &form{fields: []field{{value: "abc", filter: filterPrintable}}}
+
+	f.backspace()
+	if f.fields[0].value != "ab" {
+		t.Errorf("after backspace, field = %q, want %q", f.fields[0].value, "ab")
+	}
+
+	f.fields[0].value = ""
+	f.backspace() // must not panic or underflow
+	if f.fields[0].value != "" {
+		t.Errorf("backspace on empty field = %q, want empty", f.fields[0].value)
+	}
+}
+
+// TestFormBackspaceTrimsWholeRune verifies backspace removes an entire multibyte
+// rune, leaving valid UTF-8 (a byte-trim would corrupt the string).
+func TestFormBackspaceTrimsWholeRune(t *testing.T) {
+	f := &form{fields: []field{{value: "a中😀", filter: filterPrintable}}}
+
+	f.backspace() // drop the emoji (4 bytes)
+	if f.fields[0].value != "a中" {
+		t.Errorf("after backspace = %q, want %q", f.fields[0].value, "a中")
+	}
+	f.backspace() // drop the CJK char (3 bytes)
+	if f.fields[0].value != "a" {
+		t.Errorf("after second backspace = %q, want %q", f.fields[0].value, "a")
+	}
+	if !utf8.ValidString(f.fields[0].value) {
+		t.Errorf("field is not valid UTF-8 after backspace: %q", f.fields[0].value)
+	}
+}
+
+// TestFormTabWraps verifies tab cycles forward and backward with wrap-around.
+func TestFormTabWraps(t *testing.T) {
+	f := &form{fields: make([]field, 3)}
+
+	f.tab(false)
+	if f.focus != 1 {
+		t.Errorf("after tab, focus = %d, want 1", f.focus)
+	}
+	f.tab(false)
+	f.tab(false) // 1 -> 2 -> 0 (wrap)
+	if f.focus != 0 {
+		t.Errorf("after wrapping tab, focus = %d, want 0", f.focus)
+	}
+	f.tab(true) // 0 -> 2 (reverse wrap)
+	if f.focus != 2 {
+		t.Errorf("after reverse tab, focus = %d, want 2", f.focus)
+	}
+}
+
+// TestFormValOutOfRange verifies val returns "" for out-of-range indices,
+// keeping named accessors safe on a zero-value form.
+func TestFormValOutOfRange(t *testing.T) {
+	var f form
+	if got := f.val(0); got != "" {
+		t.Errorf("val on nil fields = %q, want empty", got)
+	}
+}
+
+// TestDatapointFormDefaults verifies the datapoint form is constructed with the
+// expected defaults and the provided value.
+func TestDatapointFormDefaults(t *testing.T) {
+	d := newDatapointForm("7.5")
+	if d.value() != "7.5" {
+		t.Errorf("value() = %q, want %q", d.value(), "7.5")
+	}
+	if d.comment() != "Added via buzz" {
+		t.Errorf("comment() = %q, want %q", d.comment(), "Added via buzz")
+	}
+	if d.date() == "" {
+		t.Error("date() should default to today, got empty")
+	}
+}
+
+// TestDatapointFormFieldFilters verifies each datapoint field accepts/rejects
+// the right characters via handleRune — the char-filter ↔ focus interaction the
+// issue says only surfaced in manual TUI use.
+func TestDatapointFormFieldFilters(t *testing.T) {
+	d := newDatapointForm("")
+	// Clear the constructor's pre-filled date/comment so each field starts empty.
+	d.fields[dpDate].value = ""
+	d.fields[dpComment].value = ""
+
+	// Date field (focus 0): digits and dashes only.
+	if d.handleRune('a') {
+		t.Error("date field should reject letters")
+	}
+	typeInto(&d.form, "2024-01-15")
+	if d.date() != "2024-01-15" {
+		t.Errorf("date() = %q, want %q", d.date(), "2024-01-15")
+	}
+
+	// Value field (focus 1): digits, decimal, negative.
+	d.tab(false)
+	if d.handleRune('x') {
+		t.Error("value field should reject letters")
+	}
+	typeInto(&d.form, "-3.5")
+	if d.value() != "-3.5" {
+		t.Errorf("value() = %q, want %q", d.value(), "-3.5")
+	}
+
+	// Comment field (focus 2): any printable rune, including command keys.
+	d.tab(false)
+	typeInto(&d.form, "trd note 中")
+	if d.comment() != "trd note 中" {
+		t.Errorf("comment() = %q, want %q", d.comment(), "trd note 中")
+	}
+}
+
+// TestCreateGoalFormDefaults verifies the create-goal form's default field
+// values.
+func TestCreateGoalFormDefaults(t *testing.T) {
+	c := newCreateGoalForm()
+	cases := map[string]struct{ got, want string }{
+		"slug":     {c.slug(), ""},
+		"title":    {c.title(), ""},
+		"goalType": {c.goalType(), "hustler"},
+		"gunits":   {c.gunits(), "units"},
+		"goaldate": {c.goaldate(), ""},
+		"goalval":  {c.goalval(), "0"},
+		"rate":     {c.rate(), "1"},
+	}
+	for name, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s() = %q, want %q", name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestCreateGoalFormFieldFilters verifies the create-goal field filters,
+// including the "null" prefix behaviour for the goaldate/goalval/rate fields.
+func TestCreateGoalFormFieldFilters(t *testing.T) {
+	c := newCreateGoalForm()
+
+	// Slug (focus 0): alphanumeric, dash, underscore; no spaces.
+	if c.handleRune(' ') {
+		t.Error("slug should reject space")
+	}
+	typeInto(&c.form, "my-goal_1")
+	if c.slug() != "my-goal_1" {
+		t.Errorf("slug() = %q, want %q", c.slug(), "my-goal_1")
+	}
+
+	// Goal type (focus 2): letters only.
+	c.focus = cgGoalType
+	c.fields[cgGoalType].value = ""
+	if c.handleRune('1') {
+		t.Error("goal type should reject digits")
+	}
+	typeInto(&c.form, "biker")
+	if c.goalType() != "biker" {
+		t.Errorf("goalType() = %q, want %q", c.goalType(), "biker")
+	}
+
+	// Goaldate (focus 4): digits or the literal "null".
+	c.focus = cgGoaldate
+	if c.handleRune('x') {
+		t.Error("goaldate should reject non-digit, non-null chars")
+	}
+	typeInto(&c.form, "null")
+	if c.goaldate() != "null" {
+		t.Errorf("goaldate() = %q, want %q", c.goaldate(), "null")
+	}
+}
+
+// TestCreateGoalFormValidate verifies validate() delegates to the existing
+// validator: exactly two of (goaldate, goalval, rate) must be provided.
+func TestCreateGoalFormValidate(t *testing.T) {
+	c := newCreateGoalForm() // goalval=0, rate=1, goaldate="" => two provided
+	c.fields[cgSlug].value = "slug"
+	c.fields[cgTitle].value = "Title"
+	if got := c.validate(); got != "" {
+		t.Errorf("validate() = %q, want no error", got)
+	}
+
+	// Provide all three -> invalid.
+	c.fields[cgGoaldate].value = "1700000000"
+	if got := c.validate(); got == "" {
+		t.Error("validate() should fail when all three of goaldate/goalval/rate are set")
+	}
+}
+
+// TestDatapointFormValidate verifies validate() delegates to the existing
+// datapoint validator.
+func TestDatapointFormValidate(t *testing.T) {
+	d := newDatapointForm("5")
+	if got := d.validate(); got != "" {
+		t.Errorf("validate() with defaults = %q, want no error", got)
+	}
+
+	d.fields[dpValue].value = "not-a-number"
+	if got := d.validate(); got == "" {
+		t.Error("validate() should fail for non-numeric value")
+	}
+}

--- a/form_test.go
+++ b/form_test.go
@@ -231,6 +231,35 @@ func TestCreateGoalFormFieldFilters(t *testing.T) {
 	if c.goaldate() != "null" {
 		t.Errorf("goaldate() = %q, want %q", c.goaldate(), "null")
 	}
+
+	// Goalval (focus 5): digits, decimal, negative — or the literal "null".
+	c.focus = cgGoalval
+	c.fields[cgGoalval].value = ""
+	if c.handleRune('x') {
+		t.Error("goalval should reject letters that don't extend \"null\"")
+	}
+	typeInto(&c.form, "-2.5")
+	if c.goalval() != "-2.5" {
+		t.Errorf("goalval() = %q, want %q", c.goalval(), "-2.5")
+	}
+	c.fields[cgGoalval].value = ""
+	typeInto(&c.form, "null")
+	if c.goalval() != "null" {
+		t.Errorf("goalval() = %q, want %q", c.goalval(), "null")
+	}
+
+	// Rate (focus 6): same filter as goalval (filterDecimalOrNull).
+	c.focus = cgRate
+	c.fields[cgRate].value = ""
+	typeInto(&c.form, "3.5")
+	if c.rate() != "3.5" {
+		t.Errorf("rate() = %q, want %q", c.rate(), "3.5")
+	}
+	c.fields[cgRate].value = ""
+	typeInto(&c.form, "null")
+	if c.rate() != "null" {
+		t.Errorf("rate() = %q, want %q", c.rate(), "null")
+	}
 }
 
 // TestCreateGoalFormValidate verifies validate() delegates to the existing

--- a/handlers.go
+++ b/handlers.go
@@ -81,59 +81,16 @@ func isNumericWithDecimal(char string, currentValue string) bool {
 	return strings.HasPrefix("null", newValue)
 }
 
-// handleNumericDecimalInput handles input for fields that accept numeric with decimal values
-func handleNumericDecimalInput(m model, char string, fieldPtr *string) (model, bool) {
-	if isNumericWithDecimal(char, *fieldPtr) {
-		*fieldPtr += char
-		return m, true
-	}
-	return m, false
-}
-
 // handleCreateModalInput handles text input in create goal modal
 func handleCreateModalInput(m model, msg tea.KeyMsg) (model, bool) {
-	if !m.appModel.showCreateModal || m.appModel.creatingGoal {
+	if !m.appModel.showCreateModal || m.appModel.createGoal.creating {
 		return m, false
 	}
 	if len(msg.Runes) != 1 {
 		return m, false
 	}
-
-	char := string(msg.Runes)
-	r := msg.Runes[0]
-
-	switch m.appModel.createFocus {
-	case 0: // Slug - allow alphanumeric and dashes/underscores
-		if isAlphanumericOrDash(char) {
-			m.appModel.createSlug += char
-			return m, true
-		}
-	case 1: // Title - allow all printable Unicode characters
-		if unicode.IsPrint(r) {
-			m.appModel.createTitle += char
-			return m, true
-		}
-	case 2: // Goal type - allow letters
-		if isLetter(char) {
-			m.appModel.createGoalType += char
-			return m, true
-		}
-	case 3: // Gunits - allow all printable Unicode characters
-		if unicode.IsPrint(r) {
-			m.appModel.createGunits += char
-			return m, true
-		}
-	case 4: // Goaldate - allow digits or "null"
-		if isNumericOrNull(char, m.appModel.createGoaldate) {
-			m.appModel.createGoaldate += char
-			return m, true
-		}
-	case 5: // Goalval - allow digits, decimal point, negative sign, or "null"
-		return handleNumericDecimalInput(m, char, &m.appModel.createGoalval)
-	case 6: // Rate - allow digits, decimal point, negative sign, or "null"
-		return handleNumericDecimalInput(m, char, &m.appModel.createRate)
-	}
-	return m, false
+	handled := m.appModel.createGoal.handleRune(msg.Runes[0])
+	return m, handled
 }
 
 // handleDatapointInput handles text input in datapoint input mode
@@ -141,27 +98,10 @@ func handleDatapointInput(m model, msg tea.KeyMsg) (model, bool) {
 	// Handle text input in input mode
 	// This ensures that single-character command keys (like 't', 'r', 'd', etc.)
 	// can still be typed in comment fields
-	if m.appModel.showModal && m.appModel.inputMode && !m.appModel.submitting {
+	if m.appModel.showModal && m.appModel.inputMode && !m.appModel.datapoint.submitting {
 		if len(msg.Runes) == 1 {
-			char := string(msg.Runes)
-			r := msg.Runes[0]
-			switch m.appModel.inputFocus {
-			case 0: // Date field - allow digits and dashes
-				if (char >= "0" && char <= "9") || char == "-" {
-					m.appModel.inputDate += char
-					return m, true
-				}
-			case 1: // Value field - allow digits, decimal point, and negative sign
-				if (char >= "0" && char <= "9") || char == "." || char == "-" {
-					m.appModel.inputValue += char
-					return m, true
-				}
-			case 2: // Comment field - allow all printable Unicode characters
-				if unicode.IsPrint(r) {
-					m.appModel.inputComment += char
-					return m, true
-				}
-			}
+			handled := m.appModel.datapoint.handleRune(msg.Runes[0])
+			return m, handled
 		}
 	}
 	return m, false
@@ -268,13 +208,13 @@ func handleEscapeKey(m model) (tea.Model, tea.Cmd) {
 	} else if m.appModel.showCreateModal {
 		// Close create goal modal
 		m.appModel.showCreateModal = false
-		m.appModel.createError = ""
+		m.appModel.createGoal.err = ""
 	} else if m.appModel.showModal {
 		if m.appModel.inputMode {
 			// Exit input mode
 			m.appModel.inputMode = false
-			m.appModel.inputFocus = 0
-			m.appModel.inputError = ""
+			m.appModel.datapoint.focus = 0
+			m.appModel.datapoint.err = ""
 		} else {
 			// Close modal
 			m.appModel.showModal = false
@@ -288,75 +228,33 @@ func handleEscapeKey(m model) (tea.Model, tea.Cmd) {
 
 // handleAddDatapoint enters input mode for adding a datapoint
 func handleAddDatapoint(m model) (tea.Model, tea.Cmd) {
-	if m.appModel.showModal && !m.appModel.inputMode && !m.appModel.submitting {
+	if m.appModel.showModal && !m.appModel.inputMode && !m.appModel.datapoint.submitting {
 		m.appModel.inputMode = true
-		m.appModel.inputFocus = 0
-		m.appModel.inputError = "" // Clear any previous errors
-		// Set default values
-		m.appModel.inputDate = time.Now().Format("2006-01-02")
-		m.appModel.inputComment = "Added via buzz"
 
 		// Try to get the last datapoint value, default to "1" if it fails
+		defaultValue := "1"
 		if lastValue, err := m.appModel.client.GetLastDatapointValue(m.appModel.ctx, m.appModel.modalGoal.Slug); err == nil && lastValue != 0 {
-			m.appModel.inputValue = fmt.Sprintf("%.1f", lastValue)
-		} else {
-			m.appModel.inputValue = "1"
+			defaultValue = fmt.Sprintf("%.1f", lastValue)
 		}
+		m.appModel.datapoint = newDatapointForm(defaultValue)
 	}
 	return m, nil
 }
 
 // handleTabKey handles Tab and Shift+Tab navigation
 func handleTabKey(m model, reverse bool) (tea.Model, tea.Cmd) {
-	if m.appModel.showCreateModal && !m.appModel.creatingGoal {
-		if reverse {
-			m.appModel.createFocus = (m.appModel.createFocus + 6) % 7 // +6 is same as -1 in mod 7
-		} else {
-			m.appModel.createFocus = (m.appModel.createFocus + 1) % 7
-		}
-	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.submitting {
-		if reverse {
-			m.appModel.inputFocus = (m.appModel.inputFocus + 2) % 3 // +2 is same as -1 in mod 3
-		} else {
-			m.appModel.inputFocus = (m.appModel.inputFocus + 1) % 3
-		}
+	if m.appModel.showCreateModal && !m.appModel.createGoal.creating {
+		m.appModel.createGoal.tab(reverse)
+	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.datapoint.submitting {
+		m.appModel.datapoint.tab(reverse)
 	}
 	return m, nil
 }
 
 // handleBackspace handles Backspace key
 func handleBackspace(m model) (tea.Model, tea.Cmd) {
-	if m.appModel.showCreateModal && !m.appModel.creatingGoal {
-		switch m.appModel.createFocus {
-		case 0: // Slug
-			if len(m.appModel.createSlug) > 0 {
-				m.appModel.createSlug = m.appModel.createSlug[:len(m.appModel.createSlug)-1]
-			}
-		case 1: // Title
-			if len(m.appModel.createTitle) > 0 {
-				m.appModel.createTitle = m.appModel.createTitle[:len(m.appModel.createTitle)-1]
-			}
-		case 2: // Goal type
-			if len(m.appModel.createGoalType) > 0 {
-				m.appModel.createGoalType = m.appModel.createGoalType[:len(m.appModel.createGoalType)-1]
-			}
-		case 3: // Gunits
-			if len(m.appModel.createGunits) > 0 {
-				m.appModel.createGunits = m.appModel.createGunits[:len(m.appModel.createGunits)-1]
-			}
-		case 4: // Goaldate
-			if len(m.appModel.createGoaldate) > 0 {
-				m.appModel.createGoaldate = m.appModel.createGoaldate[:len(m.appModel.createGoaldate)-1]
-			}
-		case 5: // Goalval
-			if len(m.appModel.createGoalval) > 0 {
-				m.appModel.createGoalval = m.appModel.createGoalval[:len(m.appModel.createGoalval)-1]
-			}
-		case 6: // Rate
-			if len(m.appModel.createRate) > 0 {
-				m.appModel.createRate = m.appModel.createRate[:len(m.appModel.createRate)-1]
-			}
-		}
+	if m.appModel.showCreateModal && !m.appModel.createGoal.creating {
+		m.appModel.createGoal.backspace()
 	} else if m.appModel.searchMode && !m.appModel.showModal {
 		// Remove last character from search query
 		if len(m.appModel.searchQuery) > 0 {
@@ -366,21 +264,8 @@ func handleBackspace(m model) (tea.Model, tea.Cmd) {
 			m.appModel.scrollRow = 0
 			m.appModel.hasNavigated = false
 		}
-	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.submitting {
-		switch m.appModel.inputFocus {
-		case 0: // Date field
-			if len(m.appModel.inputDate) > 0 {
-				m.appModel.inputDate = m.appModel.inputDate[:len(m.appModel.inputDate)-1]
-			}
-		case 1: // Value field
-			if len(m.appModel.inputValue) > 0 {
-				m.appModel.inputValue = m.appModel.inputValue[:len(m.appModel.inputValue)-1]
-			}
-		case 2: // Comment field
-			if len(m.appModel.inputComment) > 0 {
-				m.appModel.inputComment = m.appModel.inputComment[:len(m.appModel.inputComment)-1]
-			}
-		}
+	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.datapoint.submitting {
+		m.appModel.datapoint.backspace()
 	}
 	return m, nil
 }
@@ -488,43 +373,41 @@ func validateCreateGoalInput(slug, title, goalType, gunits, goaldate, goalval, r
 
 // handleEnterKey handles Enter key press
 func handleEnterKey(m model) (tea.Model, tea.Cmd) {
-	if m.appModel.showCreateModal && !m.appModel.creatingGoal {
+	if m.appModel.showCreateModal && !m.appModel.createGoal.creating {
 		// Clear previous error
-		m.appModel.createError = ""
+		m.appModel.createGoal.err = ""
 
 		// Validate input fields
-		if errMsg := validateCreateGoalInput(m.appModel.createSlug, m.appModel.createTitle,
-			m.appModel.createGoalType, m.appModel.createGunits, m.appModel.createGoaldate,
-			m.appModel.createGoalval, m.appModel.createRate); errMsg != "" {
-			m.appModel.createError = errMsg
+		if errMsg := m.appModel.createGoal.validate(); errMsg != "" {
+			m.appModel.createGoal.err = errMsg
 			return m, nil
 		}
 
 		// Set creating state and submit goal creation asynchronously
-		m.appModel.creatingGoal = true
-		return m, createGoalCmd(m.appModel.ctx, m.appModel.client, m.appModel.createSlug, m.appModel.createTitle,
-			m.appModel.createGoalType, m.appModel.createGunits, m.appModel.createGoaldate,
-			m.appModel.createGoalval, m.appModel.createRate)
-	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.submitting {
+		m.appModel.createGoal.creating = true
+		return m, createGoalCmd(m.appModel.ctx, m.appModel.client, m.appModel.createGoal.slug(), m.appModel.createGoal.title(),
+			m.appModel.createGoal.goalType(), m.appModel.createGoal.gunits(), m.appModel.createGoal.goaldate(),
+			m.appModel.createGoal.goalval(), m.appModel.createGoal.rate())
+	} else if m.appModel.showModal && m.appModel.inputMode && !m.appModel.datapoint.submitting {
 		// Clear previous error
-		m.appModel.inputError = ""
+		m.appModel.datapoint.err = ""
 
 		// Validate input fields
-		if errMsg := validateDatapointInput(m.appModel.inputDate, m.appModel.inputValue); errMsg != "" {
-			m.appModel.inputError = errMsg
+		if errMsg := m.appModel.datapoint.validate(); errMsg != "" {
+			m.appModel.datapoint.err = errMsg
 			return m, nil
 		}
 
 		// Parse date to get timestamp. Interpret the entered calendar date in
 		// local time (matching validateDatapointInput) so the datapoint lands on
 		// the day the user intended rather than being shifted by the UTC offset.
-		date, _ := time.ParseInLocation("2006-01-02", m.appModel.inputDate, time.Local)
+		date, _ := time.ParseInLocation("2006-01-02", m.appModel.datapoint.date(), time.Local)
 		timestamp := fmt.Sprintf("%d", date.Unix())
 
 		// Set submitting state and submit datapoint asynchronously
-		m.appModel.submitting = true
+		m.appModel.datapoint.submitting = true
 		return m, submitDatapointCmd(m.appModel.ctx, m.appModel.client, m.appModel.modalGoal.Slug,
-			timestamp, m.appModel.inputValue, m.appModel.inputComment)
+			timestamp, m.appModel.datapoint.value(), m.appModel.datapoint.comment())
 	} else if !m.appModel.showModal {
 		// Show goal details modal (existing functionality)
 		displayGoals := m.appModel.getDisplayGoals()
@@ -590,7 +473,7 @@ func handleNavigationDown(m model) (tea.Model, tea.Cmd) {
 
 // handleNavigationLeft handles left arrow/h key
 func handleNavigationLeft(m model) (tea.Model, tea.Cmd) {
-	if m.appModel.showModal && !m.appModel.inputMode && !m.appModel.submitting && len(m.appModel.goals) > 0 {
+	if m.appModel.showModal && !m.appModel.inputMode && !m.appModel.datapoint.submitting && len(m.appModel.goals) > 0 {
 		// Navigate to previous goal in modal view
 		if m.appModel.cursor > 0 {
 			m.appModel.cursor--
@@ -618,7 +501,7 @@ func handleNavigationLeft(m model) (tea.Model, tea.Cmd) {
 
 // handleNavigationRight handles right arrow/l key
 func handleNavigationRight(m model) (tea.Model, tea.Cmd) {
-	if m.appModel.showModal && !m.appModel.inputMode && !m.appModel.submitting && len(m.appModel.goals) > 0 {
+	if m.appModel.showModal && !m.appModel.inputMode && !m.appModel.datapoint.submitting && len(m.appModel.goals) > 0 {
 		// Navigate to next goal in modal view
 		if m.appModel.cursor < len(m.appModel.goals)-1 {
 			m.appModel.cursor++
@@ -700,16 +583,7 @@ func handleEnterSearch(m model) (tea.Model, tea.Cmd) {
 func handleCreateGoal(m model) (tea.Model, tea.Cmd) {
 	if !m.appModel.showModal && !m.appModel.showCreateModal && !m.appModel.searchMode {
 		m.appModel.showCreateModal = true
-		m.appModel.createFocus = 0
-		m.appModel.createError = ""
-		// Set default values
-		m.appModel.createSlug = ""
-		m.appModel.createTitle = ""
-		m.appModel.createGoalType = "hustler"
-		m.appModel.createGunits = "units"
-		m.appModel.createGoaldate = ""
-		m.appModel.createGoalval = "0"
-		m.appModel.createRate = "1"
+		m.appModel.createGoal = newCreateGoalForm()
 	}
 	return m, nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -256,9 +257,12 @@ func handleBackspace(m model) (tea.Model, tea.Cmd) {
 	if m.appModel.showCreateModal && !m.appModel.createGoal.creating {
 		m.appModel.createGoal.backspace()
 	} else if m.appModel.searchMode && !m.appModel.showModal {
-		// Remove last character from search query
+		// Remove last character from search query. Trim a whole rune rather
+		// than a byte so backspacing a multibyte character (search accepts any
+		// printable Unicode) leaves valid UTF-8.
 		if len(m.appModel.searchQuery) > 0 {
-			m.appModel.searchQuery = m.appModel.searchQuery[:len(m.appModel.searchQuery)-1]
+			_, size := utf8.DecodeLastRuneInString(m.appModel.searchQuery)
+			m.appModel.searchQuery = m.appModel.searchQuery[:len(m.appModel.searchQuery)-size]
 			// Reset cursor and scroll when search query changes
 			m.appModel.cursor = 0
 			m.appModel.scrollRow = 0

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -15,6 +15,17 @@ func mockKeyMsg(runes []rune) tea.KeyMsg {
 	}
 }
 
+// mustModel asserts that a tea.Model is the concrete model type, failing the
+// test (rather than panicking) if not.
+func mustModel(t *testing.T, tm tea.Model) model {
+	t.Helper()
+	m, ok := tm.(model)
+	if !ok {
+		t.Fatalf("expected model, got %T", tm)
+	}
+	return m
+}
+
 // TestValidateDatapointInput tests the validateDatapointInput function
 func TestValidateDatapointInput(t *testing.T) {
 	tests := []struct {
@@ -664,7 +675,7 @@ func TestHandleBackspaceSearchTrimsWholeRune(t *testing.T) {
 	}
 
 	updated, _ := handleBackspace(m)
-	got := updated.(model).appModel.searchQuery
+	got := mustModel(t, updated).appModel.searchQuery
 	if got != "a中" {
 		t.Errorf("after backspace, searchQuery = %q, want %q", got, "a中")
 	}
@@ -679,12 +690,12 @@ func TestHandleTabKeyCreateGoal(t *testing.T) {
 	m := model{appModel: appModel{showCreateModal: true, createGoal: newCreateGoalForm()}}
 
 	updated, _ := handleTabKey(m, false)
-	if got := updated.(model).appModel.createGoal.focus; got != 1 {
+	if got := mustModel(t, updated).appModel.createGoal.focus; got != 1 {
 		t.Errorf("after tab, createGoal.focus = %d, want 1", got)
 	}
 
-	updated, _ = handleTabKey(updated.(model), true)
-	if got := updated.(model).appModel.createGoal.focus; got != 0 {
+	updated, _ = handleTabKey(mustModel(t, updated), true)
+	if got := mustModel(t, updated).appModel.createGoal.focus; got != 0 {
 		t.Errorf("after shift+tab, createGoal.focus = %d, want 0", got)
 	}
 
@@ -692,7 +703,7 @@ func TestHandleTabKeyCreateGoal(t *testing.T) {
 	busy := model{appModel: appModel{showCreateModal: true, createGoal: newCreateGoalForm()}}
 	busy.appModel.createGoal.creating = true
 	updated, _ = handleTabKey(busy, false)
-	if got := updated.(model).appModel.createGoal.focus; got != 0 {
+	if got := mustModel(t, updated).appModel.createGoal.focus; got != 0 {
 		t.Errorf("tab while creating should not move focus, got %d", got)
 	}
 }
@@ -703,13 +714,13 @@ func TestHandleTabKeyDatapoint(t *testing.T) {
 	m := model{appModel: appModel{showModal: true, inputMode: true, datapoint: newDatapointForm("1")}}
 
 	updated, _ := handleTabKey(m, false)
-	if got := updated.(model).appModel.datapoint.focus; got != 1 {
+	if got := mustModel(t, updated).appModel.datapoint.focus; got != 1 {
 		t.Errorf("after tab, datapoint.focus = %d, want 1", got)
 	}
 
 	// Shift+tab from focus 0 wraps to the last field (index 2).
 	updated, _ = handleTabKey(model{appModel: appModel{showModal: true, inputMode: true, datapoint: newDatapointForm("1")}}, true)
-	if got := updated.(model).appModel.datapoint.focus; got != 2 {
+	if got := mustModel(t, updated).appModel.datapoint.focus; got != 2 {
 		t.Errorf("after shift+tab wrap, datapoint.focus = %d, want 2", got)
 	}
 }
@@ -723,7 +734,7 @@ func TestHandleBackspaceCreateGoal(t *testing.T) {
 	m := model{appModel: appModel{showCreateModal: true, createGoal: cg}}
 
 	updated, _ := handleBackspace(m)
-	am := updated.(model).appModel
+	am := mustModel(t, updated).appModel
 	if got := am.createGoal.title(); got != "Hi" {
 		t.Errorf("after backspace, title() = %q, want %q", got, "Hi")
 	}
@@ -738,7 +749,7 @@ func TestHandleBackspaceDatapoint(t *testing.T) {
 	m := model{appModel: appModel{showModal: true, inputMode: true, datapoint: dp}}
 
 	updated, _ := handleBackspace(m)
-	am := updated.(model).appModel
+	am := mustModel(t, updated).appModel
 	if got := am.datapoint.comment(); got != "note" {
 		t.Errorf("after backspace, comment() = %q, want %q", got, "note")
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -647,51 +647,10 @@ func TestIssueEdgeCases(t *testing.T) {
 	}
 }
 
-// TestHandleNumericDecimalInput tests the handleNumericDecimalInput helper function
-func TestHandleNumericDecimalInput(t *testing.T) {
-	tests := []struct {
-		name          string
-		char          string
-		initialValue  string
-		expectedValue string
-		expectedOk    bool
-	}{
-		{"valid digit", "5", "10", "105", true},
-		{"valid decimal", ".", "10", "10.", true},
-		{"valid negative", "-", "", "-", true},
-		{"valid null char n", "n", "", "n", true},
-		{"valid null char u", "u", "n", "nu", true},
-		{"valid null char l", "l", "nu", "nul", true},
-		{"invalid letter", "a", "10", "10", false},
-		{"invalid space", " ", "10", "10", false},
-		{"invalid special", "@", "10", "10", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a test model
-			m := model{
-				appModel: appModel{},
-			}
-			field := tt.initialValue
-
-			// Call the function
-			resultModel, ok := handleNumericDecimalInput(m, tt.char, &field)
-
-			// Verify the result
-			if ok != tt.expectedOk {
-				t.Errorf("handleNumericDecimalInput(%q) returned ok=%v, want %v", tt.char, ok, tt.expectedOk)
-			}
-			if field != tt.expectedValue {
-				t.Errorf("handleNumericDecimalInput(%q) resulted in field=%q, want %q", tt.char, field, tt.expectedValue)
-			}
-			// Verify model is returned unchanged
-			if resultModel.appModel.createGoalval != "" {
-				t.Errorf("handleNumericDecimalInput should not modify model")
-			}
-		})
-	}
-}
+// TestHandleNumericDecimalInput was removed: the handleNumericDecimalInput
+// helper was folded into form.handleRune via the filterDecimalOrNull field
+// filter. The underlying predicate is covered by TestIsNumericWithDecimal, and
+// the form path by form_test.go.
 
 // TestHandleSearchInputUnicode tests Unicode support in search mode
 func TestHandleSearchInputUnicode(t *testing.T) {
@@ -755,27 +714,29 @@ func TestHandleCreateModalInputUnicode(t *testing.T) {
 		checkField func(appModel) string
 		fieldName  string
 	}{
-		{"Title with ASCII", 1, []rune{'a'}, true, func(a appModel) string { return a.createTitle }, "Title"},
-		{"Title with accented char", 1, []rune{'é'}, true, func(a appModel) string { return a.createTitle }, "Title"},
-		{"Title with Chinese", 1, []rune{'中'}, true, func(a appModel) string { return a.createTitle }, "Title"},
-		{"Title with emoji", 1, []rune{'😀'}, true, func(a appModel) string { return a.createTitle }, "Title"},
-		{"Title with Greek", 1, []rune{'Ω'}, true, func(a appModel) string { return a.createTitle }, "Title"},
-		{"Gunits with ASCII", 3, []rune{'x'}, true, func(a appModel) string { return a.createGunits }, "Gunits"},
-		{"Gunits with accented char", 3, []rune{'ñ'}, true, func(a appModel) string { return a.createGunits }, "Gunits"},
-		{"Gunits with Cyrillic", 3, []rune{'Д'}, true, func(a appModel) string { return a.createGunits }, "Gunits"},
-		{"Gunits with emoji", 3, []rune{'📊'}, true, func(a appModel) string { return a.createGunits }, "Gunits"},
+		{"Title with ASCII", cgTitle, []rune{'a'}, true, func(a appModel) string { return a.createGoal.title() }, "Title"},
+		{"Title with accented char", cgTitle, []rune{'é'}, true, func(a appModel) string { return a.createGoal.title() }, "Title"},
+		{"Title with Chinese", cgTitle, []rune{'中'}, true, func(a appModel) string { return a.createGoal.title() }, "Title"},
+		{"Title with emoji", cgTitle, []rune{'😀'}, true, func(a appModel) string { return a.createGoal.title() }, "Title"},
+		{"Title with Greek", cgTitle, []rune{'Ω'}, true, func(a appModel) string { return a.createGoal.title() }, "Title"},
+		{"Gunits with ASCII", cgGunits, []rune{'x'}, true, func(a appModel) string { return a.createGoal.gunits() }, "Gunits"},
+		{"Gunits with accented char", cgGunits, []rune{'ñ'}, true, func(a appModel) string { return a.createGoal.gunits() }, "Gunits"},
+		{"Gunits with Cyrillic", cgGunits, []rune{'Д'}, true, func(a appModel) string { return a.createGoal.gunits() }, "Gunits"},
+		{"Gunits with emoji", cgGunits, []rune{'📊'}, true, func(a appModel) string { return a.createGoal.gunits() }, "Gunits"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a mock model with create modal open
+			// Create a mock model with create modal open. Start the title and
+			// gunits fields empty so the typed character is the whole value.
+			cg := newCreateGoalForm()
+			cg.fields[cgTitle].value = ""
+			cg.fields[cgGunits].value = ""
+			cg.focus = tt.focus
 			m := model{
 				appModel: appModel{
 					showCreateModal: true,
-					creatingGoal:    false,
-					createFocus:     tt.focus,
-					createTitle:     "",
-					createGunits:    "",
+					createGoal:      cg,
 				},
 			}
 
@@ -823,14 +784,16 @@ func TestHandleDatapointInputUnicode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a mock model in input mode with comment field focused
+			// Create a mock model in input mode with comment field focused.
+			// Start the comment empty so the typed character is the whole value.
+			dp := newDatapointForm("1")
+			dp.fields[dpComment].value = ""
+			dp.focus = dpComment
 			m := model{
 				appModel: appModel{
-					showModal:    true,
-					inputMode:    true,
-					submitting:   false,
-					inputFocus:   2, // Comment field
-					inputComment: "",
+					showModal: true,
+					inputMode: true,
+					datapoint: dp,
 				},
 			}
 
@@ -848,8 +811,8 @@ func TestHandleDatapointInputUnicode(t *testing.T) {
 			// If expected to handle, check that the comment was updated
 			if tt.expected && handled {
 				expectedComment := string(tt.runes)
-				if updatedModel.appModel.inputComment != expectedComment {
-					t.Errorf("inputComment = %q, want %q", updatedModel.appModel.inputComment, expectedComment)
+				if updatedModel.appModel.datapoint.comment() != expectedComment {
+					t.Errorf("comment = %q, want %q", updatedModel.appModel.datapoint.comment(), expectedComment)
 				}
 			}
 		})
@@ -1613,14 +1576,14 @@ func TestHandleAddDatapointPrefillsLastValue(t *testing.T) {
 
 	updated, _ := handleAddDatapoint(m)
 	got := updated.(model).appModel
-	if got.inputValue != "2.5" {
-		t.Errorf("inputValue = %q, want %q", got.inputValue, "2.5")
+	if got.datapoint.value() != "2.5" {
+		t.Errorf("inputValue = %q, want %q", got.datapoint.value(), "2.5")
 	}
 	if !got.inputMode {
 		t.Error("expected inputMode to be true after handleAddDatapoint")
 	}
-	if got.inputComment != "Added via buzz" {
-		t.Errorf("inputComment = %q, want default %q", got.inputComment, "Added via buzz")
+	if got.datapoint.comment() != "Added via buzz" {
+		t.Errorf("inputComment = %q, want default %q", got.datapoint.comment(), "Added via buzz")
 	}
 }
 
@@ -1650,14 +1613,14 @@ func TestHandleAddDatapointDefaultsToOneOnZeroValue(t *testing.T) {
 		t.Error("expected GetLastDatapointValue to be called")
 	}
 	got := updated.(model).appModel
-	if got.inputValue != "1" {
-		t.Errorf("inputValue with zero last value = %q, want %q", got.inputValue, "1")
+	if got.datapoint.value() != "1" {
+		t.Errorf("inputValue with zero last value = %q, want %q", got.datapoint.value(), "1")
 	}
 	if !got.inputMode {
 		t.Error("expected inputMode to be true after handleAddDatapoint")
 	}
-	if got.inputComment != "Added via buzz" {
-		t.Errorf("inputComment = %q, want default %q", got.inputComment, "Added via buzz")
+	if got.datapoint.comment() != "Added via buzz" {
+		t.Errorf("inputComment = %q, want default %q", got.datapoint.comment(), "Added via buzz")
 	}
 }
 
@@ -1685,14 +1648,14 @@ func TestHandleAddDatapointDefaultsToOneOnFetchError(t *testing.T) {
 		t.Error("expected GetLastDatapointValue to be called")
 	}
 	got := updated.(model).appModel
-	if got.inputValue != "1" {
-		t.Errorf("inputValue on fetch error = %q, want %q", got.inputValue, "1")
+	if got.datapoint.value() != "1" {
+		t.Errorf("inputValue on fetch error = %q, want %q", got.datapoint.value(), "1")
 	}
 	if !got.inputMode {
 		t.Error("expected inputMode to be true after handleAddDatapoint")
 	}
-	if got.inputComment != "Added via buzz" {
-		t.Errorf("inputComment = %q, want default %q", got.inputComment, "Added via buzz")
+	if got.datapoint.comment() != "Added via buzz" {
+		t.Errorf("inputComment = %q, want default %q", got.datapoint.comment(), "Added via buzz")
 	}
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -651,6 +652,26 @@ func TestIssueEdgeCases(t *testing.T) {
 // helper was folded into form.handleRune via the filterDecimalOrNull field
 // filter. The underlying predicate is covered by TestIsNumericWithDecimal, and
 // the form path by form_test.go.
+
+// TestHandleBackspaceSearchTrimsWholeRune verifies search-mode backspace removes
+// an entire multibyte rune, leaving the query as valid UTF-8.
+func TestHandleBackspaceSearchTrimsWholeRune(t *testing.T) {
+	m := model{
+		appModel: appModel{
+			searchMode:  true,
+			searchQuery: "a中😀",
+		},
+	}
+
+	updated, _ := handleBackspace(m)
+	got := updated.(model).appModel.searchQuery
+	if got != "a中" {
+		t.Errorf("after backspace, searchQuery = %q, want %q", got, "a中")
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("searchQuery is not valid UTF-8 after backspace: %q", got)
+	}
+}
 
 // TestHandleSearchInputUnicode tests Unicode support in search mode
 func TestHandleSearchInputUnicode(t *testing.T) {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -673,6 +673,77 @@ func TestHandleBackspaceSearchTrimsWholeRune(t *testing.T) {
 	}
 }
 
+// TestHandleTabKeyCreateGoal verifies tab/shift+tab cycle focus through the
+// create-goal form when its modal is open.
+func TestHandleTabKeyCreateGoal(t *testing.T) {
+	m := model{appModel: appModel{showCreateModal: true, createGoal: newCreateGoalForm()}}
+
+	updated, _ := handleTabKey(m, false)
+	if got := updated.(model).appModel.createGoal.focus; got != 1 {
+		t.Errorf("after tab, createGoal.focus = %d, want 1", got)
+	}
+
+	updated, _ = handleTabKey(updated.(model), true)
+	if got := updated.(model).appModel.createGoal.focus; got != 0 {
+		t.Errorf("after shift+tab, createGoal.focus = %d, want 0", got)
+	}
+
+	// Tab is a no-op while a goal creation is in flight.
+	busy := model{appModel: appModel{showCreateModal: true, createGoal: newCreateGoalForm()}}
+	busy.appModel.createGoal.creating = true
+	updated, _ = handleTabKey(busy, false)
+	if got := updated.(model).appModel.createGoal.focus; got != 0 {
+		t.Errorf("tab while creating should not move focus, got %d", got)
+	}
+}
+
+// TestHandleTabKeyDatapoint verifies tab/shift+tab cycle focus through the
+// datapoint form when in input mode.
+func TestHandleTabKeyDatapoint(t *testing.T) {
+	m := model{appModel: appModel{showModal: true, inputMode: true, datapoint: newDatapointForm("1")}}
+
+	updated, _ := handleTabKey(m, false)
+	if got := updated.(model).appModel.datapoint.focus; got != 1 {
+		t.Errorf("after tab, datapoint.focus = %d, want 1", got)
+	}
+
+	// Shift+tab from focus 0 wraps to the last field (index 2).
+	updated, _ = handleTabKey(model{appModel: appModel{showModal: true, inputMode: true, datapoint: newDatapointForm("1")}}, true)
+	if got := updated.(model).appModel.datapoint.focus; got != 2 {
+		t.Errorf("after shift+tab wrap, datapoint.focus = %d, want 2", got)
+	}
+}
+
+// TestHandleBackspaceCreateGoal verifies backspace trims the focused create-goal
+// field (rune-aware) when the modal is open.
+func TestHandleBackspaceCreateGoal(t *testing.T) {
+	cg := newCreateGoalForm()
+	cg.focus = cgTitle
+	cg.fields[cgTitle].value = "Hi中"
+	m := model{appModel: appModel{showCreateModal: true, createGoal: cg}}
+
+	updated, _ := handleBackspace(m)
+	am := updated.(model).appModel
+	if got := am.createGoal.title(); got != "Hi" {
+		t.Errorf("after backspace, title() = %q, want %q", got, "Hi")
+	}
+}
+
+// TestHandleBackspaceDatapoint verifies backspace trims the focused datapoint
+// field when in input mode.
+func TestHandleBackspaceDatapoint(t *testing.T) {
+	dp := newDatapointForm("1")
+	dp.focus = dpComment
+	dp.fields[dpComment].value = "note😀"
+	m := model{appModel: appModel{showModal: true, inputMode: true, datapoint: dp}}
+
+	updated, _ := handleBackspace(m)
+	am := updated.(model).appModel
+	if got := am.datapoint.comment(); got != "note" {
+		t.Errorf("after backspace, comment() = %q, want %q", got, "note")
+	}
+}
+
 // TestHandleSearchInputUnicode tests Unicode support in search mode
 func TestHandleSearchInputUnicode(t *testing.T) {
 	tests := []struct {

--- a/model.go
+++ b/model.go
@@ -23,31 +23,17 @@ type appModel struct {
 	hasNavigated       bool            // whether user has used arrow keys
 	lastNavigationTime time.Time       // last time user navigated with arrow keys
 
-	// Modal input fields
-	inputDate    string // date input (YYYY-MM-DD format)
-	inputValue   string // value input
-	inputComment string // comment input
-	inputFocus   int    // which input field is focused (0=date, 1=value, 2=comment)
-	inputMode    bool   // whether we're in input mode vs viewing mode
-	inputError   string // error message for input validation
-	submitting   bool   // whether we're currently submitting a datapoint
+	// Datapoint entry form (shown inside the goal detail modal)
+	inputMode bool          // whether we're in input mode vs viewing mode
+	datapoint datapointForm // date/value/comment fields + submitting flag
 
 	// Filter/search fields
 	searchMode  bool   // whether we're in search/filter mode
 	searchQuery string // current search query
 
-	// Goal creation fields
-	showCreateModal bool   // whether to show goal creation modal
-	createSlug      string // goal slug
-	createTitle     string // goal title
-	createGoalType  string // goal type (hustler, biker, etc.)
-	createGunits    string // goal units
-	createGoaldate  string // goal date (unix timestamp or "null")
-	createGoalval   string // goal value (number or "null")
-	createRate      string // rate (number or "null")
-	createFocus     int    // which input field is focused
-	createError     string // error message for creation validation
-	creatingGoal    bool   // whether we're currently creating a goal
+	// Goal creation form
+	showCreateModal bool           // whether to show goal creation modal
+	createGoal      createGoalForm // slug/title/type/... fields + creating flag
 }
 
 // model is the top-level model that switches between auth and app. It holds

--- a/tui.go
+++ b/tui.go
@@ -103,14 +103,14 @@ func (m model) updateApp(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case datapointSubmittedMsg:
 		// Datapoint submission completed
-		m.appModel.submitting = false
+		m.appModel.datapoint.submitting = false
 		if msg.err != nil {
-			m.appModel.inputError = fmt.Sprintf("Failed to submit: %v", msg.err)
+			m.appModel.datapoint.err = fmt.Sprintf("Failed to submit: %v", msg.err)
 		} else {
 			// Success - exit input mode and refresh goals (without showing loading state)
 			m.appModel.inputMode = false
-			m.appModel.inputFocus = 0
-			m.appModel.inputError = ""
+			m.appModel.datapoint.focus = 0
+			m.appModel.datapoint.err = ""
 			// Don't set loading = true here to avoid the full-app loading state
 			return m, loadGoalsCmd(m.appModel.ctx, m.appModel.client)
 		}
@@ -132,13 +132,13 @@ func (m model) updateApp(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case goalCreatedMsg:
 		// Goal creation completed
-		m.appModel.creatingGoal = false
+		m.appModel.createGoal.creating = false
 		if msg.err != nil {
-			m.appModel.createError = fmt.Sprintf("Failed to create goal: %v", msg.err)
+			m.appModel.createGoal.err = fmt.Sprintf("Failed to create goal: %v", msg.err)
 		} else {
 			// Success - close modal and refresh goals
 			m.appModel.showCreateModal = false
-			m.appModel.createError = ""
+			m.appModel.createGoal.err = ""
 			return m, loadGoalsCmd(m.appModel.ctx, m.appModel.client)
 		}
 		return m, nil
@@ -216,15 +216,17 @@ func (m model) viewApp() string {
 
 	// Show create goal modal if active
 	if m.appModel.showCreateModal {
-		modal := RenderCreateGoalModal(m.appModel.width, m.appModel.height, m.appModel.createSlug, m.appModel.createTitle,
-			m.appModel.createGoalType, m.appModel.createGunits, m.appModel.createGoaldate, m.appModel.createGoalval,
-			m.appModel.createRate, m.appModel.createFocus, m.appModel.createError, m.appModel.creatingGoal)
+		cg := &m.appModel.createGoal
+		modal := RenderCreateGoalModal(m.appModel.width, m.appModel.height, cg.slug(), cg.title(),
+			cg.goalType(), cg.gunits(), cg.goaldate(), cg.goalval(),
+			cg.rate(), cg.focus, cg.err, cg.creating)
 		return modal
 	}
 
 	// Show modal overlay if modal is active
 	if m.appModel.showModal && m.appModel.modalGoal != nil {
-		modal := RenderModal(m.appModel.modalGoal, m.appModel.width, m.appModel.height, m.appModel.inputDate, m.appModel.inputValue, m.appModel.inputComment, m.appModel.inputFocus, m.appModel.inputMode, m.appModel.inputError, m.appModel.submitting)
+		dp := &m.appModel.datapoint
+		modal := RenderModal(m.appModel.modalGoal, m.appModel.width, m.appModel.height, dp.date(), dp.value(), dp.comment(), dp.focus, m.appModel.inputMode, dp.err, dp.submitting)
 		return modal
 	}
 


### PR DESCRIPTION
Closes #246.

## Problem

`appModel` carried ~25 peer fields for two interactive forms (datapoint entry, goal creation) alongside the rest of the app state, and `handlers.go` reached directly into those fields to mutate them. As the issue noted, this made the interactive handlers untestable — constructing an `appModel` for a single interaction required populating dozens of unrelated fields — so only the pure validators had coverage, and char-filter ↔ focus ↔ validation bugs only surfaced in manual TUI use.

## Approach

We grilled the design first (the issue flagged it as low-confidence / "fights the framework"). The conclusion, recorded in **ADR-0001**: the issue's own proposal — bisecting `appModel` into domain vs UI structs — fails the deletion test (navigation inherently needs `goals` + `cursor` + `width` + `scrollRow` together; splitting just relocates fields). The genuinely *deep* module is the **form**.

- **`form.go`** — a generic `form` (`[]field` + `focus` + `err`) owning the shared `handleRune` / `backspace` / `tab` / `val` behavior. Thin typed wrappers `datapointForm` and `createGoalForm` embed it, expose named accessors, hold their own lifecycle flag (`submitting` / `creating`), and delegate `validate()` to the existing validators.
- The seven existing char predicates (`isAlphanumericOrDash`, `isNumericOrNull`, …) become `field.filter` funcs — **zero behavior change**.
- `handlers.go` shrinks ~180 lines: the per-field `switch` ladders collapse to one-line delegations; `handleNumericDecimalInput` is folded into `filterDecimalOrNull`.
- Mode/visibility booleans **deliberately stay** on `appModel`. The `Mode`-enum state machine is its own focused follow-up: #292.

## Bug fix riding along

`form.backspace()` is now rune-aware — it trims a whole rune instead of a single byte, fixing latent UTF-8 corruption when backspacing multibyte characters (emoji/CJK) in the comment/title/gunits fields. This preexisting bug was invisible until the new test seam existed.

## Tests

New `form_test.go` (14 tests) exercises the form directly — per-field filter accept/reject, focus routing, tab wrap, the `"null"`-prefix logic, bounds-safe backspace/accessors, and whole-rune backspace. The two existing handler tests were updated to the nested shape. `go vet`, `gofmt`, and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architectural decision record describing a new generic form abstraction for modal inputs.

* **Tests**
  * Added comprehensive unit tests for multi-field forms, validation rules, keyboard navigation, and UTF‑8-aware backspace behavior.

* **Refactor**
  * Consolidated modal input state into nested form objects for create-goal and datapoint flows and updated UI rendering to use form accessors.

* **Bug Fixes / UX**
  * Improved tab/backspace/enter handling, safer UTF‑8 deletion, and more reliable modal prefill/defaults and validation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->