### PR TITLE
feat(chart): aggregate datapoints per day honoring the goal's aggday

### DIFF
--- a/aggday.go
+++ b/aggday.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"math"
+	"sort"
+)
+
+// aggday (aggregation method) decides how multiple datapoints landing on the
+// same day combine into the single value plotted for that day. This mirrors
+// Beeminder: each day's datapoints are reduced to one value via the goal's
+// aggday, and then — for cumulative (kyoom) goals — those daily values are
+// summed into a running total (see processDatapoints).
+//
+// The reducers below are ported from beebrain's broad.js AGGR map; the names
+// (including Beeminder's legacy aliases) are matched exactly so any goal renders
+// the same way buzz's chart does as on beeminder.com.
+
+// resolveAggday returns the goal's aggday method, falling back to Beeminder's
+// per-kyoom default when the goal carries none: "sum" for cumulative goals,
+// "last" otherwise (beebrain.js: `p.aggday = gol.kyoom ? "sum" : "last"`).
+func resolveAggday(goal Goal) string {
+	if goal.Aggday != "" {
+		return goal.Aggday
+	}
+	return defaultAggday(goal)
+}
+
+func defaultAggday(goal Goal) string {
+	if goal.Kyoom {
+		return "sum"
+	}
+	return "last"
+}
+
+// aggregateDay reduces one day's datapoint values to a single value using the
+// named aggday method. vals must be in datapoint order (ascending timestamp) so
+// "first"/"last" pick the correct ends, and is always non-empty (a day exists
+// only because it has at least one datapoint). An unrecognised method falls back
+// to the goal's default.
+func aggregateDay(goal Goal, name string, vals []float64) float64 {
+	switch name {
+	case "sum":
+		return aggSum(vals)
+	case "last":
+		return vals[len(vals)-1]
+	case "first":
+		return vals[0]
+	case "min":
+		return aggMin(vals)
+	case "max":
+		return aggMax(vals)
+	case "count":
+		return float64(len(vals))
+	case "mu", "truemean", "average":
+		return aggMean(vals)
+	case "mean", "munique", "uniqmean":
+		return aggMean(aggDedup(vals))
+	case "mutrim", "trimmean":
+		return aggTrimMean(vals, 0.1)
+	case "median":
+		return aggMedian(vals)
+	case "mode":
+		return aggMode(vals)
+	case "unary", "binary", "jolly":
+		// 1 if any datapoint exists, else 0. vals is non-empty here, so it's 1;
+		// the 0 is kept for clarity/parity with beebrain.
+		if len(vals) > 0 {
+			return 1
+		}
+		return 0
+	case "unaryflat", "nonzero":
+		for _, v := range vals {
+			if v != 0 {
+				return 1
+			}
+		}
+		return 0
+	case "triangle":
+		s := aggSum(vals)
+		return s * (s + 1) / 2
+	case "square":
+		s := aggSum(vals)
+		return s * s
+	case "clocky":
+		return aggClocky(vals)
+	case "skatesum":
+		// Sum, capped at the goal's daily rate. When the rate isn't usable
+		// (missing, or runits we can't convert), fall back to a plain sum rather
+		// than cap at a dimensionally-wrong value.
+		if r, ok := goalDailyRate(goal); ok {
+			return math.Min(r, aggSum(vals))
+		}
+		return aggSum(vals)
+	case "satsum", "cap1":
+		return math.Min(1, aggSum(vals))
+	case "sqrt":
+		return math.Sqrt(aggSum(vals))
+	case "countflat":
+		return float64(countNonzero(vals))
+	case "muflat":
+		return aggMean(nonzero(vals))
+	default:
+		// Unknown method: render with the goal's default rather than nothing.
+		def := defaultAggday(goal)
+		if name == def {
+			return aggSum(vals) // guard against recursion if a default is ever unknown
+		}
+		return aggregateDay(goal, def, vals)
+	}
+}
+
+// goalDailyRate converts the goal's bright-line rate into gunits/day for the
+// skatesum cap. ok is false when the rate is absent or expressed in runits we
+// can't translate.
+func goalDailyRate(g Goal) (float64, bool) {
+	if g.Rate == nil || !isKnownRunits(g.Runits) {
+		return 0, false
+	}
+	return ratePerDay(*g.Rate, g.Runits), true
+}
+
+func aggSum(a []float64) float64 {
+	s := 0.0
+	for _, v := range a {
+		s += v
+	}
+	return s
+}
+
+func aggMean(a []float64) float64 {
+	if len(a) == 0 {
+		return 0
+	}
+	return aggSum(a) / float64(len(a))
+}
+
+func aggMin(a []float64) float64 {
+	m := a[0]
+	for _, v := range a[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+func aggMax(a []float64) float64 {
+	m := a[0]
+	for _, v := range a[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// aggDedup drops duplicate values, preserving first-seen order (for uniqmean).
+func aggDedup(a []float64) []float64 {
+	seen := make(map[float64]bool, len(a))
+	out := make([]float64, 0, len(a))
+	for _, v := range a {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// aggMedian is the middle value of the sorted list, or the mean of the two
+// middle values when the count is even.
+func aggMedian(a []float64) float64 {
+	if len(a) == 0 {
+		return 0
+	}
+	b := append([]float64(nil), a...)
+	sort.Float64s(b)
+	l := len(b)
+	if l%2 == 0 {
+		return (b[l/2-1] + b[l/2]) / 2
+	}
+	return b[(l-1)/2]
+}
+
+// aggMode returns the most common value, breaking ties toward the value that
+// first reaches the highest tally (matching beebrain's tie-break closely enough
+// — aggday=mode is vanishingly rare).
+func aggMode(a []float64) float64 {
+	if len(a) == 0 {
+		return 0
+	}
+	tally := make(map[float64]int, len(a))
+	maxTally := 1
+	item := a[0]
+	for _, v := range a {
+		tally[v]++
+		if tally[v] > maxTally {
+			maxTally = tally[v]
+			item = v
+		}
+	}
+	return item
+}
+
+// aggTrimMean is the mean after dropping the lowest and highest trim-fraction of
+// the sorted values.
+func aggTrimMean(a []float64, trim float64) float64 {
+	b := append([]float64(nil), a...)
+	sort.Float64s(b)
+	n := int(math.Floor(float64(len(b)) * trim))
+	t := b[n : len(b)-n]
+	if len(t) == 0 {
+		return 0
+	}
+	return aggSum(t) / float64(len(t))
+}
+
+// aggClocky sums the differences of consecutive pairs, e.g. [1,2,6,9] →
+// (2-1)+(9-6) = 4. A trailing unpaired value is ignored. Used for timer-style
+// goals that log start/stop timestamps.
+func aggClocky(a []float64) float64 {
+	s := 0.0
+	for i := 1; i < len(a); i += 2 {
+		s += a[i] - a[i-1]
+	}
+	return s
+}
+
+func countNonzero(a []float64) int {
+	n := 0
+	for _, v := range a {
+		if v != 0 {
+			n++
+		}
+	}
+	return n
+}
+
+func nonzero(a []float64) []float64 {
+	out := make([]float64, 0, len(a))
+	for _, v := range a {
+		if v != 0 {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/aggday_test.go
+++ b/aggday_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestResolveAggdayDefaults(t *testing.T) {
+	if got := resolveAggday(Goal{Kyoom: true}); got != "sum" {
+		t.Errorf("kyoom default: got %q, want \"sum\"", got)
+	}
+	if got := resolveAggday(Goal{Kyoom: false}); got != "last" {
+		t.Errorf("non-kyoom default: got %q, want \"last\"", got)
+	}
+	if got := resolveAggday(Goal{Kyoom: true, Aggday: "max"}); got != "max" {
+		t.Errorf("explicit aggday: got %q, want \"max\"", got)
+	}
+}
+
+func TestAggregateDayMethods(t *testing.T) {
+	vals := []float64{1, 2, 2, 5} // ascending-timestamp order
+
+	cases := map[string]float64{
+		"sum":       10,
+		"last":      5,
+		"first":     1,
+		"min":       1,
+		"max":       5,
+		"count":     4,
+		"truemean":  2.5,                  // mean of all
+		"uniqmean":  float64(1+2+5) / 3.0, // mean of unique {1,2,5}
+		"median":    2,                    // sorted {1,2,2,5} → (2+2)/2
+		"mode":      2,
+		"binary":    1,
+		"nonzero":   1,
+		"triangle":  55, // 10*11/2
+		"square":    100,
+		"cap1":      1,
+		"sqrt":      math.Sqrt(10),
+		"countflat": 4, // all nonzero
+		"muflat":    2.5,
+	}
+	for name, want := range cases {
+		if got := aggregateDay(Goal{}, name, vals); math.Abs(got-want) > 1e-9 {
+			t.Errorf("aggday=%s: got %v, want %v", name, got, want)
+		}
+	}
+
+	// nonzero / countflat / muflat ignore zeros.
+	withZeros := []float64{0, 0, 4}
+	if got := aggregateDay(Goal{}, "nonzero", withZeros); got != 1 {
+		t.Errorf("nonzero with a nonzero present: got %v, want 1", got)
+	}
+	if got := aggregateDay(Goal{}, "nonzero", []float64{0, 0}); got != 0 {
+		t.Errorf("nonzero all-zero: got %v, want 0", got)
+	}
+	if got := aggregateDay(Goal{}, "countflat", withZeros); got != 1 {
+		t.Errorf("countflat: got %v, want 1", got)
+	}
+	if got := aggregateDay(Goal{}, "muflat", withZeros); got != 4 {
+		t.Errorf("muflat: got %v, want 4 (mean of nonzero)", got)
+	}
+}
+
+func TestAggregateDayClocky(t *testing.T) {
+	// Sum of differences of consecutive pairs; trailing unpaired value ignored.
+	if got := aggClocky([]float64{1, 2, 6, 9}); got != 4 {
+		t.Errorf("clocky [1,2,6,9]: got %v, want 4", got)
+	}
+	if got := aggClocky([]float64{1, 2, 6}); got != 1 {
+		t.Errorf("clocky [1,2,6] (odd): got %v, want 1", got)
+	}
+}
+
+func TestAggregateDaySkatesum(t *testing.T) {
+	rate := 5.0
+	g := Goal{Rate: &rate, Runits: "d"} // 5/day
+
+	// Sum (1+2+3=6) capped at the daily rate (5).
+	if got := aggregateDay(g, "skatesum", []float64{1, 2, 3}); got != 5 {
+		t.Errorf("skatesum capped: got %v, want 5", got)
+	}
+	// Under the cap, the sum passes through.
+	if got := aggregateDay(g, "skatesum", []float64{1, 2}); got != 3 {
+		t.Errorf("skatesum under cap: got %v, want 3", got)
+	}
+	// Unusable rate → fall back to a plain sum rather than a wrong cap.
+	if got := aggregateDay(Goal{}, "skatesum", []float64{1, 2, 3}); got != 6 {
+		t.Errorf("skatesum no rate: got %v, want 6 (plain sum)", got)
+	}
+}
+
+func TestAggregateDayUnknownFallsBackToDefault(t *testing.T) {
+	// Unknown method renders with the goal's default (sum for kyoom, last else).
+	if got := aggregateDay(Goal{Kyoom: true}, "bogus", []float64{1, 2, 3}); got != 6 {
+		t.Errorf("unknown on kyoom: got %v, want 6 (sum)", got)
+	}
+	if got := aggregateDay(Goal{Kyoom: false}, "bogus", []float64{1, 2, 3}); got != 3 {
+		t.Errorf("unknown on non-kyoom: got %v, want 3 (last)", got)
+	}
+}

--- a/aggday_test.go
+++ b/aggday_test.go
@@ -46,6 +46,24 @@ func TestAggregateDayMethods(t *testing.T) {
 		}
 	}
 
+	// median with an odd count returns the true middle of the sorted input
+	// (inputs need not be pre-sorted).
+	if got := aggregateDay(Goal{}, "median", []float64{5, 1, 3}); got != 3 {
+		t.Errorf("median odd-count: got %v, want 3", got)
+	}
+
+	// trimmean drops the lowest/highest trim-fraction before averaging. With <10
+	// values floor(0.1*n)=0, so it degenerates to the plain mean...
+	if got := aggregateDay(Goal{}, "trimmean", vals); math.Abs(got-2.5) > 1e-9 {
+		t.Errorf("trimmean small list (no trim): got %v, want 2.5", got)
+	}
+	// ...and with >=10 values the single lowest and highest are dropped: trimming
+	// 1 and 100 from {1,2,3,4,5,6,7,8,9,100} leaves {2..9}, mean 5.5.
+	big := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 100}
+	if got := aggregateDay(Goal{}, "trimmean", big); math.Abs(got-5.5) > 1e-9 {
+		t.Errorf("trimmean trimming extremes: got %v, want 5.5", got)
+	}
+
 	// nonzero / countflat / muflat ignore zeros.
 	withZeros := []float64{0, 0, 4}
 	if got := aggregateDay(Goal{}, "nonzero", withZeros); got != 1 {

--- a/beeminder.go
+++ b/beeminder.go
@@ -29,6 +29,7 @@ type Goal struct {
 	Yaw         int                   `json:"yaw"`        // Good side of the bright red line (+1 = above, -1 = below)
 	Dir         int                   `json:"dir"`        // Direction the bright red line is sloping (+1 = up, -1 = down)
 	Kyoom       bool                  `json:"kyoom"`      // Whether the goal is cumulative (datapoints auto-sum into a running total)
+	Aggday      string                `json:"aggday"`     // How same-day datapoints combine into one daily value (sum, last, min, max, …); "" means Beeminder's default (sum for kyoom, last otherwise)
 	Tmin        string                `json:"tmin"`       // User-set earliest date shown on the goal's graph (YYYY-MM-DD); null/"" unless explicitly set
 	Tmax        string                `json:"tmax"`       // User-set latest date shown on the goal's graph (YYYY-MM-DD); null/"" unless set and still in the future (Beeminder nulls it once past)
 	Initday     int64                 `json:"initday"`    // Goal start: Unix timestamp (seconds) of the date the bright red line begins. Used as the default chart start so the whole goal is shown.

--- a/chart.go
+++ b/chart.go
@@ -219,7 +219,20 @@ type timedValue struct {
 // For non-cumulative goals each in-window day's aggregate is plotted directly.
 func processDatapoints(goal Goal, startTime, endTime time.Time) []timedValue {
 	loc := startTime.Location()
-	days := bucketByDay(goal.Datapoints, loc)
+
+	// Drop datapoints after the window end (including future-dated ones) before
+	// bucketing. This matches Beeminder — which filters data to "now" (asof)
+	// before aggregating — and stops a day's aggregate from absorbing same-day
+	// points logged after endTime when the window ends mid-day.
+	endUnix := endTime.Unix()
+	inRange := make([]Datapoint, 0, len(goal.Datapoints))
+	for _, dp := range goal.Datapoints {
+		if dp.Timestamp <= endUnix {
+			inRange = append(inRange, dp)
+		}
+	}
+
+	days := bucketByDay(inRange, loc)
 	if len(days) == 0 {
 		return nil
 	}

--- a/chart.go
+++ b/chart.go
@@ -261,7 +261,11 @@ func processDatapoints(goal Goal, startTime, endTime time.Time) []timedValue {
 		return nil
 	}
 	if goal.Kyoom {
-		processed = append([]timedValue{{timestamp: startTime.Unix(), value: carry}}, processed...)
+		// Anchor at the start of the window's day (not the raw startTime instant),
+		// so it sorts at-or-before every day point — which sit at local midnight.
+		// A mid-day startTime would otherwise place the anchor after the first
+		// day point, breaking datapointSeries' ascending-order assumption.
+		processed = append([]timedValue{{timestamp: startDay.Unix(), value: carry}}, processed...)
 	}
 	return processed
 }

--- a/chart.go
+++ b/chart.go
@@ -202,68 +202,123 @@ type timedValue struct {
 // processDatapoints reduces a goal's datapoints to the series to plot within
 // [startTime, endTime], sorted by time.
 //
-// For cumulative (kyoom) goals the plotted value is the running total, so the
-// sum is accumulated across ALL datapoints (including those before the window)
-// and a synthetic anchor is prepended at startTime carrying the total reached
-// just before the window — otherwise the in-window line would start from zero
-// instead of where the goal actually stood.
+// Datapoints are first aggregated per calendar day using the goal's aggday
+// method (see aggregateDay), producing one value per day positioned at that
+// day's boundary — matching Beeminder, which plots one aggregated point per day
+// rather than one per datapoint. This is why two datapoints on the same day
+// share a column (e.g. a same-day "0 then 1" reads as a single riser at the
+// start of the day, not a within-day ramp).
+//
+// For cumulative (kyoom) goals the plotted value is then the running total of
+// the daily aggregates, accumulated across ALL days (including those before the
+// window); a synthetic anchor is prepended at startTime carrying the total
+// reached just before the window, so the in-window line begins where the goal
+// actually stood rather than at zero. It returns nil when no day falls inside
+// the window (so a pure carry-over never draws a dataless line).
+//
+// For non-cumulative goals each in-window day's aggregate is plotted directly.
 func processDatapoints(goal Goal, startTime, endTime time.Time) []timedValue {
-	if goal.Kyoom {
-		return processCumulative(goal, startTime, endTime)
+	loc := startTime.Location()
+	days := bucketByDay(goal.Datapoints, loc)
+	if len(days) == 0 {
+		return nil
 	}
+	aggday := resolveAggday(goal)
+
+	// Days are compared against the start of startTime's calendar day, not the
+	// startTime instant itself: when the window begins mid-day (e.g. a stale
+	// goal whose window starts at its last datapoint's timestamp), that day's
+	// midnight-anchored aggregate would otherwise fall just before the window
+	// and be dropped.
+	startDay := time.Date(startTime.Year(), startTime.Month(), startTime.Day(), 0, 0, 0, 0, loc)
 
 	var processed []timedValue
-	for _, dp := range goal.Datapoints {
-		dpTime := time.Unix(dp.Timestamp, 0)
-		if !dpTime.Before(startTime) && !dpTime.After(endTime) {
-			processed = append(processed, timedValue{timestamp: dp.Timestamp, value: dp.Value})
+	running := 0.0 // cumulative total of daily aggregates (kyoom only)
+	carry := 0.0   // running total reached just before the window (kyoom only)
+	inWindow := false
+
+	for _, d := range days {
+		if d.day.After(endTime) {
+			continue // future day: not plotted, and doesn't affect the in-window line
+		}
+		ad := aggregateDay(goal, aggday, d.values)
+		switch {
+		case goal.Kyoom:
+			running += ad
+			if d.day.Before(startDay) {
+				carry = running
+			} else {
+				processed = append(processed, timedValue{timestamp: d.day.Unix(), value: running})
+				inWindow = true
+			}
+		case !d.day.Before(startDay):
+			processed = append(processed, timedValue{timestamp: d.day.Unix(), value: ad})
+			inWindow = true
 		}
 	}
-	sort.Slice(processed, func(i, j int) bool {
-		return processed[i].timestamp < processed[j].timestamp
-	})
+
+	if !inWindow {
+		return nil
+	}
+	if goal.Kyoom {
+		processed = append([]timedValue{{timestamp: startTime.Unix(), value: carry}}, processed...)
+	}
 	return processed
 }
 
-// processCumulative builds the in-window plot series for a cumulative (kyoom)
-// goal: it sums every datapoint in chronological order so each in-window point
-// carries the running total, prepends a synthetic anchor at the window start
-// holding the total reached just before it, and returns nil when no datapoints
-// fall inside the window (so a pure carry-over never draws a dataless line).
-func processCumulative(goal Goal, startTime, endTime time.Time) []timedValue {
-	sorted := make([]Datapoint, len(goal.Datapoints))
-	copy(sorted, goal.Datapoints)
-	sort.Slice(sorted, func(i, j int) bool {
+// dayBucket is one calendar day's worth of datapoint values, in ascending
+// timestamp order, tagged with the day's start instant (local midnight).
+type dayBucket struct {
+	day    time.Time
+	values []float64
+}
+
+// bucketByDay groups datapoints into calendar days, ascending. Each day's
+// values stay in datapoint (ascending-timestamp) order so order-sensitive
+// aggdays (first/last) pick the right ends.
+//
+// The day is taken from the datapoint's Beeminder daystamp when present (it
+// already accounts for the goal's deadline), otherwise from the timestamp. Both
+// are resolved in loc — the same zone the chart window uses — so day boundaries
+// line up with the window and x-axis.
+func bucketByDay(datapoints []Datapoint, loc *time.Location) []dayBucket {
+	sorted := append([]Datapoint(nil), datapoints...)
+	sort.SliceStable(sorted, func(i, j int) bool {
 		return sorted[i].Timestamp < sorted[j].Timestamp
 	})
 
-	sum := 0.0
-	startSum := 0.0
-	var processed []timedValue
+	index := make(map[string]int)
+	var buckets []dayBucket
 	for _, dp := range sorted {
-		dpTime := time.Unix(dp.Timestamp, 0)
-		switch {
-		case dpTime.Before(startTime):
-			sum += dp.Value
-			startSum = sum
-		case !dpTime.After(endTime):
-			sum += dp.Value
-			processed = append(processed, timedValue{timestamp: dp.Timestamp, value: sum})
+		day := dayStart(dp, loc)
+		key := day.Format("2006-01-02")
+		if i, ok := index[key]; ok {
+			buckets[i].values = append(buckets[i].values, dp.Value)
+		} else {
+			index[key] = len(buckets)
+			buckets = append(buckets, dayBucket{day: day, values: []float64{dp.Value}})
 		}
-		// Datapoints after endTime are ignored.
 	}
 
-	// No datapoints inside the window means nothing to chart — even if earlier
-	// datapoints pushed the running total above zero. (renderGoalChart's
-	// contract is to return empty when none fall inside the window; a lone
-	// carry-over anchor would otherwise draw a flat, dataless line.)
-	if len(processed) == 0 {
-		return nil
-	}
+	// Buckets are first-seen in ascending-timestamp order, which is already
+	// ascending-day order; sort defensively in case daystamps and timestamps
+	// disagree near a boundary.
+	sort.SliceStable(buckets, func(i, j int) bool {
+		return buckets[i].day.Before(buckets[j].day)
+	})
+	return buckets
+}
 
-	// Prepend an anchor at the window start carrying the running total so far,
-	// so the line begins where the goal actually stood rather than at zero.
-	return append([]timedValue{{timestamp: startTime.Unix(), value: startSum}}, processed...)
+// dayStart returns the local-midnight instant of the datapoint's day, preferring
+// its daystamp (YYYYMMDD) and falling back to its timestamp.
+func dayStart(dp Datapoint, loc *time.Location) time.Time {
+	if len(dp.Daystamp) == 8 {
+		if t, err := time.ParseInLocation("20060102", dp.Daystamp, loc); err == nil {
+			return t
+		}
+	}
+	t := time.Unix(dp.Timestamp, 0).In(loc)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
 }
 
 // datapointSeries maps processed datapoints onto chartWidth evenly-spaced

--- a/chart_test.go
+++ b/chart_test.go
@@ -676,7 +676,7 @@ func TestProcessDatapointsMidDayWindowStartAndNoDaystamp(t *testing.T) {
 	goal := Goal{
 		Kyoom: true,
 		Datapoints: []Datapoint{
-			{Timestamp: day0.Add(14 * time.Hour).Unix(), Value: 5}, // no Daystamp → day 0
+			{Timestamp: day0.Add(14 * time.Hour).Unix(), Value: 5},                 // no Daystamp → day 0
 			{Timestamp: day0.AddDate(0, 0, 1).Add(9 * time.Hour).Unix(), Value: 3}, // day 1
 		},
 	}

--- a/chart_test.go
+++ b/chart_test.go
@@ -700,6 +700,37 @@ func TestProcessDatapointsMidDayWindowStartAndNoDaystamp(t *testing.T) {
 	}
 }
 
+func TestProcessDatapointsExcludesPointsAfterWindowEnd(t *testing.T) {
+	// A datapoint logged later the same day, after a mid-day endTime, must not
+	// leak into that day's aggregate (it's effectively in the future relative to
+	// the charted window). Mirrors Beeminder filtering data to "now" before
+	// aggregating.
+	loc := time.UTC
+	day := time.Date(2024, 7, 1, 0, 0, 0, 0, loc)
+	start := day
+	end := day.Add(15 * time.Hour) // window ends at 3pm
+
+	goal := Goal{
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: day.Add(10 * time.Hour).Unix(), Daystamp: "20240701", Value: 5},  // before end → counts
+			{Timestamp: day.Add(20 * time.Hour).Unix(), Daystamp: "20240701", Value: 99}, // after end → excluded
+		},
+	}
+	got := processDatapoints(goal, start, end)
+
+	// anchor 0 + the day's aggregate of just the 5 (the 99 is excluded), not 104.
+	want := []float64{0, 5}
+	if len(got) != len(want) {
+		t.Fatalf("got %d points, want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].value != w {
+			t.Errorf("value[%d] = %v, want %v (point after endTime must be excluded)", i, got[i].value, w)
+		}
+	}
+}
+
 func TestProcessDatapointsAggregatesSameDay(t *testing.T) {
 	// The crux of the aggday work: multiple datapoints on one day collapse to a
 	// single plotted point per day, using the goal's aggday.

--- a/chart_test.go
+++ b/chart_test.go
@@ -662,6 +662,44 @@ func TestProcessDatapointsNonCumulative(t *testing.T) {
 	}
 }
 
+func TestProcessDatapointsMidDayWindowStartAndNoDaystamp(t *testing.T) {
+	// Two subtle paths at once: a window that starts mid-day (as stale goals do,
+	// anchored at the last datapoint's timestamp), and datapoints carrying no
+	// Daystamp (so the day is derived from the timestamp). The day whose midnight
+	// precedes the mid-day startTime must still count as in-window, and the kyoom
+	// anchor must sort at-or-before the first day point.
+	loc := time.UTC
+	day0 := time.Date(2024, 5, 10, 0, 0, 0, 0, loc)
+	start := day0.Add(12 * time.Hour) // window starts at noon on day 0
+	end := day0.AddDate(0, 0, 2)
+
+	goal := Goal{
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: day0.Add(14 * time.Hour).Unix(), Value: 5}, // no Daystamp → day 0
+			{Timestamp: day0.AddDate(0, 0, 1).Add(9 * time.Hour).Unix(), Value: 3}, // day 1
+		},
+	}
+	got := processDatapoints(goal, start, end)
+
+	// anchor (carry 0) + day0 cumulative 5 + day1 cumulative 8.
+	want := []float64{0, 5, 8}
+	if len(got) != len(want) {
+		t.Fatalf("got %d points, want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].value != w {
+			t.Errorf("value[%d] = %v, want %v", i, got[i].value, w)
+		}
+	}
+	// The series must stay sorted ascending by time for datapointSeries.
+	for i := 1; i < len(got); i++ {
+		if got[i].timestamp < got[i-1].timestamp {
+			t.Errorf("processed not ascending at %d: %d < %d", i, got[i].timestamp, got[i-1].timestamp)
+		}
+	}
+}
+
 func TestProcessDatapointsAggregatesSameDay(t *testing.T) {
 	// The crux of the aggday work: multiple datapoints on one day collapse to a
 	// single plotted point per day, using the goal's aggday.

--- a/chart_test.go
+++ b/chart_test.go
@@ -580,25 +580,25 @@ func TestRenderGoalChartHonorsTminForStaleGoal(t *testing.T) {
 	}
 }
 
-func TestProcessCumulativeNoInWindowDatapointsReturnsNil(t *testing.T) {
-	// Invariant: when no datapoints fall inside the window, processCumulative
-	// returns nil even though earlier datapoints push the running total above
-	// zero — a lone carry-over anchor must never draw a dataless flat line.
+func TestProcessDatapointsCumulativeNoInWindowReturnsNil(t *testing.T) {
+	// Invariant: when no day falls inside the window, a cumulative goal yields nil
+	// even though earlier datapoints push the running total above zero — a lone
+	// carry-over anchor must never draw a dataless flat line.
 	start := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	end := start.AddDate(0, 0, 30)
 	goal := Goal{
 		Kyoom: true,
 		Datapoints: []Datapoint{
-			{Timestamp: start.AddDate(0, 0, -10).Unix(), Value: 5.0},
-			{Timestamp: start.AddDate(0, 0, -5).Unix(), Value: 7.0},
+			{Timestamp: start.AddDate(0, 0, -10).Unix(), Daystamp: "20240522", Value: 5.0},
+			{Timestamp: start.AddDate(0, 0, -5).Unix(), Daystamp: "20240527", Value: 7.0},
 		},
 	}
-	if got := processCumulative(goal, start, end); got != nil {
+	if got := processDatapoints(goal, start, end); got != nil {
 		t.Errorf("expected nil when no datapoints fall in the window, got %v", got)
 	}
 }
 
-func TestProcessCumulativeValues(t *testing.T) {
+func TestProcessDatapointsCumulativeValues(t *testing.T) {
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.AddDate(0, 0, 2)
 
@@ -613,24 +613,24 @@ func TestProcessCumulativeValues(t *testing.T) {
 		}
 	}
 
-	// Two datapoints inside the window, nothing before it: the anchor carries 0,
-	// then the running total reaches 5, then 8.
-	check("in-window", processCumulative(Goal{
+	// Two datapoints inside the window (one per day), nothing before it: the
+	// anchor carries 0, then the running total reaches 5, then 8.
+	check("in-window", processDatapoints(Goal{
 		Kyoom: true,
 		Datapoints: []Datapoint{
-			{Timestamp: start.Unix(), Value: 5},
-			{Timestamp: start.AddDate(0, 0, 1).Unix(), Value: 3},
+			{Timestamp: start.Unix(), Daystamp: "20240101", Value: 5},
+			{Timestamp: start.AddDate(0, 0, 1).Unix(), Daystamp: "20240102", Value: 3},
 		},
 	}, start, end), []float64{0, 5, 8})
 
 	// A datapoint before the window feeds the carry-over anchor (10) but isn't
 	// itself plotted; in-window points continue the running total: 15, then 18.
-	check("carry-over", processCumulative(Goal{
+	check("carry-over", processDatapoints(Goal{
 		Kyoom: true,
 		Datapoints: []Datapoint{
-			{Timestamp: start.AddDate(0, 0, -1).Unix(), Value: 10},
-			{Timestamp: start.Unix(), Value: 5},
-			{Timestamp: start.AddDate(0, 0, 1).Unix(), Value: 3},
+			{Timestamp: start.AddDate(0, 0, -1).Unix(), Daystamp: "20231231", Value: 10},
+			{Timestamp: start.Unix(), Daystamp: "20240101", Value: 5},
+			{Timestamp: start.AddDate(0, 0, 1).Unix(), Daystamp: "20240102", Value: 3},
 		},
 	}, start, end), []float64{10, 15, 18})
 }
@@ -639,25 +639,76 @@ func TestProcessDatapointsNonCumulative(t *testing.T) {
 	start := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
 	end := start.AddDate(0, 0, 5)
 
-	// Non-cumulative goal: only in-window points, sorted ascending, raw values.
+	// Non-cumulative goal: only in-window days, ascending, the day's aggregate
+	// (default aggday "last" → the single value).
 	goal := Goal{
 		Datapoints: []Datapoint{
-			{Timestamp: start.AddDate(0, 0, 3).Unix(), Value: 30},  // in window, later
-			{Timestamp: start.AddDate(0, 0, -2).Unix(), Value: 99}, // before window → excluded
-			{Timestamp: start.AddDate(0, 0, 1).Unix(), Value: 10},  // in window, earlier
-			{Timestamp: end.AddDate(0, 0, 2).Unix(), Value: 88},    // after window → excluded
+			{Timestamp: start.AddDate(0, 0, 3).Unix(), Daystamp: "20240113", Value: 30},  // in window, later
+			{Timestamp: start.AddDate(0, 0, -2).Unix(), Daystamp: "20240108", Value: 99}, // before window → excluded
+			{Timestamp: start.AddDate(0, 0, 1).Unix(), Daystamp: "20240111", Value: 10},  // in window, earlier
+			{Timestamp: end.AddDate(0, 0, 2).Unix(), Daystamp: "20240117", Value: 88},    // after window → excluded
 		},
 	}
 
 	got := processDatapoints(goal, start, end)
 	if len(got) != 2 {
-		t.Fatalf("expected 2 in-window datapoints, got %d", len(got))
+		t.Fatalf("expected 2 in-window days, got %d", len(got))
 	}
 	if got[0].timestamp >= got[1].timestamp {
-		t.Error("expected datapoints sorted ascending by timestamp")
+		t.Error("expected days sorted ascending by time")
 	}
 	if got[0].value != 10 || got[1].value != 30 {
-		t.Errorf("expected raw (un-summed) values [10 30], got [%v %v]", got[0].value, got[1].value)
+		t.Errorf("expected per-day (un-summed) values [10 30], got [%v %v]", got[0].value, got[1].value)
+	}
+}
+
+func TestProcessDatapointsAggregatesSameDay(t *testing.T) {
+	// The crux of the aggday work: multiple datapoints on one day collapse to a
+	// single plotted point per day, using the goal's aggday.
+	start := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 3)
+	noon := func(d int) int64 {
+		return time.Date(2024, 3, 1+d, 12, 0, 0, 0, time.UTC).Unix()
+	}
+
+	// A cumulative goal whose default aggday is "sum": two same-day points sum
+	// within the day, then accumulate across days.
+	kyoom := processDatapoints(Goal{
+		Kyoom: true,
+		Datapoints: []Datapoint{
+			{Timestamp: noon(0), Daystamp: "20240301", Value: 1},
+			{Timestamp: noon(0) + 60, Daystamp: "20240301", Value: 2}, // same day → sums to 3
+			{Timestamp: noon(1), Daystamp: "20240302", Value: 4},      // running 3 → 7
+		},
+	}, start, end)
+	// anchor 0, day1 cumulative 3, day2 cumulative 7
+	wantK := []float64{0, 3, 7}
+	if len(kyoom) != len(wantK) {
+		t.Fatalf("kyoom: got %d points, want %d (%v)", len(kyoom), len(wantK), kyoom)
+	}
+	for i, w := range wantK {
+		if kyoom[i].value != w {
+			t.Errorf("kyoom value[%d] = %v, want %v", i, kyoom[i].value, w)
+		}
+	}
+	// Both day-1 points must collapse to one column (the day boundary), not two.
+	if kyoom[1].timestamp != kyoom[0].timestamp {
+		// anchor and day1 both sit at the window start (2024-03-01).
+		t.Errorf("expected the day-1 point at the window-start day boundary, got %d vs anchor %d", kyoom[1].timestamp, kyoom[0].timestamp)
+	}
+
+	// A non-cumulative goal with an explicit aggday="max": the day's value is the
+	// largest datapoint, with no accumulation.
+	maxGoal := processDatapoints(Goal{
+		Aggday: "max",
+		Datapoints: []Datapoint{
+			{Timestamp: noon(0), Daystamp: "20240301", Value: 1},
+			{Timestamp: noon(0) + 60, Daystamp: "20240301", Value: 9},
+			{Timestamp: noon(0) + 120, Daystamp: "20240301", Value: 4},
+		},
+	}, start, end)
+	if len(maxGoal) != 1 || maxGoal[0].value != 9 {
+		t.Errorf("aggday=max: want a single day valued 9, got %v", maxGoal)
 	}
 }
 


### PR DESCRIPTION
Closes #311.

## Problem

The progress chart plotted one point per datapoint. Beeminder plots one aggregated point **per calendar day**, combining same-day datapoints with the goal's `aggday` method. So buzz spread same-day points across the x-axis (the leftover from the diagonal/step work in #310 — a same-day "0 then 1" still jumped at the time of the second log, not at the day boundary).

## Fix

`processDatapoints` now buckets datapoints by day, reduces each day to one value via the goal's `aggday`, and — for cumulative (kyoom) goals — takes the running total of those daily aggregates.

- **`aggday.go`** ports beebrain's `broad.js` `AGGR` map faithfully: `sum`, `last`, `first`, `min`, `max`, `count`, the mean family (`mu`/`truemean`/`average` = mean of all; `mean`/`munique`/`uniqmean` = mean of unique), `trimmean`, `median`, `mode`, `unary`/`binary`/`jolly`, `nonzero`/`unaryflat`, `triangle`, `square`, `clocky`, `skatesum`, `cap1`/`satsum`, `sqrt`, `countflat`, `muflat`, plus legacy aliases. The fiddly ones (`clocky`, `skatesum`, `triangle`, `trimmean`, `mode`) are ported from the source, not approximated; an unknown method falls back to the goal's default.
- **`Goal.Aggday`** is parsed from the API; default is `sum` for kyoom, `last` otherwise (matching beebrain: `p.aggday = gol.kyoom ? "sum" : "last"`).
- Days are taken from the Beeminder **daystamp** when present (it already accounts for the goal's deadline), falling back to the timestamp. Buckets and the kyoom carry-over anchor are positioned at the day boundary.

### Result

Same-day datapoints now share a column. The reported `integrations` goal — a value-0 anchor and a same-day value-1 `#calendar` point — renders as a single riser at the **start of the day**, then flat, matching the official Beeminder graph (previously it jumped mid-window at the second log's time).

## Tests

- `aggday_test.go`: per-reducer coverage (incl. the unique-mean quirk, `median` odd/even, `trimmean` trim vs degenerate, `clocky` odd, `skatesum` cap + fallback, unknown→default).
- `chart_test.go`: same-day aggregation (sum across a day, `aggday=max`), kyoom carry-over/running-total, and a mid-day window-start + no-daystamp case (which also guards the carry anchor's ordering).
- Full suite green; `go vet` clean.

## Review

Ran the local review loop (6 dimensions). It caught one real bug — the kyoom carry anchor was positioned at the raw `startTime` instant rather than the window-start day, which could violate `datapointSeries`' ascending-order assumption for stale goals — now fixed and regression-tested; an adversarial re-review confirmed the fix across all window-start cases.

## Not included

The demo GIF is unchanged: its goals use default aggday and one datapoint per day, so the rendered charts are visually identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added datapoint aggregation to combine same-day entries into single daily values
  * Introduced support for multiple aggregation methods (sum, mean, min, max, median, mode, and specialized transforms)
  * Goals now properly apply their configured aggregation method during charting

* **Bug Fixes**
  * Improved chart processing for cumulative goals and date-windowed views

* **Tests**
  * Expanded test coverage for aggregation behavior and datapoint processing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->