### PR TITLE
fix(chart): honor tmin and chart the goal's full history by default

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -29,8 +29,9 @@ type Goal struct {
 	Yaw         int                   `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
 	Dir         int                   `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
 	Kyoom       bool                  `json:"kyoom"`      // Whether the goal is cumulative (datapoints auto-sum into a running total)
-	Tmin        string                `json:"tmin"`       // Earliest date shown on the goal's graph (YYYY-MM-DD)
-	Tmax        string                `json:"tmax"`       // Latest date shown on the goal's graph (YYYY-MM-DD)
+	Tmin        string                `json:"tmin"`       // User-set earliest date shown on the goal's graph (YYYY-MM-DD); null/"" unless explicitly set
+	Tmax        string                `json:"tmax"`       // User-set latest date shown on the goal's graph (YYYY-MM-DD); null/"" unless set and still in the future (Beeminder nulls it once past)
+	Initday     int64                 `json:"initday"`    // Goal start: Unix timestamp (seconds) of the date the bright red line begins. Used as the default chart start so the whole goal is shown.
 	Curval      *float64              `json:"curval"`     // Most recent datapoint value
 	Goalval     *float64              `json:"goalval"`    // End value of the goal (may be null if computed from goaldate+rate)
 	Mathishard  []*float64            `json:"mathishard"` // [goaldate, goalval, rate] all filled in (may be null in error states)

--- a/chart.go
+++ b/chart.go
@@ -104,28 +104,86 @@ func renderGoalChart(goal Goal, width int) string {
 }
 
 // chartTimeframe resolves the [start, end] window to chart from the goal's
-// tmin/tmax (parsed in the user's local zone), falling back to the last 30
-// days when those are missing or unparseable. tmax is a calendar day, not an
-// instant, so it is extended to the end of that day — otherwise a datapoint
-// logged late on the tmax day (in local time) would fall outside the window.
+// tmin/tmax (the graph axis limits the user set, parsed in the user's local
+// zone), each falling back to defaultTimeframe independently when absent or
+// unparseable.
+//
+// tmin and tmax are resolved separately rather than all-or-nothing because
+// Beeminder force-nulls tmax once it falls into the past (gen_graph/writer.rb
+// drops it; the goal model nils it on save), so tmax is null for virtually
+// every goal — while tmin is commonly set. Gating on both would mean a user's
+// explicit tmin was ignored on every goal, collapsing every chart onto the
+// default window.
 func chartTimeframe(goal Goal, now time.Time) (start, end time.Time) {
-	if goal.Tmin == "" || goal.Tmax == "" {
-		return now.AddDate(0, 0, -30), now
+	defStart, defEnd := defaultTimeframe(goal, now)
+
+	start = defStart
+	if t, err := time.ParseInLocation("2006-01-02", goal.Tmin, time.Local); err == nil {
+		start = t
 	}
 
-	start, err := time.ParseInLocation("2006-01-02", goal.Tmin, time.Local)
-	if err != nil {
-		start = now.AddDate(0, 0, -30)
+	end = defEnd
+	if t, err := time.ParseInLocation("2006-01-02", goal.Tmax, time.Local); err == nil {
+		// Extend to the last second of the Tmax calendar day. Build it as the
+		// start of the next day minus one second (not +24h) so DST transitions —
+		// where a local day is 23h or 25h — don't spill into the next day or clip
+		// late ones.
+		end = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, t.Location()).Add(-time.Second)
 	}
-	end, err = time.ParseInLocation("2006-01-02", goal.Tmax, time.Local)
-	if err != nil {
-		return start, now
-	}
-	// Extend to the last second of the Tmax calendar day. Build it as the start
-	// of the next day minus one second (not +24h) so DST transitions — where a
-	// local day is 23h or 25h — don't spill into the next day or clip late ones.
-	end = time.Date(end.Year(), end.Month(), end.Day()+1, 0, 0, 0, 0, end.Location()).Add(-time.Second)
 	return start, end
+}
+
+// defaultTimeframe is the window charted when the goal carries no usable
+// tmin/tmax. Beeminder leaves both null unless the user has set custom graph
+// axis limits, so in practice this is the window almost every goal uses.
+//
+// The default start is the goal's own start (initday) — the date the bright red
+// line begins — so the whole goal is charted, matching Beeminder's own default
+// of showing all of a goal's data. The default end is now.
+//
+// When initday is unavailable, it falls back to the last 30 days, widened back
+// to the most recent datapoint if that predates the window — otherwise a goal
+// not updated within 30 days would have every datapoint fall outside the window
+// and render no chart at all (graphs would appear only for recently-touched
+// goals, seemingly at random).
+func defaultTimeframe(goal Goal, now time.Time) (start, end time.Time) {
+	end = now
+
+	if goal.Initday > 0 {
+		// initday marks a calendar day, so floor it to the start of that local
+		// day. Using the raw instant (which Beeminder aligns to the goal's
+		// deadline, often midday) would exclude a same-day datapoint logged
+		// earlier in the day — e.g. a brand-new goal's only point.
+		d := time.Unix(goal.Initday, 0).In(time.Local)
+		start = time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.Local)
+	} else {
+		start = now.AddDate(0, 0, -30)
+		if last, ok := lastDatapointTime(goal); ok && last.Before(start) {
+			start = last
+		}
+	}
+
+	// A future-dated most-recent datapoint would otherwise sit past the window;
+	// widen the end so it still shows.
+	if last, ok := lastDatapointTime(goal); ok && last.After(end) {
+		end = last
+	}
+	return start, end
+}
+
+// lastDatapointTime returns the timestamp of the goal's most recent datapoint.
+// ok is false when the goal has no datapoints.
+func lastDatapointTime(goal Goal) (t time.Time, ok bool) {
+	if len(goal.Datapoints) == 0 {
+		return time.Time{}, false
+	}
+	latest := goal.Datapoints[0].Timestamp
+	for _, dp := range goal.Datapoints[1:] {
+		if dp.Timestamp > latest {
+			latest = dp.Timestamp
+		}
+	}
+	return time.Unix(latest, 0), true
 }
 
 // timedValue is a datapoint reduced to the two things the chart cares about:

--- a/chart.go
+++ b/chart.go
@@ -184,7 +184,11 @@ func lastDatapointTime(goal Goal) (t time.Time, ok bool) {
 			latest = dp.Timestamp
 		}
 	}
