### PR TITLE
feat(view): show 7-day amount-due forecast in view and review

### DIFF
--- a/filtered.go
+++ b/filtered.go
@@ -289,17 +289,23 @@ func bareminFromDueby(g Goal, now time.Time) (string, bool) {
 	return entry.FormattedDelta, true
 }
 
-// tomorrowDaystampFor returns the YYYYMMDD daystamp representing the day
-// after the goal's current Beeminder day. Beeminder shifts day boundaries
-// by the goal's `deadline` seconds — positive deadlines push the boundary
-// past midnight (e.g. +10800 = 3am cutoff), negative deadlines pull it
-// before (e.g. -10800 = 9pm cutoff). Subtracting the deadline from `now`
-// produces a wall-clock time inside the user's calendar date that matches
-// the goal's current daystamp; the next calendar day is tomorrow's.
-func tomorrowDaystampFor(g Goal, now time.Time) string {
+// todayDaystampFor returns the YYYYMMDD daystamp of the goal's current
+// Beeminder day. Beeminder shifts day boundaries by the goal's `deadline`
+// seconds — positive deadlines push the boundary past midnight (e.g. +10800 =
+// 3am cutoff), negative deadlines pull it before (e.g. -10800 = 9pm cutoff).
+// Subtracting the deadline from `now` produces a wall-clock time inside the
+// user's calendar date that matches the goal's current daystamp.
+func todayDaystampFor(g Goal, now time.Time) string {
 	shifted := now.Add(-time.Duration(g.Deadline) * time.Second).In(now.Location())
-	tomorrow := time.Date(shifted.Year(), shifted.Month(), shifted.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, 1)
-	return tomorrow.Format("20060102")
+	return time.Date(shifted.Year(), shifted.Month(), shifted.Day(), 0, 0, 0, 0, now.Location()).Format("20060102")
+}
+
+// tomorrowDaystampFor returns the YYYYMMDD daystamp representing the day after
+// the goal's current Beeminder day (see todayDaystampFor for the deadline-shift
+// rationale).
+func tomorrowDaystampFor(g Goal, now time.Time) string {
+	today, _ := time.ParseInLocation("20060102", todayDaystampFor(g, now), now.Location())
+	return today.AddDate(0, 0, 1).Format("20060102")
 }
 
 // losedateByEndOfTomorrowAt returns the deadline timestamp to display for a

--- a/review.go
+++ b/review.go
@@ -509,25 +509,43 @@ func formatGoalDetails(goal *Goal, config *Config) string {
 // an empty string when the goal has no dueby data (e.g. a freshly created
 // goal), so callers can append the result unconditionally.
 func formatSevenDayForecast(goal *Goal) string {
+	return formatSevenDayForecastAt(goal, time.Now())
+}
+
+// formatSevenDayForecastAt is the testable core of formatSevenDayForecast with
+// the clock injected. It anchors on the goal's current daystamp (deadline-aware)
+// rather than the dueby map's sort position: Beeminder's dueby can carry past
+// daystamps as well as today's and future ones, so we drop anything before today
+// and label each remaining day by its actual date — never by slice index — to
+// avoid mislabelling a stale past day as "Today".
+func formatSevenDayForecastAt(goal *Goal, now time.Time) string {
 	if len(goal.Dueby) == 0 {
 		return ""
 	}
 
+	today := todayDaystampFor(*goal, now)
+
 	days := make([]string, 0, len(goal.Dueby))
 	for daystamp := range goal.Dueby {
-		days = append(days, daystamp)
+		// YYYYMMDD strings compare chronologically; drop stale past daystamps.
+		if daystamp >= today {
+			days = append(days, daystamp)
+		}
 	}
-	sort.Strings(days) // YYYYMMDD daystamps sort chronologically
+	sort.Strings(days)
 	if len(days) > 7 {
 		days = days[:7]
+	}
+	if len(days) == 0 {
+		return ""
 	}
 
 	type forecastRow struct{ label, due, total string }
 	rows := make([]forecastRow, 0, len(days))
-	for i, daystamp := range days {
+	for _, daystamp := range days {
 		entry := goal.Dueby[daystamp]
 		rows = append(rows, forecastRow{
-			label: forecastDayLabel(daystamp, i),
+			label: forecastDayLabel(daystamp, today),
 			due:   entry.FormattedDelta,
 			total: entry.FormattedTotal,
 		})
@@ -551,20 +569,23 @@ func formatSevenDayForecast(goal *Goal) string {
 	return b.String()
 }
 
-// forecastDayLabel returns a human label for a dueby daystamp (YYYYMMDD).
-// Index 0 is "Today" and index 1 is "Tomorrow" (Beeminder's dueby map always
-// begins at today); any later day is shown as weekday + ordinal day-of-month,
-// e.g. "Fri (12th)". Falls back to the raw daystamp if it can't be parsed.
-func forecastDayLabel(daystamp string, index int) string {
-	switch index {
-	case 0:
+// forecastDayLabel returns a human label for a dueby daystamp (YYYYMMDD),
+// relative to today's daystamp: "Today", "Tomorrow", or otherwise weekday +
+// ordinal day-of-month, e.g. "Fri (12th)". Labelling by actual date (rather
+// than position) keeps the labels correct even if the dueby map has gaps or
+// stale entries. Falls back to the raw daystamp if it can't be parsed.
+func forecastDayLabel(daystamp, today string) string {
+	if daystamp == today {
 		return "Today"
-	case 1:
-		return "Tomorrow"
 	}
 	t, err := time.Parse("20060102", daystamp)
 	if err != nil {
 		return daystamp
+	}
+	if todayTime, err := time.Parse("20060102", today); err == nil {
+		if daystamp == todayTime.AddDate(0, 0, 1).Format("20060102") {
+			return "Tomorrow"
+		}
 	}
 	return fmt.Sprintf("%s (%d%s)", t.Format("Mon"), t.Day(), ordinalSuffix(t.Day()))
 }

--- a/review.go
+++ b/review.go
@@ -272,7 +272,7 @@ func (m reviewModel) View() string {
 	detailStyle := lipgloss.NewStyle().
 		Padding(0, 2)
 
-	details := formatGoalDetails(&goal, m.config)
+	details := formatGoalDetails(&goal, m.config, time.Now())
 
 	view += detailStyle.Render(details) + "\n"
 
@@ -423,8 +423,10 @@ func formatRecentDatapoints(datapoints []Datapoint) string {
 	return output
 }
 
-// formatGoalDetails formats the goal details in a consistent way for both view and review commands
-func formatGoalDetails(goal *Goal, config *Config) string {
+// formatGoalDetails formats the goal details in a consistent way for both view
+// and review commands. now is the reference clock for the 7-day forecast; pass
+// time.Now() in production.
+func formatGoalDetails(goal *Goal, config *Config, now time.Time) string {
 	var details string
 
 	// Field order follows issue #229: the goal's commitment (rate, autoratchet)
@@ -491,7 +493,7 @@ func formatGoalDetails(goal *Goal, config *Config) string {
 	}
 
 	// Display the next-seven-days "amount due" forecast, when available.
-	details += formatSevenDayForecast(goal)
+	details += formatSevenDayForecastAt(goal, now)
 
 	// Display recent datapoints if available
 	if len(goal.Datapoints) > 0 {
@@ -501,23 +503,20 @@ func formatGoalDetails(goal *Goal, config *Config) string {
 	return details
 }
 
-// formatSevenDayForecast renders the goal's per-day "amount due" forecast for
+// formatSevenDayForecastAt renders the goal's per-day "amount due" forecast for
 // the next seven days from Beeminder's dueby map. Each entry carries the delta
 // (how much is needed that day to stay on the safe side of the bright line) and
 // the running red-line total, both pre-formatted by Beeminder to the goal's
 // display precision — the same strings the Beeminder Android app shows. Returns
 // an empty string when the goal has no dueby data (e.g. a freshly created
 // goal), so callers can append the result unconditionally.
-func formatSevenDayForecast(goal *Goal) string {
-	return formatSevenDayForecastAt(goal, time.Now())
-}
-
-// formatSevenDayForecastAt is the testable core of formatSevenDayForecast with
-// the clock injected. It anchors on the goal's current daystamp (deadline-aware)
-// rather than the dueby map's sort position: Beeminder's dueby can carry past
-// daystamps as well as today's and future ones, so we drop anything before today
-// and label each remaining day by its actual date — never by slice index — to
-// avoid mislabelling a stale past day as "Today".
+//
+// now is the reference clock (injected for testability). The forecast anchors
+// on the goal's current daystamp (deadline-aware) rather than the dueby map's
+// sort position: Beeminder's dueby can carry past daystamps as well as today's
+// and future ones, so we drop anything before today and label each remaining
+// day by its actual date — never by slice index — to avoid mislabelling a stale
+// past day as "Today".
 func formatSevenDayForecastAt(goal *Goal, now time.Time) string {
 	if len(goal.Dueby) == 0 {
 		return ""

--- a/review.go
+++ b/review.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -488,10 +490,99 @@ func formatGoalDetails(goal *Goal, config *Config) string {
 		details += fmt.Sprintf("Fine print:  %s\n", goal.Fineprint)
 	}
 
+	// Display the next-seven-days "amount due" forecast, when available.
+	details += formatSevenDayForecast(goal)
+
 	// Display recent datapoints if available
 	if len(goal.Datapoints) > 0 {
 		details += formatRecentDatapoints(goal.Datapoints)
 	}
 
 	return details
+}
+
+// formatSevenDayForecast renders the goal's per-day "amount due" forecast for
+// the next seven days from Beeminder's dueby map. Each entry carries the delta
+// (how much is needed that day to stay on the safe side of the bright line) and
+// the running red-line total, both pre-formatted by Beeminder to the goal's
+// display precision — the same strings the Beeminder Android app shows. Returns
+// an empty string when the goal has no dueby data (e.g. a freshly created
+// goal), so callers can append the result unconditionally.
+func formatSevenDayForecast(goal *Goal) string {
+	if len(goal.Dueby) == 0 {
+		return ""
+	}
+
+	days := make([]string, 0, len(goal.Dueby))
+	for daystamp := range goal.Dueby {
+		days = append(days, daystamp)
+	}
+	sort.Strings(days) // YYYYMMDD daystamps sort chronologically
+	if len(days) > 7 {
+		days = days[:7]
+	}
+
+	type forecastRow struct{ label, due, total string }
+	rows := make([]forecastRow, 0, len(days))
+	for i, daystamp := range days {
+		entry := goal.Dueby[daystamp]
+		rows = append(rows, forecastRow{
+			label: forecastDayLabel(daystamp, i),
+			due:   entry.FormattedDelta,
+			total: entry.FormattedTotal,
+		})
+	}
+
+	// Size each column to the widest of its header and values so the columns
+	// line up regardless of count-vs-time formatting (e.g. "+1" vs "+00:05:59").
+	dayW, dueW, totW := len("Day"), len("Due"), len("Total")
+	for _, r := range rows {
+		dayW = max(dayW, len(r.label))
+		dueW = max(dueW, len(r.due))
+		totW = max(totW, len(r.total))
+	}
+
+	var b strings.Builder
+	b.WriteString("\n7-Day Forecast:\n")
+	fmt.Fprintf(&b, "  %-*s  %-*s  %-*s\n", dayW, "Day", dueW, "Due", totW, "Total")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "  %-*s  %-*s  %-*s\n", dayW, r.label, dueW, r.due, totW, r.total)
+	}
+	return b.String()
+}
+
+// forecastDayLabel returns a human label for a dueby daystamp (YYYYMMDD).
+// Index 0 is "Today" and index 1 is "Tomorrow" (Beeminder's dueby map always
+// begins at today); any later day is shown as weekday + ordinal day-of-month,
+// e.g. "Fri (12th)". Falls back to the raw daystamp if it can't be parsed.
+func forecastDayLabel(daystamp string, index int) string {
+	switch index {
+	case 0:
+		return "Today"
+	case 1:
+		return "Tomorrow"
+	}
+	t, err := time.Parse("20060102", daystamp)
+	if err != nil {
+		return daystamp
+	}
+	return fmt.Sprintf("%s (%d%s)", t.Format("Mon"), t.Day(), ordinalSuffix(t.Day()))
+}
+
+// ordinalSuffix returns the English ordinal suffix ("st", "nd", "rd", "th") for
+// a day-of-month, handling the 11–13 exceptions.
+func ordinalSuffix(day int) string {
+	if day >= 11 && day <= 13 {
+		return "th"
+	}
+	switch day % 10 {
+	case 1:
+		return "st"
+	case 2:
+		return "nd"
+	case 3:
+		return "rd"
+	default:
+		return "th"
+	}
 }

--- a/review_test.go
+++ b/review_test.go
@@ -1265,6 +1265,10 @@ func TestReviewViewMergesDetailFieldsOntoSummaryGoal(t *testing.T) {
 	}
 }
 
+// forecastTestNow is a fixed clock for the forecast tests: 2026-06-10 (a
+// Wednesday) at noon UTC, so today's daystamp is "20260610".
+var forecastTestNow = time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
 func TestFormatSevenDayForecast(t *testing.T) {
 	goal := &Goal{
 		Gunits: "clears",
@@ -1275,7 +1279,7 @@ func TestFormatSevenDayForecast(t *testing.T) {
 		},
 	}
 
-	out := formatSevenDayForecast(goal)
+	out := formatSevenDayForecastAt(goal, forecastTestNow)
 
 	for _, want := range []string{"7-Day Forecast:", "Day", "Due", "Total", "Today", "Tomorrow", "Fri (12th)", "+1", "138", "+3", "140"} {
 		if !strings.Contains(out, want) {
@@ -1291,20 +1295,28 @@ func TestFormatSevenDayForecast(t *testing.T) {
 }
 
 func TestFormatSevenDayForecastEmpty(t *testing.T) {
-	if got := formatSevenDayForecast(&Goal{}); got != "" {
+	if got := formatSevenDayForecastAt(&Goal{}, forecastTestNow); got != "" {
 		t.Errorf("expected empty string for goal with no dueby, got: %q", got)
 	}
 }
 
-func TestFormatSevenDayForecastTruncatesToSeven(t *testing.T) {
+func TestFormatSevenDayForecastDropsPastDaysAndTruncatesToSeven(t *testing.T) {
 	dueby := map[string]DuebyEntry{}
-	for _, d := range []string{"20260610", "20260611", "20260612", "20260613", "20260614", "20260615", "20260616", "20260617", "20260618"} {
+	// A stale past day (20260609) plus eight forward days from today.
+	for _, d := range []string{"20260609", "20260610", "20260611", "20260612", "20260613", "20260614", "20260615", "20260616", "20260617"} {
 		dueby[d] = DuebyEntry{FormattedDelta: "+1", FormattedTotal: "10"}
 	}
-	out := formatSevenDayForecast(&Goal{Dueby: dueby})
+	out := formatSevenDayForecastAt(&Goal{Dueby: dueby}, forecastTestNow)
 
-	// The 7th day (index 6) is 20260616 = Tue 16th; the 8th (20260617 = Wed 17th)
-	// must be dropped.
+	// The past day (Tue 9th) must be dropped, not labelled "Today".
+	if strings.Contains(out, "(9th)") {
+		t.Errorf("expected the past day (9th) to be dropped, but found it in:\n%s", out)
+	}
+	if !strings.Contains(out, "Today") {
+		t.Errorf("expected today's row to be present, got:\n%s", out)
+	}
+	// Seven forward days are kept (today..20260616 = Tue 16th); the 8th forward
+	// day (20260617 = Wed 17th) is truncated.
 	if !strings.Contains(out, "Tue (16th)") {
 		t.Errorf("expected the 7th day (Tue (16th)) to be present, got:\n%s", out)
 	}
@@ -1314,20 +1326,20 @@ func TestFormatSevenDayForecastTruncatesToSeven(t *testing.T) {
 }
 
 func TestForecastDayLabel(t *testing.T) {
+	const today = "20260610"
 	tests := []struct {
 		daystamp string
-		index    int
 		want     string
 	}{
-		{"20260610", 0, "Today"},
-		{"20260611", 1, "Tomorrow"},
-		{"20260612", 2, "Fri (12th)"},
-		{"20260621", 3, "Sun (21st)"},
-		{"notadate", 4, "notadate"},
+		{"20260610", "Today"},
+		{"20260611", "Tomorrow"},
+		{"20260612", "Fri (12th)"},
+		{"20260621", "Sun (21st)"},
+		{"notadate", "notadate"},
 	}
 	for _, tt := range tests {
-		if got := forecastDayLabel(tt.daystamp, tt.index); got != tt.want {
-			t.Errorf("forecastDayLabel(%q, %d) = %q, want %q", tt.daystamp, tt.index, got, tt.want)
+		if got := forecastDayLabel(tt.daystamp, today); got != tt.want {
+			t.Errorf("forecastDayLabel(%q, %q) = %q, want %q", tt.daystamp, today, got, tt.want)
 		}
 	}
 }
@@ -1352,7 +1364,7 @@ func TestFormatSevenDayForecastAlignsColumnsWithTimeValues(t *testing.T) {
 			"20260611": {FormattedDelta: "+2", FormattedTotal: "139"},             // Tomorrow
 		},
 	}
-	out := formatSevenDayForecast(goal)
+	out := formatSevenDayForecastAt(goal, forecastTestNow)
 
 	// Time-formatted values (HH:MM:SS) must render intact — the case the
 	// dynamic column widths exist for.
@@ -1385,9 +1397,12 @@ func TestFormatSevenDayForecastAlignsColumnsWithTimeValues(t *testing.T) {
 }
 
 func TestFormatGoalDetailsIncludesForecastBeforeDatapoints(t *testing.T) {
+	// formatGoalDetails uses the real clock, so key the dueby entry to today's
+	// actual daystamp; the forecast drops anything before today.
+	today := todayDaystampFor(Goal{}, time.Now())
 	goal := &Goal{
 		Slug:       "test",
-		Dueby:      map[string]DuebyEntry{"20260610": {FormattedDelta: "+1", FormattedTotal: "10"}},
+		Dueby:      map[string]DuebyEntry{today: {FormattedDelta: "+1", FormattedTotal: "10"}},
 		Datapoints: []Datapoint{{Daystamp: "20260609", Value: 1, Comment: "x"}},
 	}
 	config := &Config{Username: "u", BaseURL: "https://example.com"}

--- a/review_test.go
+++ b/review_test.go
@@ -701,7 +701,7 @@ func TestFineprintOrderInOutput(t *testing.T) {
 		AuthToken: "testtoken",
 	}
 
-	output := formatGoalDetails(&goal, config)
+	output := formatGoalDetails(&goal, config, time.Now())
 
 	// Find positions of URL and Fine print in the output
 	urlIndex := strings.Index(output, "URL:")
@@ -857,7 +857,7 @@ func TestFormatGoalDetailsWithDatapoints(t *testing.T) {
 
 	config := &Config{Username: "testuser"}
 
-	result := formatGoalDetails(goal, config)
+	result := formatGoalDetails(goal, config, time.Now())
 
 	for _, want := range []string{
 		"Recent datapoints:",
@@ -885,7 +885,7 @@ func TestFormatGoalDetailsWithoutDatapoints(t *testing.T) {
 
 	config := &Config{Username: "testuser"}
 
-	result := formatGoalDetails(goal, config)
+	result := formatGoalDetails(goal, config, time.Now())
 
 	if strings.Contains(result, "Recent datapoints:") {
 		t.Error("Expected result to NOT contain 'Recent datapoints:' header when no datapoints present")
@@ -1048,7 +1048,7 @@ func TestGoalDetailsFieldOrder(t *testing.T) {
 	}
 	config := &Config{Username: "narthur"}
 
-	out := formatGoalDetails(goal, config)
+	out := formatGoalDetails(goal, config, time.Now())
 
 	// Each label must appear, and in this exact relative order.
 	want := []string{
@@ -1079,7 +1079,7 @@ func TestGoalDetailsFieldOrderMinimal(t *testing.T) {
 		Losedate: 4102444800, // fixed future timestamp; only label positions matter
 		// Rate nil, Autoratchet nil, Title/Autodata/Fineprint empty → all omitted.
 	}
-	out := formatGoalDetails(goal, &Config{Username: "narthur"})
+	out := formatGoalDetails(goal, &Config{Username: "narthur"}, time.Now())
 
 	for _, absent := range []string{"Rate:", "Autoratchet:", "Title:", "Autodata:", "Fine print:"} {
 		if strings.Contains(out, absent) {
@@ -1397,9 +1397,9 @@ func TestFormatSevenDayForecastAlignsColumnsWithTimeValues(t *testing.T) {
 }
 
 func TestFormatGoalDetailsIncludesForecastBeforeDatapoints(t *testing.T) {
-	// formatGoalDetails uses the real clock, so key the dueby entry to today's
-	// actual daystamp; the forecast drops anything before today.
-	today := todayDaystampFor(Goal{}, time.Now())
+	// Inject a fixed clock so the test is deterministic (no midnight-rollover
+	// flake): key the dueby entry to that clock's daystamp.
+	today := todayDaystampFor(Goal{}, forecastTestNow)
 	goal := &Goal{
 		Slug:       "test",
 		Dueby:      map[string]DuebyEntry{today: {FormattedDelta: "+1", FormattedTotal: "10"}},
@@ -1407,7 +1407,7 @@ func TestFormatGoalDetailsIncludesForecastBeforeDatapoints(t *testing.T) {
 	}
 	config := &Config{Username: "u", BaseURL: "https://example.com"}
 
-	out := formatGoalDetails(goal, config)
+	out := formatGoalDetails(goal, config, forecastTestNow)
 
 	fi := strings.Index(out, "7-Day Forecast:")
 	di := strings.Index(out, "Recent datapoints:")

--- a/review_test.go
+++ b/review_test.go
@@ -1264,3 +1264,83 @@ func TestReviewViewMergesDetailFieldsOntoSummaryGoal(t *testing.T) {
 		t.Errorf("expected chart (from merged road + datapoints) to render\n%s", out)
 	}
 }
+
+func TestFormatSevenDayForecast(t *testing.T) {
+	goal := &Goal{
+		Gunits: "clears",
+		Dueby: map[string]DuebyEntry{
+			"20260610": {FormattedDelta: "+1", FormattedTotal: "138"},
+			"20260611": {FormattedDelta: "+2", FormattedTotal: "139"},
+			"20260612": {FormattedDelta: "+3", FormattedTotal: "140"},
+		},
+	}
+
+	out := formatSevenDayForecast(goal)
+
+	for _, want := range []string{"7-Day Forecast:", "Day", "Due", "Total", "Today", "Tomorrow", "Fri (12th)", "+1", "138", "+3", "140"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected forecast to contain %q, got:\n%s", want, out)
+		}
+	}
+
+	// Rows must be in chronological order regardless of map iteration order.
+	iToday, iTomorrow, iFri := strings.Index(out, "Today"), strings.Index(out, "Tomorrow"), strings.Index(out, "Fri (12th)")
+	if !(iToday < iTomorrow && iTomorrow < iFri) {
+		t.Errorf("expected chronological order Today < Tomorrow < Fri, got positions %d/%d/%d in:\n%s", iToday, iTomorrow, iFri, out)
+	}
+}
+
+func TestFormatSevenDayForecastEmpty(t *testing.T) {
+	if got := formatSevenDayForecast(&Goal{}); got != "" {
+		t.Errorf("expected empty string for goal with no dueby, got: %q", got)
+	}
+}
+
+func TestFormatSevenDayForecastTruncatesToSeven(t *testing.T) {
+	dueby := map[string]DuebyEntry{}
+	for _, d := range []string{"20260610", "20260611", "20260612", "20260613", "20260614", "20260615", "20260616", "20260617", "20260618"} {
+		dueby[d] = DuebyEntry{FormattedDelta: "+1", FormattedTotal: "10"}
+	}
+	out := formatSevenDayForecast(&Goal{Dueby: dueby})
+
+	// The 7th day (index 6) is 20260616 = Tue 16th; the 8th (20260617 = Wed 17th)
+	// must be dropped.
+	if !strings.Contains(out, "Tue (16th)") {
+		t.Errorf("expected the 7th day (Tue (16th)) to be present, got:\n%s", out)
+	}
+	if strings.Contains(out, "(17th)") {
+		t.Errorf("expected days beyond the 7th to be truncated, but found (17th) in:\n%s", out)
+	}
+}
+
+func TestForecastDayLabel(t *testing.T) {
+	tests := []struct {
+		daystamp string
+		index    int
+		want     string
+	}{
+		{"20260610", 0, "Today"},
+		{"20260611", 1, "Tomorrow"},
+		{"20260612", 2, "Fri (12th)"},
+		{"20260621", 3, "Sun (21st)"},
+		{"notadate", 4, "notadate"},
+	}
+	for _, tt := range tests {
+		if got := forecastDayLabel(tt.daystamp, tt.index); got != tt.want {
+			t.Errorf("forecastDayLabel(%q, %d) = %q, want %q", tt.daystamp, tt.index, got, tt.want)
+		}
+	}
+}
+
+func TestOrdinalSuffix(t *testing.T) {
+	tests := map[int]string{
+		1: "st", 2: "nd", 3: "rd", 4: "th", 10: "th",
+		11: "th", 12: "th", 13: "th",
+		21: "st", 22: "nd", 23: "rd", 31: "st",
+	}
+	for day, want := range tests {
+		if got := ordinalSuffix(day); got != want {
+			t.Errorf("ordinalSuffix(%d) = %q, want %q", day, got, want)
+		}
+	}
+}

--- a/review_test.go
+++ b/review_test.go
@@ -1344,3 +1344,65 @@ func TestOrdinalSuffix(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatSevenDayForecastAlignsColumnsWithTimeValues(t *testing.T) {
+	goal := &Goal{
+		Dueby: map[string]DuebyEntry{
+			"20260610": {FormattedDelta: "+00:05:59", FormattedTotal: "56:08:17"}, // Today
+			"20260611": {FormattedDelta: "+2", FormattedTotal: "139"},             // Tomorrow
+		},
+	}
+	out := formatSevenDayForecast(goal)
+
+	// Time-formatted values (HH:MM:SS) must render intact — the case the
+	// dynamic column widths exist for.
+	for _, want := range []string{"+00:05:59", "56:08:17"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected time value %q in output:\n%s", want, out)
+		}
+	}
+
+	var todayLine, tomorrowLine string
+	for _, l := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(l, "Today"):
+			todayLine = l
+		case strings.Contains(l, "Tomorrow"):
+			tomorrowLine = l
+		}
+	}
+	if todayLine == "" || tomorrowLine == "" {
+		t.Fatalf("expected Today and Tomorrow rows, got:\n%s", out)
+	}
+	// Despite the very different value widths ("+00:05:59" vs "+2"), the Due and
+	// Total columns must start at the same offset on both rows.
+	if a, b := strings.Index(todayLine, "+00:05:59"), strings.Index(tomorrowLine, "+2"); a != b {
+		t.Errorf("Due column misaligned: Today at %d, Tomorrow at %d\n%s", a, b, out)
+	}
+	if a, b := strings.Index(todayLine, "56:08:17"), strings.Index(tomorrowLine, "139"); a != b {
+		t.Errorf("Total column misaligned: Today at %d, Tomorrow at %d\n%s", a, b, out)
+	}
+}
+
+func TestFormatGoalDetailsIncludesForecastBeforeDatapoints(t *testing.T) {
+	goal := &Goal{
+		Slug:       "test",
+		Dueby:      map[string]DuebyEntry{"20260610": {FormattedDelta: "+1", FormattedTotal: "10"}},
+		Datapoints: []Datapoint{{Daystamp: "20260609", Value: 1, Comment: "x"}},
+	}
+	config := &Config{Username: "u", BaseURL: "https://example.com"}
+
+	out := formatGoalDetails(goal, config)
+
+	fi := strings.Index(out, "7-Day Forecast:")
+	di := strings.Index(out, "Recent datapoints:")
+	if fi == -1 {
+		t.Fatalf("expected forecast section in formatGoalDetails output:\n%s", out)
+	}
+	if di == -1 {
+		t.Fatalf("expected recent datapoints section in output:\n%s", out)
+	}
+	if fi > di {
+		t.Errorf("expected forecast (at %d) before recent datapoints (at %d):\n%s", fi, di, out)
+	}
+}

--- a/view.go
+++ b/view.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 )
 
 // handleViewCommand displays detailed information about a specific goal
@@ -117,7 +118,7 @@ func handleViewCommand() {
 
 	// Display goal information (human-readable format)
 	fmt.Printf("Goal: %s\n", goal.Slug)
-	fmt.Print(formatGoalDetails(goal, config))
+	fmt.Print(formatGoalDetails(goal, config, time.Now()))
 
 	// Check for updates and display message if available
 	fmt.Print(getUpdateMessage())


### PR DESCRIPTION
## Summary

Adds a **7-Day Forecast** section to `buzz view` and `buzz review` (both share `formatGoalDetails`), showing how much is due each of the next seven days plus the running red-line total — the Android-app view requested in #200.

```
7-Day Forecast:
  Day         Due        Total
  Today       +00:05:59  56:08:17
  Tomorrow    +00:12:10  56:14:28
  Fri (12th)  +00:19:50  56:22:09
  Sat (13th)  +00:19:50  56:22:09
  Sun (14th)  +00:19:50  56:22:09
  Mon (15th)  +00:25:51  56:28:09
  Tue (16th)  +00:31:50  56:34:08
```

Closes #200.

## Approach

The data comes **straight from Beeminder's `dueby` map** (already on the `Goal` struct), not derived from the bright line. The API returns exactly seven days keyed by `YYYYMMDD`, with delta and total **pre-formatted to the goal's display precision** in the `formatted_*_for_beedroid` fields — literally the strings the Beeminder Android app shows. So:

- No `fullroad`/red-line math, no float rounding to get wrong.
- Time-based goals render as `HH:MM:SS`, counts as integers — automatically.
- Verified against the live API for both count and time goals before building.

## Changes

- **`formatSevenDayForecast`** — sorts the `dueby` daystamps, truncates to 7, and renders an aligned `Day / Due / Total` table. Returns `""` when `dueby` is empty (e.g. a freshly created goal) so it appends safely. Inserted in `formatGoalDetails` just before the recent-datapoints block (within the trailing, non-#229-enumerated field group, so field-order intent is preserved).
- **`forecastDayLabel`** — `"Today"` / `"Tomorrow"`, then weekday + ordinal (`"Fri (12th)"`); falls back to the raw daystamp on a parse error.
- **`ordinalSuffix`** — English ordinals with the 11–13 exceptions.
- **Tests** — sorting/ordering, truncate-to-7, empty, day labels (incl. parse fallback), ordinals, column alignment with time values, and integration (forecast appears before datapoints).

## Notes

- Read-only feature; all tests use in-memory `Goal`/`DuebyEntry` structs — no live account.
- Pre-push review-loop (6 agents × 2 cycles) ran clean; cycle 1 added the alignment/time-value/integration tests, cycle 2 converged with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 7-day forecast to goal details (shown after fine-print, before recent datapoints). Displays upcoming due amounts chronologically, omits past days, limits to 7 days, uses “Today/Tomorrow” and weekday+ordinal labels, and keeps Due/Total columns aligned.

* **Tests**
  * Added comprehensive tests for label/ordinal formatting, ordering, truncation, empty-state handling, column alignment, and forecast placement relative to recent datapoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->