### PR TITLE
fix(demo): keep chart data on the safe side of the red line (cumulative + non-cumulative)

### DIFF
--- a/scripts/demo/mockserver/main.go
+++ b/scripts/demo/mockserver/main.go
@@ -172,11 +172,14 @@ func goalJSON(g demoGoal, now time.Time, withData bool) map[string]any {
 // sets exactly one of value/rate.
 //
 // Cumulative goals anchor at 0 and rise at the goal's rate, so the summed
-// datapoint staircase climbs alongside the line. Non-cumulative goals use a
-// gentle value-to-value line in a positive band around their typical daily level
-// (rather than the headline rate, which over a two-week window would send the
-// line far off-scale and leave the plot mostly empty), so the datapoints and the
-// line stay visible together.
+// datapoint staircase climbs alongside the line.
+//
+// The demo's non-cumulative goals are all Do Less (yaw -1), where the safe side
+// is *below* the bright red line. So their road is a flat horizontal cap sitting
+// a few units above the datapoints' typical level — the data oscillates safely
+// under it and never crosses, which reads as an on-track goal. (An inclined road
+// the data dipped across looked like uncaught derails, since the chart doesn't
+// draw the derail region.)
 func roadall(g demoGoal, initday, startOfToday time.Time) [][]any {
 	end := startOfToday.AddDate(0, 0, 7)
 	if g.kyoom {
@@ -185,14 +188,12 @@ func roadall(g demoGoal, initday, startOfToday time.Time) [][]any {
 			{float64(end.Unix()), nil, g.Rate},
 		}
 	}
-	startV := float64(g.lvl)
-	endV := startV * 0.6
-	if endV < 1 {
-		endV = 1
-	}
+	// Flat cap above the data. Datapoints range over lvl±2 (see datapoints), so a
+	// cap at lvl+3 keeps the line clear of the highest point with visible headroom.
+	capLine := float64(g.lvl) + 3
 	return [][]any{
-		{float64(initday.Unix()), startV, nil},
-		{float64(end.Unix()), endV, nil},
+		{float64(initday.Unix()), capLine, nil},
+		{float64(end.Unix()), capLine, nil},
 	}
 }
 

--- a/scripts/demo/mockserver/main.go
+++ b/scripts/demo/mockserver/main.go
@@ -188,8 +188,9 @@ func roadall(g demoGoal, initday, startOfToday time.Time) [][]any {
 			{float64(end.Unix()), nil, g.Rate},
 		}
 	}
-	// Flat cap above the data. Datapoints range over lvl±2 (see datapoints), so a
-	// cap at lvl+3 keeps the line clear of the highest point with visible headroom.
+	// Flat cap above the data. Datapoints peak around lvl+1 (see datapoints'
+	// wave, which spans lvl-2..lvl+1), so a cap at lvl+3 keeps the line clear of
+	// the highest point with visible headroom.
 	capLine := float64(g.lvl) + 3
 	return [][]any{
 		{float64(initday.Unix()), capLine, nil},

--- a/scripts/demo/mockserver/main.go
+++ b/scripts/demo/mockserver/main.go
@@ -226,10 +226,14 @@ func datapoints(g demoGoal, now time.Time) []map[string]any {
 	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	initday := startOfToday.AddDate(0, 0, -chartWindowDays)
 
-	// Day-to-day texture. The kyoom pattern's zeros produce flat segments in the
-	// cumulative staircase; the last day is non-zero so the latest value reads
-	// cleanly. The non-kyoom wave nudges values around the goal's level.
-	kyoomMult := []float64{1, 1, 0, 2, 1, 0, 1, 2, 1, 0, 1, 1, 2}
+	// Day-to-day texture. The cumulative goals are all Do More (yaw +1), where the
+	// safe side is *above* the bright red line (which rises at the goal's rate).
+	// Each day's multiplier averages above 1, and the running sum stays above the
+	// day index throughout, so the summed staircase rides above the road with a
+	// growing safety buffer — an on-track Do More goal — while the varied steps
+	// and a zero day keep the staircase shape. The non-kyoom wave nudges values
+	// around the goal's level.
+	kyoomMult := []float64{2, 1, 2, 1, 2, 0, 2, 1, 2, 1, 2, 1, 2}
 	wave := []float64{0, 1, -1, 0, 1, -2, 1, 0, -1, 1, 0, 1, -1}
 
 	out := make([]map[string]any, 0, chartWindowDays-1)


### PR DESCRIPTION
## Problem

The demo charts showed goals whose data line sat on the *wrong* side of the bright red line, with no derails drawn to explain the crossings — making healthy-looking goals read as derailing.

- **Non-cumulative** (`inbox`, `screen`) are **Do Less** (`yaw: -1`): safe side is *below* the line, but the data oscillated across a declining road.
- **Cumulative** (`read`, `meditate`, `pushups`) are **Do More** (`yaw: +1`): safe side is *above* the line, but the summed total accumulated at ~the road's rate, so it hugged or dipped below the line ("behind").

## Fix (demo mock-data only — chart code unchanged)

`scripts/demo/mockserver/main.go`:

- **Non-cumulative → flat cap, data below.** The bright red line is now a flat horizontal cap a few units above the datapoints (`lvl + 3`); the data oscillates safely under it and never crosses — an on-track Do Less goal.
- **Cumulative → data above an inclined line.** Bumped the per-day multipliers (running sum stays above the day index) so the cumulative staircase rides above the red line with a growing safety buffer — an on-track Do More goal. The cumulative red line correctly stays **inclined** (the required total accumulates over time; flattening it would be wrong).

## Verification (rendered through the real chart code)

- `inbox`: flat cap at 9, data 4–7 below. `screen`: flat cap at 5, data 0–3 below.
- `meditate`: inclined red line 0→~304 (in-window), data staircase 0→380 riding above it throughout.

`go build`, `go vet`, and the full test suite pass.

The committed `demo.gif` isn't touched here — `ci.yml` records the updated charts and posts them as this PR's release artifact, and `release.yml` refreshes the committed GIF on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)