### PR TITLE
feat(list): add `--archived` flag to list archived goals

### DIFF
--- a/beeminder_test.go
+++ b/beeminder_test.go
@@ -1256,6 +1256,55 @@ func TestFetchGoalsWithGoalType(t *testing.T) {
 	}
 }
 
+// TestFetchArchivedGoals tests that FetchArchivedGoals hits the archived
+// endpoint and decodes the returned goals.
+func TestFetchArchivedGoals(t *testing.T) {
+	t.Run("fetches and decodes archived goals", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("Expected GET request, got %s", r.Method)
+			}
+			expectedPath := "/api/v1/users/testuser/goals/archived.json"
+			if r.URL.Path != expectedPath {
+				t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+			}
+			goals := []Goal{
+				{Slug: "olddiet", Title: "Old Diet", Gunits: "lbs", Pledge: 30},
+				{Slug: "retired", Title: "Retired Goal", Gunits: "reps"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(goals)
+		}))
+		defer mockServer.Close()
+
+		config := &Config{Username: "testuser", AuthToken: "testtoken", BaseURL: mockServer.URL}
+
+		goals, err := NewHTTPClient(config).FetchArchivedGoals(context.Background())
+		if err != nil {
+			t.Fatalf("FetchArchivedGoals failed: %v", err)
+		}
+		if len(goals) != 2 {
+			t.Fatalf("Expected 2 archived goals, got %d", len(goals))
+		}
+		if goals[0].Slug != "olddiet" {
+			t.Errorf("Expected first archived goal slug %q, got %q", "olddiet", goals[0].Slug)
+		}
+	})
+
+	t.Run("non-200 status returns an error", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer mockServer.Close()
+
+		config := &Config{Username: "testuser", AuthToken: "testtoken", BaseURL: mockServer.URL}
+
+		if _, err := NewHTTPClient(config).FetchArchivedGoals(context.Background()); err == nil {
+			t.Error("Expected an error for non-200 status, got nil")
+		}
+	})
+}
+
 // TestRefreshGoalWithMockServer tests RefreshGoal function with a mock HTTP server
 func TestRefreshGoalWithMockServer(t *testing.T) {
 	// Test case 1: successful refresh (returns true)

--- a/client.go
+++ b/client.go
@@ -25,6 +25,10 @@ const httpClientTimeout = 30 * time.Second
 // further interface changes — that wiring is tracked in a follow-up.
 type Client interface {
 	FetchGoals(ctx context.Context) ([]Goal, error)
+	// FetchArchivedGoals returns the user's archived goals. Beeminder exposes
+	// these on a separate endpoint from active goals; the response uses the
+	// same Goal shape.
+	FetchArchivedGoals(ctx context.Context) ([]Goal, error)
 	// FetchUserTimezone returns the IANA timezone configured on the user's
 	// Beeminder account (e.g. "America/New_York"), or an empty string if the
 	// account has none set.
@@ -119,6 +123,29 @@ func (c *HTTPClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 	var goals []Goal
 	if err := json.NewDecoder(resp.Body).Decode(&goals); err != nil {
 		return nil, fmt.Errorf("failed to decode goals: %w", err)
+	}
+
+	return goals, nil
+}
+
+// FetchArchivedGoals fetches the user's archived goals from the Beeminder API.
+func (c *HTTPClient) FetchArchivedGoals(ctx context.Context) ([]Goal, error) {
+	url := fmt.Sprintf("%s/api/v1/users/%s/goals/archived.json?auth_token=%s",
+		c.baseURL(), c.config.Username, c.config.AuthToken)
+
+	resp, err := c.doRequest(ctx, http.MethodGet, url, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch archived goals: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var goals []Goal
+	if err := json.NewDecoder(resp.Body).Decode(&goals); err != nil {
+		return nil, fmt.Errorf("failed to decode archived goals: %w", err)
 	}
 
 	return goals, nil

--- a/client_fake_test.go
+++ b/client_fake_test.go
@@ -25,6 +25,7 @@ import (
 // explicit context-capture field when the need arises.
 type FakeClient struct {
 	FetchGoalsFunc                  func() ([]Goal, error)
+	FetchArchivedGoalsFunc          func() ([]Goal, error)
 	FetchUserTimezoneFunc           func() (string, error)
 	APIRequestFunc                  func(method, path string, params url.Values) (int, []byte, error)
 	FetchGoalFunc                   func(goalSlug string) (*Goal, error)
@@ -51,6 +52,13 @@ func (c *FakeClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 		return nil, errFakeNotConfigured
 	}
 	return c.FetchGoalsFunc()
+}
+
+func (c *FakeClient) FetchArchivedGoals(ctx context.Context) ([]Goal, error) {
+	if c.FetchArchivedGoalsFunc == nil {
+		return nil, errFakeNotConfigured
+	}
+	return c.FetchArchivedGoalsFunc()
 }
 
 func (c *FakeClient) FetchUserTimezone(ctx context.Context) (string, error) {

--- a/list.go
+++ b/list.go
@@ -13,21 +13,12 @@ import (
 // rate, and stakes. With --archived it lists archived goals instead of active
 // ones.
 func handleListCommand() {
-	listFlags := flag.NewFlagSet("list", flag.ContinueOnError)
-	archived := listFlags.Bool("archived", false, "List archived goals instead of active ones")
-	if err := listFlags.Parse(os.Args[2:]); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			fmt.Println("Usage: buzz list [--archived]")
-			return
+	archived, code, done := parseListArgs(os.Args[2:], os.Stdout, os.Stderr)
+	if done {
+		if code != 0 {
+			os.Exit(code)
 		}
-		fmt.Fprintf(os.Stderr, "Error parsing flags: %s\n", redactError(err))
-		fmt.Fprintln(os.Stderr, "Usage: buzz list [--archived]")
-		os.Exit(2)
-	}
-	if args := listFlags.Args(); len(args) > 0 {
-		fmt.Fprintf(os.Stderr, "Unknown arguments: %v\n", args)
-		fmt.Fprintln(os.Stderr, "Usage: buzz list [--archived]")
-		os.Exit(2)
+		return
 	}
 
 	// Load config
@@ -43,12 +34,39 @@ func handleListCommand() {
 	}
 
 	client := NewHTTPClient(config)
-	code := runListCommand(context.Background(), client, *archived, os.Stdout)
+	code = runListCommand(context.Background(), client, archived, os.Stdout)
 	if code == 0 {
 		// Check for updates and display message if available
 		fmt.Print(getUpdateMessage())
 	}
 	os.Exit(code)
+}
+
+// parseListArgs parses the `buzz list` arguments (everything after the
+// subcommand). It returns the --archived flag, a process exit code, and done:
+// when done is true the caller should stop (help was printed, or a usage error
+// occurred) and honor exitCode (0 = help/clean stop, non-zero = error). On the
+// normal path done is false and exitCode is 0. Usage/errors are written to
+// out/errOut rather than fixed streams so the parsing is unit-testable.
+func parseListArgs(args []string, out, errOut io.Writer) (archived bool, exitCode int, done bool) {
+	listFlags := flag.NewFlagSet("list", flag.ContinueOnError)
+	listFlags.SetOutput(errOut)
+	archivedFlag := listFlags.Bool("archived", false, "List archived goals instead of active ones")
+	if err := listFlags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(out, "Usage: buzz list [--archived]")
+			return false, 0, true
+		}
+		fmt.Fprintf(errOut, "Error parsing flags: %s\n", redactError(err))
+		fmt.Fprintln(errOut, "Usage: buzz list [--archived]")
+		return false, 2, true
+	}
+	if extra := listFlags.Args(); len(extra) > 0 {
+		fmt.Fprintf(errOut, "Unknown arguments: %v\n", extra)
+		fmt.Fprintln(errOut, "Usage: buzz list [--archived]")
+		return false, 2, true
+	}
+	return *archivedFlag, 0, false
 }
 
 // runListCommand is the testable core of `buzz list`. It fetches the requested

--- a/list.go
+++ b/list.go
@@ -34,7 +34,7 @@ func handleListCommand() {
 	}
 
 	client := NewHTTPClient(config)
-	code = runListCommand(context.Background(), client, archived, os.Stdout)
+	code = runListCommand(context.Background(), client, archived, os.Stdout, os.Stderr)
 	if code == 0 {
 		// Check for updates and display message if available
 		fmt.Print(getUpdateMessage())
@@ -72,9 +72,11 @@ func parseListArgs(args []string, out, errOut io.Writer) (archived bool, exitCod
 }
 
 // runListCommand is the testable core of `buzz list`. It fetches the requested
-// set of goals (active, or archived when archived is true), renders them as a
-// table to out, and returns the process exit code.
-func runListCommand(ctx context.Context, client Client, archived bool, out io.Writer) int {
+// set of goals (active, or archived when archived is true), renders the table
+// to out, writes any fetch error to errOut, and returns the process exit code.
+// Splitting stdout (out) from stderr (errOut) keeps the table pipeable and
+// matches the other command cores (e.g. runCreateCommand).
+func runListCommand(ctx context.Context, client Client, archived bool, out, errOut io.Writer) int {
 	noun := "goals"
 	fetch := client.FetchGoals
 	if archived {
@@ -84,7 +86,7 @@ func runListCommand(ctx context.Context, client Client, archived bool, out io.Wr
 
 	goals, err := fetch(ctx)
 	if err != nil {
-		fmt.Fprintf(out, "Error: Failed to fetch %s: %s\n", noun, redactError(err))
+		fmt.Fprintf(errOut, "Error: Failed to fetch %s: %s\n", noun, redactError(err))
 		return 1
 	}
 

--- a/list.go
+++ b/list.go
@@ -50,7 +50,9 @@ func handleListCommand() {
 // out/errOut rather than fixed streams so the parsing is unit-testable.
 func parseListArgs(args []string, out, errOut io.Writer) (archived bool, exitCode int, done bool) {
 	listFlags := flag.NewFlagSet("list", flag.ContinueOnError)
-	listFlags.SetOutput(errOut)
+	// Silence flag's built-in error/usage printing so it doesn't duplicate (and
+	// cross-stream) the explicit messages below; we own all user-facing output.
+	listFlags.SetOutput(io.Discard)
 	archivedFlag := listFlags.Bool("archived", false, "List archived goals instead of active ones")
 	if err := listFlags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {

--- a/list.go
+++ b/list.go
@@ -2,12 +2,34 @@ package main
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"os"
 )
 
-// handleListCommand outputs a summary list of all goals with slug, title, rate, and stakes
+// handleListCommand outputs a summary list of goals with slug, title, units,
+// rate, and stakes. With --archived it lists archived goals instead of active
+// ones.
 func handleListCommand() {
+	listFlags := flag.NewFlagSet("list", flag.ContinueOnError)
+	archived := listFlags.Bool("archived", false, "List archived goals instead of active ones")
+	if err := listFlags.Parse(os.Args[2:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Println("Usage: buzz list [--archived]")
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Error parsing flags: %s\n", redactError(err))
+		fmt.Fprintln(os.Stderr, "Usage: buzz list [--archived]")
+		os.Exit(2)
+	}
+	if args := listFlags.Args(); len(args) > 0 {
+		fmt.Fprintf(os.Stderr, "Unknown arguments: %v\n", args)
+		fmt.Fprintln(os.Stderr, "Usage: buzz list [--archived]")
+		os.Exit(2)
+	}
+
 	// Load config
 	if !ConfigExists() {
 		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
@@ -21,25 +43,41 @@ func handleListCommand() {
 	}
 
 	client := NewHTTPClient(config)
+	code := runListCommand(context.Background(), client, *archived, os.Stdout)
+	if code == 0 {
+		// Check for updates and display message if available
+		fmt.Print(getUpdateMessage())
+	}
+	os.Exit(code)
+}
 
-	// Fetch goals
-	goals, err := client.FetchGoals(context.Background())
+// runListCommand is the testable core of `buzz list`. It fetches the requested
+// set of goals (active, or archived when archived is true), renders them as a
+// table to out, and returns the process exit code.
+func runListCommand(ctx context.Context, client Client, archived bool, out io.Writer) int {
+	noun := "goals"
+	fetch := client.FetchGoals
+	if archived {
+		noun = "archived goals"
+		fetch = client.FetchArchivedGoals
+	}
+
+	goals, err := fetch(ctx)
 	if err != nil {
-		fmt.Printf("Error: Failed to fetch goals: %s\n", redactError(err))
-		os.Exit(1)
+		fmt.Fprintf(out, "Error: Failed to fetch %s: %s\n", noun, redactError(err))
+		return 1
 	}
 
 	// Sort goals alphabetically by slug for easy scanning
 	SortGoalsBySlug(goals)
 
-	// If no goals, exit
 	if len(goals) == 0 {
-		fmt.Println("No goals found.")
-		return
+		fmt.Fprintf(out, "No %s found.\n", noun)
+		return 0
 	}
 
 	// Print summary header
-	fmt.Printf("Total goals: %d\n\n", len(goals))
+	fmt.Fprintf(out, "Total %s: %d\n\n", noun, len(goals))
 
 	table := Table{
 		ShowHeader: true,
@@ -56,10 +94,9 @@ func handleListCommand() {
 			{Header: "Stakes", Cell: func(g Goal) string { return fmt.Sprintf("$%.2f", g.Pledge) }},
 		},
 	}
-	fmt.Print(table.Render(goals))
+	fmt.Fprint(out, table.Render(goals))
 
-	// Check for updates and display message if available
-	fmt.Print(getUpdateMessage())
+	return 0
 }
 
 // getDisplayUnits returns the display value for goal units, using "-" if empty

--- a/list_test.go
+++ b/list_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
 	"testing"
 )
 
@@ -63,6 +67,100 @@ func TestFormatListRate(t *testing.T) {
 // float64Ptr is a helper function to create a pointer to a float64
 func float64Ptr(f float64) *float64 {
 	return &f
+}
+
+// TestRunListCommand exercises the testable core of `buzz list`, covering the
+// active/archived split, sorting, the empty case, and fetch errors.
+func TestRunListCommand(t *testing.T) {
+	t.Run("lists active goals sorted by slug", func(t *testing.T) {
+		client := &FakeClient{
+			FetchGoalsFunc: func() ([]Goal, error) {
+				return []Goal{
+					{Slug: "zebra", Title: "Z Goal", Gunits: "reps", Rate: float64Ptr(2), Runits: "d", Pledge: 5},
+					{Slug: "apple", Title: "A Goal", Gunits: "pages", Pledge: 0},
+				}, nil
+			},
+			// Leaving FetchArchivedGoalsFunc nil ensures the active path never
+			// touches the archived endpoint.
+		}
+
+		var out bytes.Buffer
+		code := runListCommand(context.Background(), client, false, &out)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		got := out.String()
+		if !strings.Contains(got, "Total goals: 2") {
+			t.Errorf("expected active-goals header, got:\n%s", got)
+		}
+		if i, j := strings.Index(got, "apple"), strings.Index(got, "zebra"); i == -1 || j == -1 || i > j {
+			t.Errorf("expected goals sorted by slug (apple before zebra), got:\n%s", got)
+		}
+	})
+
+	t.Run("lists archived goals", func(t *testing.T) {
+		client := &FakeClient{
+			FetchArchivedGoalsFunc: func() ([]Goal, error) {
+				return []Goal{{Slug: "olddiet", Title: "Old Diet", Gunits: "lbs", Pledge: 30}}, nil
+			},
+		}
+
+		var out bytes.Buffer
+		code := runListCommand(context.Background(), client, true, &out)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		got := out.String()
+		if !strings.Contains(got, "Total archived goals: 1") {
+			t.Errorf("expected archived-goals header, got:\n%s", got)
+		}
+		if !strings.Contains(got, "olddiet") {
+			t.Errorf("expected archived goal slug in output, got:\n%s", got)
+		}
+	})
+
+	t.Run("empty active goals", func(t *testing.T) {
+		client := &FakeClient{FetchGoalsFunc: func() ([]Goal, error) { return nil, nil }}
+
+		var out bytes.Buffer
+		code := runListCommand(context.Background(), client, false, &out)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		if got := out.String(); !strings.Contains(got, "No goals found.") {
+			t.Errorf("expected empty-active message, got:\n%s", got)
+		}
+	})
+
+	t.Run("empty archived goals", func(t *testing.T) {
+		client := &FakeClient{FetchArchivedGoalsFunc: func() ([]Goal, error) { return nil, nil }}
+
+		var out bytes.Buffer
+		code := runListCommand(context.Background(), client, true, &out)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		if got := out.String(); !strings.Contains(got, "No archived goals found.") {
+			t.Errorf("expected empty-archived message, got:\n%s", got)
+		}
+	})
+
+	t.Run("fetch error returns exit code 1", func(t *testing.T) {
+		client := &FakeClient{
+			FetchArchivedGoalsFunc: func() ([]Goal, error) {
+				return nil, errors.New("boom")
+			},
+		}
+
+		var out bytes.Buffer
+		code := runListCommand(context.Background(), client, true, &out)
+		if code != 1 {
+			t.Fatalf("expected exit code 1, got %d", code)
+		}
+		if got := out.String(); !strings.Contains(got, "Failed to fetch archived goals") {
+			t.Errorf("expected fetch-error message, got:\n%s", got)
+		}
+	})
 }
 
 // TestGetDisplayUnits tests the getDisplayUnits function

--- a/list_test.go
+++ b/list_test.go
@@ -150,8 +150,8 @@ func TestRunListCommand(t *testing.T) {
 			// touches the archived endpoint.
 		}
 
-		var out bytes.Buffer
-		code := runListCommand(context.Background(), client, false, &out)
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, false, &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -162,6 +162,9 @@ func TestRunListCommand(t *testing.T) {
 		if i, j := strings.Index(got, "apple"), strings.Index(got, "zebra"); i == -1 || j == -1 || i > j {
 			t.Errorf("expected goals sorted by slug (apple before zebra), got:\n%s", got)
 		}
+		if errOut.Len() != 0 {
+			t.Errorf("expected nothing on stderr, got: %q", errOut.String())
+		}
 	})
 
 	t.Run("lists archived goals", func(t *testing.T) {
@@ -171,8 +174,8 @@ func TestRunListCommand(t *testing.T) {
 			},
 		}
 
-		var out bytes.Buffer
-		code := runListCommand(context.Background(), client, true, &out)
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, true, &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -183,13 +186,16 @@ func TestRunListCommand(t *testing.T) {
 		if !strings.Contains(got, "olddiet") {
 			t.Errorf("expected archived goal slug in output, got:\n%s", got)
 		}
+		if errOut.Len() != 0 {
+			t.Errorf("expected nothing on stderr, got: %q", errOut.String())
+		}
 	})
 
 	t.Run("empty active goals", func(t *testing.T) {
 		client := &FakeClient{FetchGoalsFunc: func() ([]Goal, error) { return nil, nil }}
 
-		var out bytes.Buffer
-		code := runListCommand(context.Background(), client, false, &out)
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, false, &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -201,8 +207,8 @@ func TestRunListCommand(t *testing.T) {
 	t.Run("empty archived goals", func(t *testing.T) {
 		client := &FakeClient{FetchArchivedGoalsFunc: func() ([]Goal, error) { return nil, nil }}
 
-		var out bytes.Buffer
-		code := runListCommand(context.Background(), client, true, &out)
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, true, &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -218,13 +224,17 @@ func TestRunListCommand(t *testing.T) {
 			},
 		}
 
-		var out bytes.Buffer
-		code := runListCommand(context.Background(), client, true, &out)
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, true, &out, &errOut)
 		if code != 1 {
 			t.Fatalf("expected exit code 1, got %d", code)
 		}
-		if got := out.String(); !strings.Contains(got, "Failed to fetch archived goals") {
-			t.Errorf("expected fetch-error message, got:\n%s", got)
+		// The fetch error goes to stderr, keeping stdout clean for piping.
+		if got := errOut.String(); !strings.Contains(got, "Failed to fetch archived goals") {
+			t.Errorf("expected fetch-error message on stderr, got:\n%s", got)
+		}
+		if out.Len() != 0 {
+			t.Errorf("expected nothing on stdout for fetch error, got: %q", out.String())
 		}
 	})
 }

--- a/list_test.go
+++ b/list_test.go
@@ -98,6 +98,10 @@ func TestParseListArgs(t *testing.T) {
 		if !strings.Contains(out.String(), "Usage: buzz list") {
 			t.Errorf("expected usage on stdout, got: %q", out.String())
 		}
+		// Help goes to stdout only; flag's built-in usage must not leak to stderr.
+		if errOut.Len() != 0 {
+			t.Errorf("expected nothing on stderr for help, got: %q", errOut.String())
+		}
 	})
 
 	t.Run("unknown flag errors with exit code 2", func(t *testing.T) {
@@ -108,6 +112,14 @@ func TestParseListArgs(t *testing.T) {
 		}
 		if !strings.Contains(errOut.String(), "Usage: buzz list") {
 			t.Errorf("expected usage on stderr, got: %q", errOut.String())
+		}
+		// Only our explicit message should print — flag's auto-output is
+		// suppressed, so usage appears exactly once and nothing leaks to stdout.
+		if n := strings.Count(errOut.String(), "Usage:"); n != 1 {
+			t.Errorf("expected usage printed once, got %d times: %q", n, errOut.String())
+		}
+		if out.Len() != 0 {
+			t.Errorf("expected nothing on stdout for parse error, got: %q", out.String())
 		}
 	})
 

--- a/list_test.go
+++ b/list_test.go
@@ -69,6 +69,60 @@ func float64Ptr(f float64) *float64 {
 	return &f
 }
 
+// TestParseListArgs covers the `buzz list` argument-parsing branches: the
+// default and --archived success paths, help, an unknown flag, and an
+// unexpected positional argument.
+func TestParseListArgs(t *testing.T) {
+	t.Run("no args defaults to active", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		archived, code, done := parseListArgs(nil, &out, &errOut)
+		if archived || code != 0 || done {
+			t.Fatalf("got archived=%v code=%d done=%v, want false/0/false", archived, code, done)
+		}
+	})
+
+	t.Run("--archived selects archived", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		archived, code, done := parseListArgs([]string{"--archived"}, &out, &errOut)
+		if !archived || code != 0 || done {
+			t.Fatalf("got archived=%v code=%d done=%v, want true/0/false", archived, code, done)
+		}
+	})
+
+	t.Run("help prints usage and stops cleanly", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		archived, code, done := parseListArgs([]string{"-h"}, &out, &errOut)
+		if archived || code != 0 || !done {
+			t.Fatalf("got archived=%v code=%d done=%v, want false/0/true", archived, code, done)
+		}
+		if !strings.Contains(out.String(), "Usage: buzz list") {
+			t.Errorf("expected usage on stdout, got: %q", out.String())
+		}
+	})
+
+	t.Run("unknown flag errors with exit code 2", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		_, code, done := parseListArgs([]string{"--bogus"}, &out, &errOut)
+		if code != 2 || !done {
+			t.Fatalf("got code=%d done=%v, want 2/true", code, done)
+		}
+		if !strings.Contains(errOut.String(), "Usage: buzz list") {
+			t.Errorf("expected usage on stderr, got: %q", errOut.String())
+		}
+	})
+
+	t.Run("unexpected positional arg errors with exit code 2", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		_, code, done := parseListArgs([]string{"extra"}, &out, &errOut)
+		if code != 2 || !done {
+			t.Fatalf("got code=%d done=%v, want 2/true", code, done)
+		}
+		if !strings.Contains(errOut.String(), "Unknown arguments") {
+			t.Errorf("expected unknown-arguments message on stderr, got: %q", errOut.String())
+		}
+	})
+}
+
 // TestRunListCommand exercises the testable core of `buzz list`, covering the
 // active/archived split, sorting, the empty case, and fetch errors.
 func TestRunListCommand(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func printHelp() {
 	fmt.Println("  buzz next --watch                 Watch mode - continuously refresh every 5 minutes")
 	fmt.Println("  buzz next -w                      Watch mode (shorthand)")
 	fmt.Println("  buzz list                         List all goals with slug, title, units, rate, and stakes")
+	fmt.Println("  buzz list --archived              List archived goals instead of active ones")
 	fmt.Println("  buzz all                          Output all goals")
 	fmt.Println("  buzz today                        Output all goals due today")
 	fmt.Println("  buzz tomorrow                     Output all goals due tomorrow")


### PR DESCRIPTION
## Summary

Adds a `buzz list --archived` flag that lists the user's **archived** Beeminder goals instead of active ones, using the same table layout as the existing `buzz list`.

```
$ buzz list --archived
Total archived goals: 2

Slug      Title          Units  Rate  Stakes
olddiet   Old Diet       lbs    -     $30.00
retired   Retired Goal   reps   -     $0.00
```

Closes #225.

## Changes

- **`client.go`** — add `FetchArchivedGoals` to the `Client` interface and `HTTPClient`, hitting `/api/v1/users/{username}/goals/archived.json` (a faithful mirror of `FetchGoals`).
- **`list.go`** — parse the `--archived` flag and extract two testable cores mirroring the `buzz create` pattern:
  - `parseListArgs` — pure flag parsing (returns `archived`, exit code, `done`), writing usage/errors to injected writers.
  - `runListCommand` — fetches active or archived goals, sorts by slug, and renders the existing table.
- **`main.go`** — document the flag in help text.
- **Tests** — `httptest` coverage for `FetchArchivedGoals` (endpoint path + non-200), `parseListArgs` (default, `--archived`, help, unknown flag, unexpected arg, single-stream output), and `runListCommand` (active/archived/empty/error paths).

## Notes

- The feature is read-only; all tests use `httptest` mock servers or the in-repo `FakeClient` — no live account calls.
- Pre-push review-loop (6 agents × 3 cycles) ran clean: it caught and fixed a flag-output duplication/cross-stream bug introduced while extracting the parser, now pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `buzz list --archived` added to list archived goals (instead of active ones); output is sorted by slug and shows a total header.

* **Behavior**
  * Shows "No … found." when there are no goals; prints fetch errors to stderr and returns a non-zero exit code on failure.

* **Documentation**
  * CLI help updated to document the `--archived` option.

* **Tests**
  * Added tests covering argument parsing and list execution (active/archived, empty state, error handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->