### PR TITLE
feat(create): add `buzz create` command for interactive goal creation

### DIFF
--- a/create.go
+++ b/create.go
@@ -6,11 +6,34 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 )
 
 // defaultGoalType is used when the user leaves the goal type prompt blank.
 const defaultGoalType = "hustler"
+
+// goalTypeOption describes a Beeminder goal type: its canonical goal_type value
+// (name, what the API expects), a human-friendly label, and a one-line
+// explanation of how the goal behaves.
+type goalTypeOption struct {
+	name  string
+	label string
+	desc  string
+}
+
+// goalTypeOptions lists Beeminder's goal types in the order shown in the create
+// menu. The labels and descriptions exist so users don't have to memorize the
+// jargon names (e.g. "hustler" really means "Do More").
+var goalTypeOptions = []goalTypeOption{
+	{"hustler", "Do More", "accumulate at least a set amount; the line is a floor you stay above (e.g. exercise, writing)"},
+	{"drinker", "Do Less", "stay under a ceiling that ratchets down; the line is a cap you stay below (e.g. junk food, spending)"},
+	{"biker", "Odometer", "track a running total that only goes up and occasionally resets, like a car odometer"},
+	{"fatloser", "Weight loss", "drive a value down toward a target; the line slopes downward (e.g. lose weight)"},
+	{"gainer", "Gain Weight", "drive a value up at a steady rate (e.g. gain weight or muscle)"},
+	{"inboxer", "Inbox Fewer", "whittle a count down toward zero and keep it there (e.g. email inbox, open bugs)"},
+	{"custom", "Custom", "full manual control over the underlying goal parameters"},
+}
 
 // handleCreateCommand creates a new Beeminder goal by prompting interactively
 // for its fields. It mirrors the TUI's create-goal modal (the `n` key) but as a
@@ -50,10 +73,7 @@ func runCreateCommand(stdin io.Reader, client Client, stdout, stderr io.Writer) 
 
 	slug := promptField(r, stdout, "Goal slug: ")
 	title := promptField(r, stdout, "Goal title: ")
-	goalType := promptField(r, stdout, fmt.Sprintf("Goal type (default: %s): ", defaultGoalType))
-	if goalType == "" {
-		goalType = defaultGoalType
-	}
+	goalType := promptGoalType(r, stdout)
 	gunits := promptField(r, stdout, "Goal units: ")
 
 	fmt.Fprintln(stdout, "")
@@ -87,4 +107,41 @@ func promptField(r *bufio.Reader, w io.Writer, label string) string {
 	fmt.Fprint(w, label)
 	line, _ := r.ReadString('\n')
 	return strings.TrimSpace(line)
+}
+
+// promptGoalType prints the explained goal-type menu and resolves the user's
+// choice to a canonical goal_type value. Accepted input: a number from the list,
+// a type's name or label (e.g. "hustler" or "Do More", case-insensitive — keeps
+// piped/scripted input working), or blank to take the default. An unrecognized
+// non-empty entry is passed through unchanged so newly-added Beeminder types
+// still work; the API validates the final value.
+func promptGoalType(r *bufio.Reader, w io.Writer) string {
+	fmt.Fprintln(w, "Goal type:")
+	for i, gt := range goalTypeOptions {
+		marker := ""
+		if gt.name == defaultGoalType {
+			marker = " [default]"
+		}
+		fmt.Fprintf(w, "  %d. %s (%s)%s — %s\n", i+1, gt.label, gt.name, marker, gt.desc)
+	}
+
+	choice := promptField(r, w, fmt.Sprintf("Choose a number or name (default: %s): ", defaultGoalType))
+	if choice == "" {
+		return defaultGoalType
+	}
+
+	// Numeric selection from the menu.
+	if n, err := strconv.Atoi(choice); err == nil && n >= 1 && n <= len(goalTypeOptions) {
+		return goalTypeOptions[n-1].name
+	}
+
+	// Match a canonical name or human label, case-insensitively.
+	for _, gt := range goalTypeOptions {
+		if strings.EqualFold(choice, gt.name) || strings.EqualFold(choice, gt.label) {
+			return gt.name
+		}
+	}
+
+	// Pass through anything else; validation / the API decides if it's valid.
+	return choice
 }

