### PR TITLE
docs: bright-red-line parsing policy (ADR-0003) + vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,3 +25,32 @@ terminology.
 - **Busy / in-flight** — a form is awaiting a Beeminder API response
   (`datapoint.submitting`, `createGoal.creating`). A *flag on the form*, not a
   mode; the screen looks the same, just locked against re-submission.
+
+## Bright red line vocabulary
+
+The **bright red line** is a goal's commitment line — the value Beeminder
+expects you to stay on the right side of. "Road" and "the yellow brick road"
+are Beeminder's *deprecated* names for it: use **bright red line** in all
+user-facing text, and reserve "road" / `roadall` for the raw API field. It is
+read two ways — its value at a moment, and its slope at a moment — by the module
+that owns both (see #317 and
+[ADR-0003](./docs/adr/0003-bright-red-line-parsing-failure-policy.md)).
+
+- **`roadall`** — the API field encoding the bright red line: `[][]*float64`
+  rows of `[t, v, r]`, the first an anchor (t, v set; r nil), each later row
+  with *exactly one* of v/r null. (Observed shape: the API doc claims a final
+  all-set `[goaldate, goalval, rate]` row, but real goals don't emit one — the
+  validator stays strict and treats an all-set row as an anomaly to surface;
+  see ADR-0003.)
+- **Segment** — one piece of the bright red line between two boundaries, with
+  known start/end time, start/end value, and a **slope**. Parsing `roadall`
+  materialises a list of segments **all-or-nothing**: an *absent* `roadall`
+  (length < 2) is a benign "not populated" state, but a *malformed* one yields
+  no line and is surfaced loudly (it signals a parser or upstream bug).
+- **Slope** — how fast the bright red line moves, in gunits/day, at a given
+  moment: the slope of the segment containing it. Distinct from `g.Rate`, which
+  is the rate at the *end* of the graph, not at any specific moment.
+- **Value at time** — the bright red line's value at a moment: interpolated
+  within its span, extrapolated backward before the start, held flat past the
+  end. Value is defined for all t; slope only *within* the span (outside it,
+  callers fall back to `g.Rate`).