-	return time.Unix(latest, 0), true
+	// Return in the local zone: chartTimeframe resolves every other bound in
+	// local time, and when this value becomes the window start/end it drives the
+	// timeframe header and x-axis labels — a UTC instant could render the wrong
+	// calendar day near midnight.
+	return time.Unix(latest, 0).In(time.Local), true
 }
 
 // timedValue is a datapoint reduced to the two things the chart cares about:

--- a/chart.go
+++ b/chart.go
@@ -23,11 +23,12 @@ const (
 	maxChartWidth = 80
 )
 
-// renderGoalChart renders an ASCII chart of a goal's recent progress: the
-// goal's datapoints (blue) against its bright red line (red), over the graph
-// window the Beeminder API reports (tmin..tmax), falling back to the last 30
-// days. It returns "" when there is nothing chartable (no datapoints, or none
-// inside the window).
+// renderGoalChart renders an ASCII chart of a goal's progress: the goal's
+// datapoints (blue) against its bright red line (red), over the goal's graph
+// window — the user-set tmin/tmax axis limits where present, otherwise the
+// goal's full history (initday..now). See chartTimeframe and defaultTimeframe
+// for the exact window resolution. It returns "" when there is nothing
+// chartable (no datapoints, or none inside the window).
 func renderGoalChart(goal Goal, width int) string {
 	if len(goal.Datapoints) == 0 {
 		return ""

--- a/chart_test.go
+++ b/chart_test.go
@@ -452,17 +452,89 @@ func TestRenderGoalChartStaleGoalStillCharts(t *testing.T) {
 func TestChartTimeframeDefaultsStartToInitday(t *testing.T) {
 	// With no user-set tmin/tmax, the window defaults to the goal's start
 	// (initday) through now, charting the whole goal — matching Beeminder's
-	// default of showing all data.
-	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.Local)
-	initday := time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local)
+	// default of showing all data. initday carries a midday (deadline-aligned)
+	// instant, which must be floored to the start of its local day.
+	now := time.Date(2026, 6, 10, 23, 0, 0, 0, time.Local)
+	initday := time.Date(2024, 1, 15, 16, 30, 0, 0, time.Local)
 	goal := Goal{Slug: "wholehistory", Initday: initday.Unix()}
 
 	start, end := chartTimeframe(goal, now)
-	if !start.Equal(initday) {
-		t.Errorf("start = %s, want goal start (initday) %s", start, initday)
+	wantStart := time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local) // floored to local midnight
+	if !start.Equal(wantStart) {
+		t.Errorf("start = %s, want goal-start day floored to local midnight %s", start, wantStart)
 	}
 	if !end.Equal(now) {
 		t.Errorf("end = %s, want now %s", end, now)
+	}
+}
+
+func TestRenderGoalChartIncludesSameDayDatapointBeforeInitdayInstant(t *testing.T) {
+	// A brand-new goal whose initday instant is midday and whose only datapoint
+	// was logged earlier the same day: flooring initday to the start of the day
+	// must keep that datapoint inside the window so the goal still charts.
+	day := time.Date(2026, 6, 10, 0, 0, 0, 0, time.Local)
+	initday := day.Add(16 * time.Hour) // midday-ish initday instant
+	dp := day.Add(6 * time.Hour)       // logged earlier the same day
+	now := day.Add(20 * time.Hour)
+	goal := Goal{
+		Slug:       "newgoal",
+		Yaw:        1,
+		Kyoom:      true,
+		Initday:    initday.Unix(),
+		Datapoints: []Datapoint{{Timestamp: dp.Unix(), Value: 1.0}},
+	}
+
+	start, _ := chartTimeframe(goal, now)
+	if dp.Before(start) {
+		t.Fatalf("datapoint %s fell before window start %s", dp, start)
+	}
+	if chart := renderGoalChart(goal, 100); chart == "" {
+		t.Error("expected a chart for a same-day datapoint logged before the initday instant")
+	}
+}
+
+func TestChartTimeframeWidensEndForFutureDatapoint(t *testing.T) {
+	// A datapoint timestamped after now (e.g. a scheduled/future-dated point)
+	// would otherwise sit past the default end (now); the end widens to include
+	// it.
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.Local)
+	future := now.AddDate(0, 0, 3)
+	goal := Goal{
+		Slug:       "future",
+		Initday:    now.AddDate(0, 0, -10).Unix(),
+		Datapoints: []Datapoint{{Timestamp: future.Unix(), Value: 1.0}},
+	}
+
+	_, end := chartTimeframe(goal, now)
+	if end.Before(future) {
+		t.Errorf("end = %s, want >= future datapoint %s", end, future)
+	}
+}
+
+func TestLastDatapointTime(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Empty: ok is false.
+	if _, ok := lastDatapointTime(Goal{}); ok {
+		t.Error("expected ok=false for a goal with no datapoints")
+	}
+
+	// Single datapoint.
+	if got, ok := lastDatapointTime(Goal{Datapoints: []Datapoint{
+		{Timestamp: base.Unix(), Value: 1},
+	}}); !ok || !got.Equal(base) {
+		t.Errorf("single: got %s ok=%v, want %s true", got, ok, base)
+	}
+
+	// Unsorted: must return the maximum timestamp, not the last element.
+	want := base.AddDate(0, 0, 100)
+	got, ok := lastDatapointTime(Goal{Datapoints: []Datapoint{
+		{Timestamp: want.Unix(), Value: 1},
+		{Timestamp: base.Unix(), Value: 2},
+		{Timestamp: base.AddDate(0, 0, 50).Unix(), Value: 3},
+	}})
+	if !ok || !got.Equal(want) {
+		t.Errorf("unsorted: got %s ok=%v, want %s true", got, ok, want)
 	}
 }
 