--- a/create.go
+++ b/create.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// defaultGoalType is used when the user leaves the goal type prompt blank.
+const defaultGoalType = "hustler"
+
+// handleCreateCommand creates a new Beeminder goal by prompting interactively
+// for its fields. It mirrors the TUI's create-goal modal (the `n` key) but as a
+// plain CLI command, reusing the same validateCreateGoalInput validation and the
+// client's CreateGoal method.
+func handleCreateCommand() {
+	if !ConfigExists() {
+		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
+		os.Exit(1)
+	}
+
+	config, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to load config: %s\n", redactError(err))
+		os.Exit(1)
+	}
+
+	client := NewHTTPClient(config)
+	code := runCreateCommand(os.Stdin, client, os.Stdout, os.Stderr)
+	if code == 0 {
+		// Check for updates and display message if available
+		fmt.Print(getUpdateMessage())
+	}
+	os.Exit(code)
+}
+
+// runCreateCommand is the testable core of `buzz create`. It prompts for goal
+// fields on stdin, validates them, creates the goal, and returns the process
+// exit code. Reading line-by-line means it also works with piped input for
+// scripting (e.g. `printf '...' | buzz create`).
+func runCreateCommand(stdin io.Reader, client Client, stdout, stderr io.Writer) int {
+	r := bufio.NewReader(stdin)
+
+	fmt.Fprintln(stdout, "Create a new Beeminder goal")
+	fmt.Fprintln(stdout, "===========================")
+	fmt.Fprintln(stdout, "")
+
+	slug := promptField(r, stdout, "Goal slug: ")
+	title := promptField(r, stdout, "Goal title: ")
+	goalType := promptField(r, stdout, fmt.Sprintf("Goal type (default: %s): ", defaultGoalType))
+	if goalType == "" {
+		goalType = defaultGoalType
+	}
+	gunits := promptField(r, stdout, "Goal units: ")
+
+	fmt.Fprintln(stdout, "")
+	fmt.Fprintln(stdout, "Provide exactly 2 of the next 3 (leave one blank):")
+	goaldate := promptField(r, stdout, "Goal date (epoch timestamp): ")
+	goalval := promptField(r, stdout, "Goal value: ")
+	rate := promptField(r, stdout, "Rate: ")
+
+	if errMsg := validateCreateGoalInput(slug, title, goalType, gunits, goaldate, goalval, rate); errMsg != "" {
+		fmt.Fprintf(stderr, "Error: %s\n", errMsg)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "")
+	fmt.Fprintln(stdout, "Creating goal...")
+
+	goal, err := client.CreateGoal(context.Background(), slug, title, goalType, gunits, goaldate, goalval, rate)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: Failed to create goal: %s\n", redactError(err))
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Successfully created goal: %s\n", goal.Slug)
+	return 0
+}
+
+// promptField writes a prompt and reads a single trimmed line of input. A read
+// error (including EOF before a newline) still returns whatever was read so far;
+// missing required fields are caught by validation rather than here.
+func promptField(r *bufio.Reader, w io.Writer, label string) string {
+	fmt.Fprint(w, label)
+	line, _ := r.ReadString('\n')
+	return strings.TrimSpace(line)
+}

