### PR TITLE
refactor(client): collapse per-method HTTP ritual into a typed helper

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,41 +126,45 @@ func (e *apiStatusError) Error() string {
 	return fmt.Sprintf("API returned status %d", e.status)
 }
 
-// execute runs an authenticated request and returns the response body on a 200
-// OK. It centralises the read-body + status-check that every typed method
-// shared: a transport failure is wrapped with failMsg, and a non-200 becomes an
-// *apiStatusError carrying the code (and body, when present). URL construction
-// stays in the calling method — it is the one genuinely per-endpoint piece, and
-// keeping the exact request strings (auth-token placement, query params, slug
-// escaping) means this helper changes no request actually sent to Beeminder.
-func (c *HTTPClient) execute(ctx context.Context, method, url, failMsg string, body io.Reader, contentType string) ([]byte, error) {
+// send runs an authenticated request and, on a 200 OK, returns the live
+// response for the caller to stream — the caller owns resp.Body and must close
+// it. It centralises the status-check that every typed method shared: a
+// transport failure is wrapped with failMsg, and a non-200 becomes an
+// *apiStatusError carrying the code and (best-effort) the response body, after
+// which send closes the body itself. Returning the un-read 200 body lets
+// callers decode straight from the stream rather than buffering large payloads
+// (e.g. goal details with datapoints) in memory.
+//
+// URL construction stays in the calling method — it is the one genuinely
+// per-endpoint piece, and keeping the exact request strings (auth-token
+// placement, query params, slug escaping) means this helper changes no request
+// actually sent to Beeminder.
+func (c *HTTPClient) send(ctx context.Context, method, url, failMsg string, body io.Reader, contentType string) (*http.Response, error) {
 	resp, err := c.doRequest(ctx, method, url, body, contentType)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", failMsg, err)
 	}
-	defer resp.Body.Close()
-
-	respBody, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", readErr)
-	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, &apiStatusError{status: resp.StatusCode, body: strings.TrimSpace(string(respBody))}
+		defer resp.Body.Close()
+		errBody, _ := io.ReadAll(resp.Body)
+		return nil, &apiStatusError{status: resp.StatusCode, body: strings.TrimSpace(string(errBody))}
 	}
-	return respBody, nil
+	return resp, nil
 }
 
-// doJSON is execute plus a JSON decode of the success body into T. Go methods
-// can't take type parameters, so this is a package-level function taking the
-// client; most Client methods are a single call to it.
+// doJSON is send plus a streaming JSON decode of the success body into T. Go
+// methods can't take type parameters, so this is a package-level function
+// taking the client; most Client methods are a single call to it. failMsg
+// attributes both transport and decode failures to the calling endpoint.
 func doJSON[T any](ctx context.Context, c *HTTPClient, method, url, failMsg string, body io.Reader, contentType string) (T, error) {
 	var out T
-	respBody, err := c.execute(ctx, method, url, failMsg, body, contentType)
+	resp, err := c.send(ctx, method, url, failMsg, body, contentType)
 	if err != nil {
 		return out, err
 	}
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return out, fmt.Errorf("failed to decode response: %w", err)
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return out, fmt.Errorf("%s: failed to decode response: %w", failMsg, err)
 	}
 	return out, nil
 }
@@ -435,7 +439,7 @@ func (c *HTTPClient) FetchGoalRawJSON(ctx context.Context, goalSlug string, incl
 		apiURL += "&datapoints=true"
 	}
 
-	body, err := c.execute(ctx, http.MethodGet, apiURL, "failed to fetch goal", nil, "")
+	resp, err := c.send(ctx, http.MethodGet, apiURL, "failed to fetch goal", nil, "")
 	if err != nil {
 		var se *apiStatusError
 		if errors.As(err, &se) && se.status == http.StatusNotFound {
@@ -443,7 +447,13 @@ func (c *HTTPClient) FetchGoalRawJSON(ctx context.Context, goalSlug string, incl
 		}
 		return nil, err
 	}
-	return json.RawMessage(body), nil
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch goal: failed to read response: %w", err)
+	}
+	return json.RawMessage(raw), nil
 }
 
 // CreateGoal creates a new goal for the user.

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -105,50 +106,77 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, url string, body io.
 	return resp, nil
 }
 