--- a/chart_test.go
+++ b/chart_test.go
@@ -427,23 +427,102 @@ func TestChartTimeframeTmaxAcrossDSTFallBack(t *testing.T) {
 	}
 }
 
-func TestRenderGoalChartCumulativeAllBeforeWindow(t *testing.T) {
-	// Cumulative goal whose only datapoints predate the 30-day window. There
-	// are no in-window datapoints, so no chart should render even though the
-	// running total is non-zero (a lone carry-over anchor must not draw a line).
-	old := time.Now().AddDate(0, 0, -60).Unix()
+func TestRenderGoalChartStaleGoalStillCharts(t *testing.T) {
+	// A goal not updated within the last 30 days (and with no tmin/tmax) used to
+	// render no chart at all: the fallback window was anchored at now, so every
+	// datapoint fell before it. The default window now shifts back to the most
+	// recent datapoint, so the goal still charts. This is the fix for graphs
+	// appearing only on recently-touched goals and seeming random.
+	old := time.Now().AddDate(0, 0, -60)
 	goal := Goal{
 		Slug:  "stale",
 		Yaw:   1,
 		Kyoom: true,
 		Datapoints: []Datapoint{
-			{Timestamp: old, Value: 5.0},
-			{Timestamp: old + 3600, Value: 7.0},
+			{Timestamp: old.Unix(), Value: 5.0},
+			{Timestamp: old.AddDate(0, 0, 1).Unix(), Value: 7.0},
 		},
-		// No Tmin/Tmax → 30-day fallback window, which excludes both points.
+		// No Tmin/Tmax → data-aware default window, which now reaches the points.
 	}
-	if chart := renderGoalChart(goal, 100); chart != "" {
-		t.Errorf("expected empty chart when no datapoints fall in the window, got:\n%s", chart)
+	if chart := renderGoalChart(goal, 100); chart == "" {
+		t.Error("expected a chart for a stale goal whose datapoints predate 30 days")
+	}
+}
+
+func TestChartTimeframeDefaultsStartToInitday(t *testing.T) {
+	// With no user-set tmin/tmax, the window defaults to the goal's start
+	// (initday) through now, charting the whole goal — matching Beeminder's
+	// default of showing all data.
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.Local)
+	initday := time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local)
+	goal := Goal{Slug: "wholehistory", Initday: initday.Unix()}
+
+	start, end := chartTimeframe(goal, now)
+	if !start.Equal(initday) {
+		t.Errorf("start = %s, want goal start (initday) %s", start, initday)
+	}
+	if !end.Equal(now) {
+		t.Errorf("end = %s, want now %s", end, now)
+	}
+}
+
+func TestChartTimeframeHonorsTminWithoutTmax(t *testing.T) {
+	// Beeminder force-nulls tmax once it's in the past, so tmax is null on
+	// virtually every goal while tmin is commonly set. The window must still
+	// honor an explicit tmin rather than collapsing onto the default window.
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.Local)
+	goal := Goal{
+		Slug: "has-tmin",
+		Tmin: "2024-08-02",
+		// Tmax empty (null from the API).
+	}
+	start, end := chartTimeframe(goal, now)
+
+	wantStart := time.Date(2024, 8, 2, 0, 0, 0, 0, time.Local)
+	if !start.Equal(wantStart) {
+		t.Errorf("start = %s, want explicit tmin %s", start, wantStart)
+	}
+	// With no tmax and no datapoints, the end falls back to now.
+	if !end.Equal(now) {
+		t.Errorf("end = %s, want fallback to now %s", end, now)
+	}
+}
+
+func TestRenderGoalChartHonorsTminForStaleGoal(t *testing.T) {
+	// Regression for the real-world "fam" goal: tmin set far in the past, tmax
+	// null, last datapoint older than 30 days. Honoring tmin (and ending at the
+	// stale last datapoint) means the goal charts instead of going blank.
+	last := time.Now().AddDate(0, 0, -40)
+	goal := Goal{
+		Slug:  "fam",
+		Yaw:   1,
+		Kyoom: true,
+		Tmin:  last.AddDate(0, 0, -300).Format("2006-01-02"),
+		Datapoints: []Datapoint{
+			{Timestamp: last.AddDate(0, 0, -5).Unix(), Value: 2.0},
+			{Timestamp: last.Unix(), Value: 3.0},
+		},
+	}
+	if chart := renderGoalChart(goal, 100); chart == "" {
+		t.Error("expected a chart for a goal with an explicit tmin and stale data")
+	}
+}
+
+func TestProcessCumulativeNoInWindowDatapointsReturnsNil(t *testing.T) {
+	// Invariant: when no datapoints fall inside the window, processCumulative
+	// returns nil even though earlier datapoints push the running total above
+	// zero — a lone carry-over anchor must never draw a dataless flat line.
+	start := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 30)
+	goal := Goal{
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: start.AddDate(0, 0, -10).Unix(), Value: 5.0},
+			{Timestamp: start.AddDate(0, 0, -5).Unix(), Value: 7.0},
+		},
+	}
+	if got := processCumulative(goal, start, end); got != nil {
+		t.Errorf("expected nil when no datapoints fall in the window, got %v", got)
 	}
 }
 