--- a/create.go
+++ b/create.go
@@ -27,7 +27,7 @@ type goalTypeOption struct {
 // jargon names (e.g. "hustler" really means "Do More").
 var goalTypeOptions = []goalTypeOption{
 	{"hustler", "Do More", "accumulate at least a set amount; the line is a floor you stay above (e.g. exercise, writing)"},
-	{"drinker", "Do Less", "stay under a ceiling that ratchets down; the line is a cap you stay below (e.g. junk food, spending)"},
+	{"drinker", "Do Less", "keep a running total under a limit; the line is a ceiling you stay below (e.g. junk food, spending)"},
 	{"biker", "Odometer", "track a running total that only goes up and occasionally resets, like a car odometer"},
 	{"fatloser", "Weight loss", "drive a value down toward a target; the line slopes downward (e.g. lose weight)"},
 	{"gainer", "Gain Weight", "drive a value up at a steady rate (e.g. gain weight or muscle)"},

--- a/create_test.go
+++ b/create_test.go
@@ -60,6 +60,27 @@ func TestRunCreateCommandDefaultGoalType(t *testing.T) {
 	}
 }
 
+// TestRunCreateCommandGoalDateAndValue verifies the third accepted permutation
+// of the 2-of-3 rule: goal date + goal value provided, rate left blank.
+func TestRunCreateCommandGoalDateAndValue(t *testing.T) {
+	var got struct{ goaldate, goalval, rate string }
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			got.goaldate, got.goalval, got.rate = goaldate, goalval, rate
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\nhustler\npages\n1700000000\n365\n\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if got.goaldate != "1700000000" || got.goalval != "365" || got.rate != "" {
+		t.Errorf("unexpected 2-of-3 fields: date=%q val=%q rate=%q", got.goaldate, got.goalval, got.rate)
+	}
+}
+
 // TestRunCreateCommandGoalDateAndRate verifies the other accepted permutation
 // of the 2-of-3 rule: goal date + rate provided, goal value left blank.
 func TestRunCreateCommandGoalDateAndRate(t *testing.T) {

--- a/create_test.go
+++ b/create_test.go
@@ -60,6 +60,75 @@ func TestRunCreateCommandDefaultGoalType(t *testing.T) {
 	}
 }
 
+// TestRunCreateCommandGoalDateAndRate verifies the other accepted permutation
+// of the 2-of-3 rule: goal date + rate provided, goal value left blank.
+func TestRunCreateCommandGoalDateAndRate(t *testing.T) {
+	var got struct{ goaldate, goalval, rate string }
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			got.goaldate, got.goalval, got.rate = goaldate, goalval, rate
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\nhustler\npages\n1700000000\n\n1\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if got.goaldate != "1700000000" || got.goalval != "" || got.rate != "1" {
+		t.Errorf("unexpected 2-of-3 fields: date=%q val=%q rate=%q", got.goaldate, got.goalval, got.rate)
+	}
+}
+
+// TestRunCreateCommandTrimsWhitespace verifies that surrounding whitespace and
+// Windows CRLF line endings (\r\n) are stripped from each field, so piped or
+// pasted input doesn't leak a stray \r or spaces into the API call.
+func TestRunCreateCommandTrimsWhitespace(t *testing.T) {
+	var got struct{ slug, title, gunits string }
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			got.slug, got.title, got.gunits = slug, title, gunits
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("  reading  \r\nDaily Reading\r\nhustler\r\n pages \r\n\r\n365\r\n1\r\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if got.slug != "reading" || got.title != "Daily Reading" || got.gunits != "pages" {
+		t.Errorf("fields not trimmed: slug=%q title=%q gunits=%q", got.slug, got.title, got.gunits)
+	}
+}
+
+// TestRunCreateCommandTruncatedInput verifies graceful failure when stdin ends
+// before all prompts are answered (e.g. a short pipe): the missing required
+// fields fail validation, no API call is made, and the exit code is non-zero.
+func TestRunCreateCommandTruncatedInput(t *testing.T) {
+	called := false
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			called = true
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	// Only slug and a partial (newline-less) title are supplied; the remaining
+	// prompts read empty strings at EOF.
+	stdin := strings.NewReader("reading\nDaily Reading")
+	var stdout, stderr bytes.Buffer
+	code := runCreateCommand(stdin, client, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if called {
+		t.Error("CreateGoal should not be called when required input is missing")
+	}
+}
+
 // TestRunCreateCommandValidationError verifies that invalid input (here, all
 // three of goaldate/goalval/rate provided, violating the 2-of-3 rule) is
 // rejected before any API call and surfaces a non-zero exit code.

--- a/create_test.go
+++ b/create_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestRunCreateCommandSuccess verifies the happy path: prompts are answered,
+// the entered fields are forwarded to CreateGoal, and the created slug is
+// reported. Goal value and rate are provided (goal date left blank), satisfying
+// the "exactly 2 of 3" rule.
+func TestRunCreateCommandSuccess(t *testing.T) {
+	var got struct{ slug, title, goalType, gunits, goaldate, goalval, rate string }
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			got.slug, got.title, got.goalType, got.gunits = slug, title, goalType, gunits
+			got.goaldate, got.goalval, got.rate = goaldate, goalval, rate
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\nhustler\npages\n\n365\n1\n")
+	var stdout, stderr bytes.Buffer
+	code := runCreateCommand(stdin, client, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if got.slug != "reading" || got.title != "Daily Reading" || got.goalType != "hustler" || got.gunits != "pages" {
+		t.Errorf("unexpected fields forwarded: %+v", got)
+	}
+	if got.goaldate != "" || got.goalval != "365" || got.rate != "1" {
+		t.Errorf("unexpected 2-of-3 fields: date=%q val=%q rate=%q", got.goaldate, got.goalval, got.rate)
+	}
+	if !strings.Contains(stdout.String(), "Successfully created goal: reading") {
+		t.Errorf("missing success message, got: %s", stdout.String())
+	}
+}
+
+// TestRunCreateCommandDefaultGoalType verifies that leaving the goal type blank
+// falls back to the default "hustler" rather than failing validation.
+func TestRunCreateCommandDefaultGoalType(t *testing.T) {
+	var gotType string
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			gotType = goalType
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\n\npages\n\n365\n1\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if gotType != defaultGoalType {
+		t.Errorf("expected default goal type %q, got %q", defaultGoalType, gotType)
+	}
+}
+
+// TestRunCreateCommandValidationError verifies that invalid input (here, all
+// three of goaldate/goalval/rate provided, violating the 2-of-3 rule) is
+// rejected before any API call and surfaces a non-zero exit code.
+func TestRunCreateCommandValidationError(t *testing.T) {
+	called := false
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			called = true
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\nhustler\npages\n1700000000\n365\n1\n")
+	var stdout, stderr bytes.Buffer
+	code := runCreateCommand(stdin, client, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if called {
+		t.Error("CreateGoal should not be called when validation fails")
+	}
+	if !strings.Contains(stderr.String(), "Exactly 2 out of 3") {
+		t.Errorf("expected validation error on stderr, got: %s", stderr.String())
+	}
+}
+
+// TestRunCreateCommandAPIError verifies that an error from CreateGoal is
+// reported and produces a non-zero exit code.
+func TestRunCreateCommandAPIError(t *testing.T) {
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			return nil, errors.New("boom")
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\nhustler\npages\n\n365\n1\n")
+	var stdout, stderr bytes.Buffer
+	code := runCreateCommand(stdin, client, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "Failed to create goal") {
+		t.Errorf("expected API error on stderr, got: %s", stderr.String())
+	}
+}

--- a/create_test.go
+++ b/create_test.go
@@ -86,6 +86,57 @@ func TestRunCreateCommandGoalTypeByNumber(t *testing.T) {
 	}
 }
 
+// TestRunCreateCommandGoalTypeCaseInsensitiveName verifies a canonical name
+// typed in a different case still resolves (EqualFold) to the canonical value.
+func TestRunCreateCommandGoalTypeCaseInsensitiveName(t *testing.T) {
+	var gotType string
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			gotType = goalType
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\nHUSTLER\npages\n\n365\n1\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if gotType != "hustler" {
+		t.Errorf("expected goal type %q for %q, got %q", "hustler", "HUSTLER", gotType)
+	}
+}
+
+// TestRunCreateCommandGoalTypePassthrough verifies the forward-compat escape
+// hatch: input that is neither a valid menu number nor a known name/label —
+// including an out-of-range number — is forwarded to CreateGoal verbatim, so a
+// goal_type buzz doesn't yet know about still works.
+func TestRunCreateCommandGoalTypePassthrough(t *testing.T) {
+	for _, tc := range []struct{ name, input, want string }{
+		{"unknown name", "whittler", "whittler"},
+		{"out-of-range number", "99", "99"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotType string
+			client := &FakeClient{
+				CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+					gotType = goalType
+					return &Goal{Slug: slug}, nil
+				},
+			}
+
+			stdin := strings.NewReader("reading\nDaily Reading\n" + tc.input + "\npages\n\n365\n1\n")
+			var stdout, stderr bytes.Buffer
+			if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+				t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+			}
+			if gotType != tc.want {
+				t.Errorf("expected goal type %q passed through, got %q", tc.want, gotType)
+			}
+		})
+	}
+}
+
 // TestRunCreateCommandGoalTypeByLabel verifies that a human label typed directly
 // (case-insensitively) resolves to the canonical goal_type value.
 func TestRunCreateCommandGoalTypeByLabel(t *testing.T) {

--- a/create_test.go
+++ b/create_test.go
@@ -60,6 +60,53 @@ func TestRunCreateCommandDefaultGoalType(t *testing.T) {
 	}
 }
 