+// formContentType is the body content type for Beeminder's form-encoded writes.
+const formContentType = "application/x-www-form-urlencoded"
+
+// apiStatusError is returned for a non-200 Beeminder response. It preserves the
+// status code (and trimmed body, when the server sent one) so callers can both
+// surface a useful message and branch on the code — e.g. FetchGoal turns a 404
+// into "goal not found". Its message keeps the "API returned status N" form the
+// per-method code produced before this helper existed.
+type apiStatusError struct {
+	status int
+	body   string
+}
+
+func (e *apiStatusError) Error() string {
+	if e.body != "" {
+		return fmt.Sprintf("API returned status %d: %s", e.status, e.body)
+	}
+	return fmt.Sprintf("API returned status %d", e.status)
+}
+
+// execute runs an authenticated request and returns the response body on a 200
+// OK. It centralises the read-body + status-check that every typed method
+// shared: a transport failure is wrapped with failMsg, and a non-200 becomes an
+// *apiStatusError carrying the code (and body, when present). URL construction
+// stays in the calling method — it is the one genuinely per-endpoint piece, and
+// keeping the exact request strings (auth-token placement, query params, slug
+// escaping) means this helper changes no request actually sent to Beeminder.
+func (c *HTTPClient) execute(ctx context.Context, method, url, failMsg string, body io.Reader, contentType string) ([]byte, error) {
+	resp, err := c.doRequest(ctx, method, url, body, contentType)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", failMsg, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &apiStatusError{status: resp.StatusCode, body: strings.TrimSpace(string(respBody))}
+	}
+	return respBody, nil
+}
+
+// doJSON is execute plus a JSON decode of the success body into T. Go methods
+// can't take type parameters, so this is a package-level function taking the
+// client; most Client methods are a single call to it.
+func doJSON[T any](ctx context.Context, c *HTTPClient, method, url, failMsg string, body io.Reader, contentType string) (T, error) {
+	var out T
+	respBody, err := c.execute(ctx, method, url, failMsg, body, contentType)
+	if err != nil {
+		return out, err
+	}
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return out, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return out, nil
+}
+
 // FetchGoals fetches the user's goals from Beeminder API.
 func (c *HTTPClient) FetchGoals(ctx context.Context) ([]Goal, error) {
 	url := fmt.Sprintf("%s/api/v1/users/%s/goals.json?auth_token=%s",
 		c.baseURL(), c.config.Username, c.config.AuthToken)
-
-	resp, err := c.doRequest(ctx, http.MethodGet, url, nil, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch goals: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var goals []Goal
-	if err := json.NewDecoder(resp.Body).Decode(&goals); err != nil {
-		return nil, fmt.Errorf("failed to decode goals: %w", err)
-	}
-
-	return goals, nil
+	return doJSON[[]Goal](ctx, c, http.MethodGet, url, "failed to fetch goals", nil, "")
 }
 
 // FetchArchivedGoals fetches the user's archived goals from the Beeminder API.
 func (c *HTTPClient) FetchArchivedGoals(ctx context.Context) ([]Goal, error) {
 	url := fmt.Sprintf("%s/api/v1/users/%s/goals/archived.json?auth_token=%s",
 		c.baseURL(), c.config.Username, c.config.AuthToken)
-
-	resp, err := c.doRequest(ctx, http.MethodGet, url, nil, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch archived goals: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var goals []Goal
-	if err := json.NewDecoder(resp.Body).Decode(&goals); err != nil {
-		return nil, fmt.Errorf("failed to decode archived goals: %w", err)
-	}
-
-	return goals, nil
+	return doJSON[[]Goal](ctx, c, http.MethodGet, url, "failed to fetch archived goals", nil, "")
 }
 
 // FetchUserTimezone fetches the IANA timezone configured on the user's
@@ -157,24 +185,12 @@ func (c *HTTPClient) FetchArchivedGoals(ctx context.Context) ([]Goal, error) {
 func (c *HTTPClient) FetchUserTimezone(ctx context.Context) (string, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s.json?auth_token=%s",
 		c.baseURL(), c.config.Username, c.config.AuthToken)
-
-	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch user: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var result struct {
+	result, err := doJSON[struct {
 		Timezone string `json:"timezone"`
+	}](ctx, c, http.MethodGet, apiURL, "failed to fetch user", nil, "")
+	if err != nil {
+		return "", err
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("failed to decode user: %w", err)
-	}
-
 	return result.Timezone, nil
 }
 
@@ -233,29 +249,15 @@ func (c *HTTPClient) APIRequest(ctx context.Context, method, path string, params
 func (c *HTTPClient) GetLastDatapointValue(ctx context.Context, goalSlug string) (float64, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s&skinny=true",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
-
-	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch goal details: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var result struct {
+	result, err := doJSON[struct {
 		LastDatapoint *Datapoint `json:"last_datapoint"`
+	}](ctx, c, http.MethodGet, apiURL, "failed to fetch goal details", nil, "")
+	if err != nil {
+		return 0, err
 	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return 0, fmt.Errorf("failed to decode goal details: %w", err)
-	}
-
 	if result.LastDatapoint == nil {
 		return 0, nil
 	}
-
 	return result.LastDatapoint.Value, nil
 }
 
@@ -287,24 +289,9 @@ func (c *HTTPClient) CreateDatapointWithDaystamp(ctx context.Context, goalSlug, 
 		data.Set("requestid", requestid)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
+	dp, err := doJSON[Datapoint](ctx, c, http.MethodPost, apiURL, "failed to create datapoint", strings.NewReader(data.Encode()), formContentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create datapoint: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return nil, fmt.Errorf("failed to read create-datapoint response: %w", readErr)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var dp Datapoint
-	if err := json.Unmarshal(body, &dp); err != nil {
-		return nil, fmt.Errorf("failed to decode created datapoint: %w", err)
+		return nil, err
 	}
 	return &dp, nil
 }
@@ -322,23 +309,9 @@ func (c *HTTPClient) CreateCharge(ctx context.Context, amount float64, note stri
 		data.Set("dryrun", "true")
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
+	ch, err := doJSON[Charge](ctx, c, http.MethodPost, apiURL, "failed to create charge", strings.NewReader(data.Encode()), formContentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create charge: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
-		if readErr != nil {
-			return nil, fmt.Errorf("API returned status %d (failed to read body: %w)", resp.StatusCode, readErr)
-		}
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var ch Charge
-	if err := json.NewDecoder(resp.Body).Decode(&ch); err != nil {
-		return nil, fmt.Errorf("failed to decode charge: %w", err)
+		return nil, err
 	}
 	return &ch, nil
 }
@@ -349,24 +322,9 @@ func (c *HTTPClient) CallUncle(ctx context.Context, goalSlug string) (*Goal, err
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/uncleme.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(""), "application/x-www-form-urlencoded")
+	goal, err := doJSON[Goal](ctx, c, http.MethodPost, apiURL, "failed to call uncle", strings.NewReader(""), formContentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call uncle: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", readErr)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var goal Goal
-	if err := json.Unmarshal(body, &goal); err != nil {
-		return nil, fmt.Errorf("failed to decode goal: %w", err)
+		return nil, err
 	}
 	return &goal, nil
 }
@@ -383,24 +341,9 @@ func (c *HTTPClient) RatchetGoal(ctx context.Context, goalSlug string, ratchet i
 	data.Set("auth_token", c.config.AuthToken)
 	data.Set("ratchet", fmt.Sprintf("%d", ratchet))
 
-	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
+	goal, err := doJSON[Goal](ctx, c, http.MethodPost, apiURL, "failed to ratchet goal", strings.NewReader(data.Encode()), formContentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ratchet goal: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", readErr)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var goal Goal
-	if err := json.Unmarshal(body, &goal); err != nil {
-		return nil, fmt.Errorf("failed to decode goal: %w", err)
+		return nil, err
 	}
 	return &goal, nil
 }
@@ -410,25 +353,14 @@ func (c *HTTPClient) FetchGoal(ctx context.Context, goalSlug string) (*Goal, err
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
+	goal, err := doJSON[Goal](ctx, c, http.MethodGet, apiURL, "failed to fetch goal", nil, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch goal: %w", err)
+		var se *apiStatusError
+		if errors.As(err, &se) && se.status == http.StatusNotFound {
+			return nil, fmt.Errorf("goal not found: %s", goalSlug)
+		}
+		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("goal not found: %s", goalSlug)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var goal Goal
-	if err := json.NewDecoder(resp.Body).Decode(&goal); err != nil {
-		return nil, fmt.Errorf("failed to decode goal: %w", err)
-	}
-
 	return &goal, nil
 }
 
@@ -437,21 +369,10 @@ func (c *HTTPClient) FetchGoalWithDatapoints(ctx context.Context, goalSlug strin
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s.json?auth_token=%s&datapoints=true",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
 
-	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
+	goal, err := doJSON[Goal](ctx, c, http.MethodGet, apiURL, "failed to fetch goal details", nil, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch goal details: %w", err)
+		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var goal Goal
-	if err := json.NewDecoder(resp.Body).Decode(&goal); err != nil {
-		return nil, fmt.Errorf("failed to decode goal details: %w", err)
-	}
-
 	return &goal, nil
 }
 
@@ -514,25 +435,14 @@ func (c *HTTPClient) FetchGoalRawJSON(ctx context.Context, goalSlug string, incl
 		apiURL += "&datapoints=true"
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
+	body, err := c.execute(ctx, http.MethodGet, apiURL, "failed to fetch goal", nil, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch goal: %w", err)
+		var se *apiStatusError
+		if errors.As(err, &se) && se.status == http.StatusNotFound {
+			return nil, fmt.Errorf("goal not found: %s", goalSlug)
+		}
+		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("goal not found: %s", goalSlug)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
 	return json.RawMessage(body), nil
 }
 
@@ -552,21 +462,10 @@ func (c *HTTPClient) CreateGoal(ctx context.Context, slug, title, goalType, guni
 	data.Set("goalval", goalval)
 	data.Set("rate", rate)
 
-	resp, err := c.doRequest(ctx, http.MethodPost, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
+	goal, err := doJSON[Goal](ctx, c, http.MethodPost, apiURL, "failed to create goal", strings.NewReader(data.Encode()), formContentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create goal: %w", err)
+		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var goal Goal
-	if err := json.NewDecoder(resp.Body).Decode(&goal); err != nil {
-		return nil, fmt.Errorf("failed to decode created goal: %w", err)
-	}
-
 	return &goal, nil
 }
 
@@ -582,25 +481,10 @@ func (c *HTTPClient) UpdateGoalDeadline(ctx context.Context, goalSlug string, de
 	data.Set("auth_token", c.config.AuthToken)
 	data.Set("deadline", fmt.Sprintf("%d", deadline))
 
-	resp, err := c.doRequest(ctx, http.MethodPut, apiURL, strings.NewReader(data.Encode()), "application/x-www-form-urlencoded")
+	goal, err := doJSON[Goal](ctx, c, http.MethodPut, apiURL, "failed to update goal deadline", strings.NewReader(data.Encode()), formContentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update goal deadline: %w", err)
+		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
-		if readErr != nil {
-			return nil, fmt.Errorf("API returned status %d (failed to read body: %w)", resp.StatusCode, readErr)
-		}
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var goal Goal
-	if err := json.NewDecoder(resp.Body).Decode(&goal); err != nil {
-		return nil, fmt.Errorf("failed to decode updated goal: %w", err)
-	}
-
 	return &goal, nil
 }
 
@@ -609,21 +493,5 @@ func (c *HTTPClient) UpdateGoalDeadline(ctx context.Context, goalSlug string, de
 func (c *HTTPClient) RefreshGoal(ctx context.Context, goalSlug string) (bool, error) {
 	apiURL := fmt.Sprintf("%s/api/v1/users/%s/goals/%s/refresh_graph.json?auth_token=%s",
 		c.baseURL(), c.config.Username, url.PathEscape(goalSlug), c.config.AuthToken)
-
-	resp, err := c.doRequest(ctx, http.MethodGet, apiURL, nil, "")
-	if err != nil {
-		return false, fmt.Errorf("failed to refresh goal: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var result bool
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return false, fmt.Errorf("failed to decode refresh result: %w", err)
-	}
-
-	return result, nil
+	return doJSON[bool](ctx, c, http.MethodGet, apiURL, "failed to refresh goal", nil, "")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestAPIStatusErrorMessage pins the message format every HTTPClient method now
+// relies on after the request-helper refactor: "API returned status N", with
+// the trimmed body appended only when the server sent one. Existing per-method
+// tests assert this via strings.Contains; this locks the exact format directly.
+func TestAPIStatusErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *apiStatusError
+		want string
+	}{
+		{
+			name: "status only when body empty",
+			err:  &apiStatusError{status: http.StatusInternalServerError, body: ""},
+			want: "API returned status 500",
+		},
+		{
+			name: "status and body when present",
+			err:  &apiStatusError{status: http.StatusUnprocessableEntity, body: `{"errors":"bad"}`},
+			want: `API returned status 422: {"errors":"bad"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAPIStatusErrorAsTarget confirms apiStatusError survives fmt.Errorf
+// wrapping and is recoverable via errors.As — the mechanism FetchGoal and
+// FetchGoalRawJSON use to turn a 404 into "goal not found".
+func TestAPIStatusErrorAsTarget(t *testing.T) {
+	wrapped := fmt.Errorf("failed to fetch goal: %w", &apiStatusError{status: http.StatusNotFound})
+
+	var se *apiStatusError
+	if !errors.As(wrapped, &se) {
+		t.Fatalf("errors.As did not recover *apiStatusError from %v", wrapped)
+	}
+	if se.status != http.StatusNotFound {
+		t.Errorf("recovered status = %d, want %d", se.status, http.StatusNotFound)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -49,5 +52,28 @@ func TestAPIStatusErrorAsTarget(t *testing.T) {
 	}
 	if se.status != http.StatusNotFound {
 		t.Errorf("recovered status = %d, want %d", se.status, http.StatusNotFound)
+	}
+}
+
+// TestDoJSONDecodeErrorAttributesEndpoint pins the behavior this refactor
+// restored: a malformed 200 body produces a decode error wrapped with the
+// calling endpoint's failMsg, so the failure can be traced to the specific API
+// call rather than a bare "failed to decode response".
+func TestDoJSONDecodeErrorAttributesEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{ this is not valid json"))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(&Config{Username: "u", AuthToken: "t", BaseURL: srv.URL})
+	_, err := c.FetchGoal(context.Background(), "g")
+	if err == nil {
+		t.Fatal("expected a decode error from malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch goal") ||
+		!strings.Contains(err.Error(), "failed to decode response") {
+		t.Errorf("decode error should be attributed to the endpoint, got: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #314 — first PR in the architecture refactor sequence.

## Problem

`doRequest` already factored out request-build + logging, but each of the ~14 `HTTPClient` methods still hand-rolled the same three remaining steps after building its URL: read the body, reject a non-200 status, JSON-decode, and wrap each step's error. That ~15-line ritual was copy-pasted across every method, and the error conventions had already drifted (some returned a bare `API returned status N`, others appended the body).

## Change

Two helpers absorb the ritual:

- **`execute()`** — run the request, read the body, return it on `200 OK` or an `*apiStatusError` (status + trimmed body) otherwise. One place owns status handling.
- **`doJSON[T]()`** — `execute()` plus a JSON decode into `T`. Most methods become a single call. (Package-level, not a method, because Go methods can't take type parameters.)

A typed **`apiStatusError`** carries the status code so the two methods that special-case 404 (`FetchGoal`, `FetchGoalRawJSON`) branch via `errors.As`, while everyone else gets a consistent `API returned status N[: body]` message.

`APIRequest` (the raw primitive behind the `buzz api` command) is left as-is — it has a different contract (returns non-2xx without an error).

## Deliberate scope decision

**URL construction stays in each method.** Routing it through a parser would have changed auth-token placement on some endpoints (e.g. `CallUncle` sends `auth_token` in the query string, not the body) — a behavior change against the live Beeminder API that can't be verified by unit tests under the repo's no-live-mutations rule. So this refactor sends **byte-identical requests**; only the plumbing collapses. Centralizing URL building can be a follow-up if desired.

## Result

- `client.go`: **630 → 497 lines** (−132; 91 insertions, 223 deletions).
- No interface change — `Client` and the `FakeClient` test double are untouched.
- Full suite green; `go vet` and `gofmt` clean.

## Review

Ran the local review loop (6 parallel agents): CLAUDE.md, bug scan, git history, comments, and security all clean. Security agent confirmed the standardized "include body in error" path still flows through `redactError`, so the auth token stays redacted. Added one targeted unit test for `apiStatusError` (both `Error()` branches + `errors.As` recovery) — the new type all 14 methods now depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTTP client error handling and JSON response processing across API endpoints for improved consistency.

* **Tests**
  * Added comprehensive tests verifying HTTP error status formatting, error type recovery, and endpoint-specific error attribution for JSON decode failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->