--- a/docs/adr/0003-bright-red-line-parsing-failure-policy.md
+++ b/docs/adr/0003-bright-red-line-parsing-failure-policy.md
@@ -1,0 +1,42 @@
+# Bright red line parsing: surface failures loudly; strict validator grounded in observed roadall, not the API doc
+
+**Status:** accepted
+
+## Context
+
+[#317](https://github.com/PinePeakDigital/buzz/issues/317) deepens the three duplicated walkers of a goal's bright red line — `getRoadValueAtTime` and `segmentSlopePerSecond` (chart.go) and `roadallSlopePerDayAt` (slope.go) — into one module that parses the `roadall` API field once into materialised segments and answers value-at-time / slope-at-time. (The structural design — materialised `[]segment`, pure geometry with the `g.Rate` fallback kept caller-side, the value-after-rate gap closed — lives in the issue.)
+
+Two questions that surfaced during design are not about structure but about **policy**, and both are easy for a future reader to "correct" in the wrong direction:
+
+1. What should happen when the `roadall` can't be parsed.
+2. What counts as a malformed row — because the API doc and reality disagree.
+
+On (2): `docs/beeminder-api.md:457` (copied from Beeminder's own API docs) states every `roadall` ends with an all-set `[goaldate, goalval, rate]` row. The repo's test fixtures (`piecewiseRoadall`) assume the opposite — every non-anchor row has *exactly one* of value/rate null. The two contradict each other on the exact thing a loud validator keys off. A read-only audit of a live 60-goal account settled it empirically: **0/60** goals had any all-set row; every terminal row was a rate-row `[t, null, r]` to a far-future goaldate; no both-null interior rows, no rows with length ≠ 3, no short roads, only known runits (`d`, `w`). The fixtures are right; the doc is wrong — or describes `fullroad`/a different encoding — for what buzz actually receives.
+
+## Decision
+
+**Surface parse failures; don't degrade silently.** A malformed `roadall` almost certainly means a bug in our parser (more likely) or upstream — not a condition to paper over.
+
+- **Absent** bright red line (`roadall` length < 2): *not* an error. A view that would draw a graph instead shows "the bright red line wasn't populated for this goal"; non-view callers (e.g. `buzz tomorrow`'s baremin bump) fall back to `g.Rate` silently.
+- **Malformed** `roadall` (present but structurally invalid): surfaced loudly and specifically — the chart replaces the line with a banner naming the defect; `buzz tomorrow` shows a per-goal `⚠` marker. Parsing is all-or-nothing: one bad row fails the whole parse.
+- **Valid:** parsed into materialised segments.
+
+So the parser returns three distinguishable outcomes and callers branch `err != nil → alarm; length 0 → "not populated"; else use it`.
+
+**The validator stays strict, grounded in observed data rather than the doc.** A non-anchor row must have exactly one of value/rate set. The doc's all-set terminal row is treated as an *unobserved anomaly*: if it ever appears, the loud failure is the correct outcome (investigate it), not a false alarm to pre-accommodate. The code enforcing this **must carry a comment pointing at `docs/beeminder-api.md:457`** so a future reader does not loosen the rule on the doc's authority — that specific trap is why this ADR exists.
+
+**Terminology.** "Road" / "the yellow brick road" are Beeminder's *deprecated* names for the bright red line. User-facing text says **bright red line**; "road" / `roadall` is reserved for the raw API field.
+
+## Considered options
+
+- **Silent degradation (status quo):** unparseable road → draw nothing / fall back to `g.Rate`. Rejected — hides a probable bug; the user sees a subtly-wrong or empty chart and never learns why.
+- **Loosen the validator to accept the doc's all-set terminal row.** Rejected — the shape does not occur in real data, and accepting an unobserved shape on the word of a doc that just proved unreliable trades a real signal (loud-on-anomaly) for defensive handling of a phantom.
+- **Treat an absent road as malformed too.** Rejected — a missing `roadall` is a legitimate "no data" state, distinct from corruption; conflating them would cry wolf.
+- **Surface loudly + strict validator grounded in observed data** — chosen.
+
+## Consequences
+
+- One deliberate behaviour change vs. today: a malformed road that the old *lazy* code tolerated (drawing a partial line / silently falling back to `g.Rate`) now blanks the chart with an explicit banner. Acceptable because the audit shows real goals don't hit it; if one does, that is the bug-signal working as intended.
+- If a future Beeminder change starts emitting the all-set terminal row, **every goal alarms at once** — a loud, immediate prompt to revisit this ADR, by design, rather than a silent drift.
+- The grounding rests on one account (60 goals). Other users may have value-defined interior segments (`[t, v, null]` interior rows), which the strict rule already accepts. Re-running the audit against a second account before merge is cheap insurance.
+- The "absent vs. malformed vs. valid" three-way contract becomes the test surface: each outcome is asserted at the parser, and each caller's branch (alarm / "not populated" / draw) is tested independently.


### PR DESCRIPTION
Documentation groundwork from the #317 design session — no code changes.

## What's here

- **`docs/adr/0003-bright-red-line-parsing-failure-policy.md`** (new) — records two load-bearing decisions a future reader could easily reverse:
  - **Surface parse failures, don't degrade silently.** Absent `roadall` (length < 2) is a benign "not populated" state; a *malformed* one is surfaced loudly (chart banner / per-goal `⚠`) because it almost certainly signals a bug in our parser or upstream. Parsing is all-or-nothing.
  - **Keep the validator strict, grounded in observed data, not the API doc.** `docs/beeminder-api.md:457` claims every `roadall` ends with an all-set `[goaldate, goalval, rate]` row; a read-only audit of a live 60-goal account found **0/60** with that shape. The validator stays strict and treats the all-set row as an anomaly to surface — and the enforcing code must comment-link the doc so nobody loosens the rule on its authority later.
- **`CONTEXT.md`** — adds the bright-red-line vocabulary: **"bright red line"** is canonical, **"road"** is Beeminder's deprecated term, and **`roadall`** is reserved for the raw API field.

## Why now

These calls are non-obvious and currently live only in #317 comments. The strict-validator decision in particular is a trap (the API doc actively contradicts it), so it's worth pinning in an ADR before the #317 implementation lands.

## Scope

Docs only — `CONTEXT.md` + one ADR. The structural design (materialised segments, the `g.Rate` fallback staying caller-side, etc.) stays tracked in #317 and will land with the implementation.

Refs #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Bright Red Line vocabulary reference defining key terminology for charting and goal tracking functionality.
  * Introduced architectural decision documentation outlining the parsing failure handling policy for improved data validation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->