+// TestRunCreateCommandGoalTypeByNumber verifies that selecting a goal type by
+// its menu number resolves to the canonical goal_type value (here, choice "2"
+// → "drinker"), and that the menu lists each type with its plain-language label.
+func TestRunCreateCommandGoalTypeByNumber(t *testing.T) {
+	var gotType string
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			gotType = goalType
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("nojunk\nNo Junk Food\n2\nservings\n\n0\n-1\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if gotType != "drinker" {
+		t.Errorf("expected goal type %q for menu choice 2, got %q", "drinker", gotType)
+	}
+	// The menu should explain types, not just name them.
+	if out := stdout.String(); !strings.Contains(out, "Do Less") || !strings.Contains(out, "drinker") {
+		t.Errorf("menu missing label/name for a goal type, got:\n%s", out)
+	}
+}
+
+// TestRunCreateCommandGoalTypeByLabel verifies that a human label typed directly
+// (case-insensitively) resolves to the canonical goal_type value.
+func TestRunCreateCommandGoalTypeByLabel(t *testing.T) {
+	var gotType string
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			gotType = goalType
+			return &Goal{Slug: slug}, nil
+		},
+	}
+
+	stdin := strings.NewReader("reading\nDaily Reading\ndo more\npages\n\n365\n1\n")
+	var stdout, stderr bytes.Buffer
+	if code := runCreateCommand(stdin, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if gotType != "hustler" {
+		t.Errorf("expected goal type %q for label %q, got %q", "hustler", "do more", gotType)
+	}
+}
+
 // TestRunCreateCommandGoalDateAndValue verifies the third accepted permutation
 // of the 2-of-3 rule: goal date + goal value provided, rate left blank.
 func TestRunCreateCommandGoalDateAndValue(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func printHelp() {
 	fmt.Println("  buzz review                       Interactive review of all goals")
 	fmt.Println("  buzz charge <amount> <note> [--dryrun]")
 	fmt.Println("                                    Create a charge for the authenticated user")
+	fmt.Println("  buzz create                       Interactively create a new Beeminder goal")
 	fmt.Println("  buzz deadline [--yes] <goalslug> <time>")
 	fmt.Println("                                    Change a goal's deadline (e.g., \"3:00 PM\" or \"15:00\")")
 	fmt.Println("  buzz schedule                     Display goal deadline distribution throughout a 24-hour day")
@@ -138,6 +139,9 @@ func main() {
 		case "charge":
 			handleChargeCommand()
 			return
+		case "create":
+			handleCreateCommand()
+			return
 		case "deadline":
 			handleDeadlineCommand()
 			return
@@ -164,7 +168,7 @@ func main() {
 			return
 		default:
 			fmt.Printf("Unknown command: %s\n", os.Args[1])
-			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, deadline, schedule, uncle, ratchet, api, auth, help, version")
+			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, create, refresh, view, review, charge, deadline, schedule, uncle, ratchet, api, auth, help, version")
 			fmt.Println("Run 'buzz --help' for more information.")
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func main() {
 			return
 		default:
 			fmt.Printf("Unknown command: %s\n", os.Args[1])
-			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, create, refresh, view, review, charge, deadline, schedule, uncle, ratchet, api, auth, help, version")
+			fmt.Println("Available commands: next, list, all, today, tomorrow, due, less, add, refresh, view, review, charge, create, deadline, schedule, uncle, ratchet, api, auth, help, version")
 			fmt.Println("Run 'buzz --help' for more information.")
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary

Adds a `buzz create` CLI command that interactively creates a new Beeminder goal, rather than only via the TUI modal (`n`) or the raw API.

It prompts for slug, title, type (default `hustler`), units, and 2 of 3 of goal date / goal value / rate, reusing the existing `validateCreateGoalInput()` validation that backs the TUI create-goal modal and the client's `CreateGoal` method. Reading input line-by-line means it also works with piped input for scripting (e.g. `printf '...' | buzz create`).

The testable core (`runCreateCommand`) takes explicit reader/writers and returns an exit code, mirroring the structure of `buzz api`.

```
$ buzz create
Create a new Beeminder goal
===========================

Goal slug: reading
Goal title: Daily Reading
Goal type (default: hustler):
Goal units: pages

Provide exactly 2 of the next 3 (leave one blank):
Goal date (epoch timestamp):
Goal value: 365
Rate: 1

Creating goal...
Successfully created goal: reading
```

## Changes

- `create.go` — `handleCreateCommand()` (config/auth check + client setup), testable `runCreateCommand()`, and a `promptField` helper.
- `main.go` — wire `create` into the command dispatch, help text, and the available-commands list.
- `create_test.go` — covers the happy path, default goal type, both 2-of-3 permutations, validation failure (short-circuits before any API call), API error, whitespace/CRLF trimming, and truncated/EOF stdin.

## Notes

- A prior attempt (#197) was built against the old monolithic `main.go` and went stale after the per-command split; this is a fresh implementation against current `main`.
- Pre-push review-loop run clean: security, bug scan, CLAUDE.md/comments/git-history all clear; the three test gaps it surfaced are included above.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive "buzz create" CLI to create goals with guided prompts (slug, title, type, units, date/value/rate).
  * Goal type can be chosen by menu number, canonical name, or human label; unknown values are forwarded unchanged.
  * Defaults goal type when blank, trims whitespace/CRLF, and enforces the "exactly 2 of 3" rule for date/value/rate.
  * Shows success confirmation and surfaces API errors.

* **Tests**
  * Added unit tests for success path, goal-type resolution, trimming, truncated input, validation failures, and API error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->