### PR TITLE
ci: pin GitHub Actions to commit SHAs repo-wide

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to commit SHAs fresh. Workflow actions are
+  # pinned to full commit SHAs (with a version comment) for supply-chain
+  # hardening; Dependabot bumps the SHA + comment when a new release lands.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
 
       - name: Checkout code (fork)
         if: github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -34,7 +34,7 @@ jobs:
       
       - name: Auto-commit formatting changes
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           commit_message: 'chore: run go fmt'
           commit_user_name: 'github-actions[bot]'
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Post or update building comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const repo = context.repo;
@@ -111,7 +111,7 @@ jobs:
             }
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -120,7 +120,7 @@ jobs:
         run: ./scripts/build.sh
 
       - name: Delete existing pre-release if it exists
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const tagName = `pr-${{ github.event.pull_request.number }}-latest`;
@@ -161,7 +161,7 @@ jobs:
             }
 
       - name: Create or update pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: pr-${{ github.event.pull_request.number }}-latest
           name: "PR #${{ github.event.pull_request.number }} - Latest Build"
@@ -187,7 +187,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post or update ready comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const repo = context.repo;
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # This job builds and runs PR code; don't leave the token in
           # .git/config where a build step could read it. The publish steps use
@@ -282,7 +282,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -316,7 +316,7 @@ jobs:
         run: ./scripts/demo/record.sh
 
       - name: Upload demo GIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: demo-gif
           path: scripts/demo/demo.gif
@@ -328,7 +328,7 @@ jobs:
         run: gh release upload "pr-${PR_NUMBER}-latest" scripts/demo/demo.gif --clobber
 
       - name: Post or update demo comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const repo = context.repo;

--- a/.github/workflows/cleanup-pr-releases.yml
+++ b/.github/workflows/cleanup-pr-releases.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Delete pre-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const repo = context.repo;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
       - name: Calculate semantic version
         id: semver
         if: github.event_name == 'push' || github.event.inputs.version == ''
-        uses: ietf-tools/semver-action@v1
+        uses: ietf-tools/semver-action@c90370b2958652d71c06a3484129a4d423a6d8a8 # v1.9.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set up Go
         if: steps.version.outputs.skip == 'false'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create Release
         if: steps.version.outputs.skip == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}
@@ -123,14 +123,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Persisted credentials are intentional here: git-auto-commit-action
           # uses them to push the refreshed demo GIF back to main.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -164,7 +164,7 @@ jobs:
         run: ./scripts/demo/record.sh
 
       - name: Commit refreshed demo GIF
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           commit_message: 'chore(demo): refresh demo gif'
           commit_user_name: 'github-actions[bot]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Calculate semantic version
         id: semver
         if: github.event_name == 'push' || github.event.inputs.version == ''
-        uses: ietf-tools/semver-action@c90370b2958652d71c06a3484129a4d423a6d8a8 # v1.9.0
+        uses: ietf-tools/semver-action@c90370b2958652d71c06a3484129a4d423a6d8a8 # v1.11.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: main


### PR DESCRIPTION
## What

Pins every GitHub Action in `.github/workflows/*` to a full commit SHA (with a `# vX.Y.Z` comment) instead of a moving version tag, and adds a Dependabot config to keep those pins current.

Closes #302.

## Why

CodeRabbit pointed out on #301 that actions on moving tags (`actions/checkout@v4` and friends) are a supply-chain risk: if a tag gets force-moved or the action's repo is compromised, CI silently runs different code. Every workflow in the repo did this, so I fixed them all at once rather than one tag at a time.

## Changes

SHA-pinned all actions across `ci.yml`, `release.yml`, and `cleanup-pr-releases.yml`:

| Action | Pinned version |
| --- | --- |
| `actions/checkout` | v4.3.1 |
| `actions/setup-go` | v6.4.0 |
| `actions/github-script` | v7.1.0 |
| `actions/upload-artifact` | v4.6.2 |
| `softprops/action-gh-release` | v2.6.2 |
| `stefanzweifel/git-auto-commit-action` | v5.2.0 |
| `ietf-tools/semver-action` | v1.11.0 |

One thing worth calling out: `softprops/action-gh-release` in `release.yml` was on `@v1`, which actually resolves to v0.1.15. I bumped it to v2.6.2 to match the PR-build job in `ci.yml`. The inputs that step uses (`tag_name`, `name`, `draft`, `prerelease`, `generate_release_notes`, `files`) all still exist in v2.

Dependabot only covers `github-actions` here. I left `gomod` out to keep this PR focused on the issue; it can go in its own PR.

## Verification

I re-resolved each SHA against the GitHub tags API to confirm it matches its version comment, and checked that all the workflow YAML and the Dependabot file parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)