--- a/chart_test.go
+++ b/chart_test.go
@@ -562,8 +562,8 @@ func TestChartTimeframeHonorsTminWithoutTmax(t *testing.T) {
 
 func TestRenderGoalChartHonorsTminForStaleGoal(t *testing.T) {
 	// Regression for the real-world "fam" goal: tmin set far in the past, tmax
-	// null, last datapoint older than 30 days. Honoring tmin (and ending at the
-	// stale last datapoint) means the goal charts instead of going blank.
+	// null, last datapoint older than 30 days. Honoring tmin as the window start
+	// (the end defaults to now) means the goal charts instead of going blank.
 	last := time.Now().AddDate(0, 0, -40)
 	goal := Goal{
 		Slug:  "fam",

--- a/client.go
+++ b/client.go
@@ -488,6 +488,7 @@ func (c *HTTPClient) FetchGoalsWithDatapoints(ctx context.Context) ([]Goal, erro
 				goals[i].Roadall = goalWithDatapoints.Roadall
 				goals[i].Tmin = goalWithDatapoints.Tmin
 				goals[i].Tmax = goalWithDatapoints.Tmax
+				goals[i].Initday = goalWithDatapoints.Initday
 				goals[i].Kyoom = goalWithDatapoints.Kyoom
 				goals[i].Yaw = goalWithDatapoints.Yaw
 			}

--- a/review.go
+++ b/review.go
@@ -226,6 +226,7 @@ func (m reviewModel) View() string {
 		goal.Roadall = d.Roadall
 		goal.Tmin = d.Tmin
 		goal.Tmax = d.Tmax
+		goal.Initday = d.Initday
 		goal.Kyoom = d.Kyoom
 		goal.Yaw = d.Yaw
 	}


### PR DESCRIPTION
## Problem

When browsing goals in `buzz review`, graphs appeared for some goals and not others, seemingly at random.

## Root cause

Two issues in the chart window resolution (`chartTimeframe` in `chart.go`):

1. **`tmin` was ignored on every goal.** The code only honored `tmin`/`tmax` when *both* were set, otherwise falling back to a 30-day window. But Beeminder force-nulls `tmax` once it's in the past (`gen_graph/writer.rb` drops it; the goal model nils it on save), so `tmax` is null for virtually every goal — meaning a user's explicitly-set `tmin` was always discarded. Confirmed against the live account: ~20 goals carry a real `tmin`, none carry a `tmax`.

2. **The fallback window excluded stale goals entirely.** The fallback was "last 30 days ending at now", so any goal not updated within 30 days had *every* datapoint fall outside the window and rendered no chart.

## Fix

- Resolve `tmin` and `tmax` **independently**, each falling back on its own.
- Default the window start to the goal's start (`initday`) so the **whole goal is charted**, matching Beeminder's own default of showing all data. `initday` is floored to the start of its local day so a brand-new goal's same-day datapoint (logged before `initday`'s midday instant) isn't excluded.
- New `Initday` field on `Goal`, merged in wherever the per-goal chart fields are merged.

## Verification

Read-only against the live account (no mutations): **63/63 goals with datapoints now render a chart.** Previously 5 stale goals were blank; a naive `initday` default also blanked 2 brand-new goals (fixed by the day-floor).

## Tests

Added coverage for: independent `tmin`-without-`tmax` resolution, the `initday` default + day-floor (incl. a same-day-before-`initday` datapoint), the future-dated-datapoint end-widening branch, `lastDatapointTime` (empty/single/unsorted), and the preserved `processCumulative` "no lone carry-over line" invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)