### PR TITLE
refactor(cli): extract auth preamble; make add/refresh/charge/deadline testable

### DIFF
--- a/add.go
+++ b/add.go
@@ -65,6 +65,7 @@ func parseAddArgs(args []string, readStdin func() (string, error), stdout, stder
 			return addRequest{}, 0, true
 		}
 		fmt.Fprintf(stderr, "Error parsing flags: %s\n", redactError(err))
+		fmt.Fprintln(stderr, addUsage)
 		return addRequest{}, 1, true
 	}
 

--- a/add.go
+++ b/add.go
@@ -5,160 +5,176 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 )
 
-// printAddUsageAndExit prints the usage for buzz add command and exits with code 1
-func printAddUsageAndExit(errorMsg string) {
-	fmt.Println("Error: " + errorMsg)
-	fmt.Println("Usage: buzz add [--requestid=<id>] [--daystamp=<date>] <goalslug> <value> [comment]")
-	fmt.Println("       echo \"<value>\" | buzz add [--requestid=<id>] [--daystamp=<date>] <goalslug> [comment]")
-	fmt.Println("")
-	fmt.Println("Note: Flags must come BEFORE positional arguments.")
-	fmt.Println("      Example: buzz add --daystamp=20240115 goalslug value comment")
-	fmt.Println("      The --daystamp flag accepts dates in YYYYMMDD format.")
-	os.Exit(1)
+const addUsage = `Usage: buzz add [--requestid=<id>] [--daystamp=<date>] <goalslug> <value> [comment]
+       echo "<value>" | buzz add [--requestid=<id>] [--daystamp=<date>] <goalslug> [comment]
+
+Note: Flags must come BEFORE positional arguments.
+      Example: buzz add --daystamp=20240115 goalslug value comment
+      The --daystamp flag accepts dates in YYYYMMDD format.`
+
+// addRequest is a fully-parsed, validated `buzz add` invocation, ready to send.
+type addRequest struct {
+	goalSlug  string
+	value     string // already converted to a decimal-hours string when a time
+	comment   string
+	daystamp  string // YYYYMMDD, or "" to use the current timestamp
+	requestid string
 }
 
-// handleAddCommand adds a datapoint to a goal without opening the TUI
+// handleAddCommand adds a datapoint to a goal without opening the TUI.
 func handleAddCommand() {
-	// Parse flags for the add command
+	req, code, done := parseAddArgs(os.Args[2:], readValueFromStdin, os.Stdout, os.Stderr)
+	if done {
+		os.Exit(code)
+	}
+
+	client, ok := loadClient(os.Stderr)
+	if !ok {
+		os.Exit(1)
+	}
+
+	code = runAddCommand(req, client, os.Stdout, os.Stderr)
+	if code == 0 {
+		fmt.Print(getUpdateMessage())
+	}
+	os.Exit(code)
+}
+
+// parseAddArgs parses and validates `buzz add` arguments, returning the resolved
+// request, a process exit code, and done=true when the caller should stop (help
+// shown, or a parse/validation error). readStdin is called lazily to read a
+// piped value only once the positional args warrant it, so `--help` and bad
+// input are reported without consuming stdin or requiring authentication.
+func parseAddArgs(args []string, readStdin func() (string, error), stdout, stderr io.Writer) (addRequest, int, bool) {
 	addFlags := flag.NewFlagSet("add", flag.ContinueOnError)
+	// Silence the flag package's own output; we print our own richer usage on
+	// both --help and parse errors.
+	addFlags.SetOutput(io.Discard)
 	requestid := addFlags.String("requestid", "", "Request ID for idempotency")
 	daystamp := addFlags.String("daystamp", "", "Date for the datapoint in YYYYMMDD format")
-	if err := addFlags.Parse(os.Args[2:]); err != nil {
+	if err := addFlags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			fmt.Println("Usage: buzz add [--requestid=<id>] [--daystamp=<date>] <goalslug> <value> [comment]")
-			fmt.Println("       echo \"<value>\" | buzz add [--requestid=<id>] [--daystamp=<date>] <goalslug> [comment]")
-			fmt.Println("")
-			fmt.Println("Note: Flags must come BEFORE positional arguments.")
-			fmt.Println("      The --daystamp flag accepts dates in YYYYMMDD format.")
-			return
+			fmt.Fprintln(stdout, addUsage)
+			return addRequest{}, 0, true
 		}
-		fmt.Fprintf(os.Stderr, "Error parsing flags: %s\n", redactError(err))
-		printAddUsageAndExit("Invalid flags")
+		fmt.Fprintf(stderr, "Error parsing flags: %s\n", redactError(err))
+		return addRequest{}, 1, true
 	}
 
-	// Get remaining positional arguments after flag parsing
-	args := addFlags.Args()
+	positional := addFlags.Args()
 
-	// Detect if known flags appear after positional arguments and warn the user
-	if misplacedFlag := detectMisplacedFlag(args); misplacedFlag != "" {
-		fmt.Fprintf(os.Stderr, "Warning: Flag '%s' appears after positional arguments and will be treated as part of the comment.\n", misplacedFlag)
-		fmt.Fprintf(os.Stderr, "Flags must come BEFORE positional arguments to be recognized.\n")
-		fmt.Fprintf(os.Stderr, "Correct usage: buzz add [--requestid=ID] [--daystamp=DATE] goalslug value comment\n")
-		fmt.Fprintln(os.Stderr, "")
+	// Detect if known flags appear after positional arguments and warn the user.
+	if misplacedFlag := detectMisplacedFlag(positional); misplacedFlag != "" {
+		fmt.Fprintf(stderr, "Warning: Flag '%s' appears after positional arguments and will be treated as part of the comment.\n", misplacedFlag)
+		fmt.Fprintf(stderr, "Flags must come BEFORE positional arguments to be recognized.\n")
+		fmt.Fprintf(stderr, "Correct usage: buzz add [--requestid=ID] [--daystamp=DATE] goalslug value comment\n")
+		fmt.Fprintln(stderr, "")
 	}
 
-	// Check arguments: buzz add <goalslug> <value> [comment]
-	// Value can also be piped via stdin: echo "123" | buzz add mygoal [comment]
-	if len(args) < 1 {
-		printAddUsageAndExit("Missing required arguments")
+	if len(positional) < 1 {
+		fmt.Fprintln(stderr, "Error: Missing required arguments")
+		fmt.Fprintln(stderr, addUsage)
+		return addRequest{}, 1, true
 	}
 
-	goalSlug := args[0]
+	goalSlug := positional[0]
 	var value string
-	var commentStartIndex int // Index where optional comment starts in args
+	var commentStartIndex int // index where the optional comment starts
 
-	// Try to read value from stdin first (for piped input)
-	stdinValue, err := readValueFromStdin()
+	// Try to read a value from stdin first (for piped input).
+	stdinValue, err := readStdin()
 	if err == nil && stdinValue != "" {
 		// Reject the ambiguous case where a value is piped AND a positional
-		// value is supplied — the previous behaviour silently took stdin and
-		// reinterpreted the positional as part of the comment, which could
-		// submit a different datapoint than the user intended for a write
-		// operation like `buzz add`.
-		if len(args) >= 2 {
-			printAddUsageAndExit("Provide value either via stdin or as a positional argument, not both")
+		// value is supplied — silently taking stdin could submit a different
+		// datapoint than the user intended for a write operation.
+		if len(positional) >= 2 {
+			fmt.Fprintln(stderr, "Error: Provide value either via stdin or as a positional argument, not both")
+			fmt.Fprintln(stderr, addUsage)
+			return addRequest{}, 1, true
 		}
-		// Value provided via stdin
 		value = stdinValue
-		commentStartIndex = 1 // Comment starts at index 1 when value is piped
-	} else if len(args) >= 2 {
-		// Value provided as argument
-		value = args[1]
-		commentStartIndex = 2 // Comment starts at index 2
+		commentStartIndex = 1
+	} else if len(positional) >= 2 {
+		value = positional[1]
+		commentStartIndex = 2
 	} else {
-		printAddUsageAndExit("Missing required value argument")
+		fmt.Fprintln(stderr, "Error: Missing required value argument")
+		fmt.Fprintln(stderr, addUsage)
+		return addRequest{}, 1, true
 	}
 
-	// Optional comment - default to "Added via buzz" if not provided
+	// Optional comment — default when not provided.
 	comment := "Added via buzz"
-	if len(args) >= commentStartIndex+1 {
-		comment = strings.Join(args[commentStartIndex:], " ")
+	if len(positional) >= commentStartIndex+1 {
+		comment = strings.Join(positional[commentStartIndex:], " ")
 	}
 
-	// Load config
-	if !ConfigExists() {
-		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
-		os.Exit(1)
-	}
-
-	config, err := LoadConfig()
-	if err != nil {
-		fmt.Printf("Error: Failed to load config: %s\n", redactError(err))
-		os.Exit(1)
-	}
-
-	client := NewHTTPClient(config)
-
-	// Parse and validate daystamp if provided
+	// Validate the daystamp format (YYYYMMDD) if provided.
 	var daystampForAPI string
 	if *daystamp != "" {
-		// Validate date format (YYYYMMDD)
-		_, err := time.Parse("20060102", *daystamp)
-		if err != nil {
-			fmt.Printf("Error: Invalid date format for --daystamp: %s (expected YYYYMMDD)\n", *daystamp)
-			os.Exit(1)
+		if _, err := time.Parse("20060102", *daystamp); err != nil {
+			fmt.Fprintf(stderr, "Error: Invalid date format for --daystamp: %s (expected YYYYMMDD)\n", *daystamp)
+			return addRequest{}, 1, true
 		}
 		daystampForAPI = *daystamp
 	}
 
-	// Use current time as timestamp (only used if daystamp is not provided)
-	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-
-	// Convert time format to decimal hours if needed
+	// Convert a time-format value (e.g. "1:30:00") to decimal hours.
 	if isTimeFormat(value) {
 		decimalValue, ok := timeToDecimalHours(value)
 		if !ok {
-			fmt.Printf("Error: Invalid time format: %s\n", value)
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error: Invalid time format: %s\n", value)
+			return addRequest{}, 1, true
 		}
 		value = fmt.Sprintf("%.6g", decimalValue)
 	}
 
-	// Validate value is a number
+	// Validate the value is a number.
 	if _, err := strconv.ParseFloat(value, 64); err != nil {
-		fmt.Printf("Error: Value must be a valid number, got: %s\n", value)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Value must be a valid number, got: %s\n", value)
+		return addRequest{}, 1, true
 	}
 
-	// Create the datapoint
-	_, err = client.CreateDatapointWithDaystamp(context.Background(), goalSlug, timestamp, daystampForAPI, value, comment, *requestid)
-	if err != nil {
-		fmt.Printf("Error: Failed to add datapoint: %s\n", redactError(err))
-		os.Exit(1)
+	return addRequest{
+		goalSlug:  goalSlug,
+		value:     value,
+		comment:   comment,
+		daystamp:  daystampForAPI,
+		requestid: *requestid,
+	}, 0, false
+}
+
+// runAddCommand submits the datapoint for an already-validated request and
+// returns the process exit code.
+func runAddCommand(req addRequest, client Client, stdout, stderr io.Writer) int {
+	// Use the current time as timestamp (only used when daystamp is empty).
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	if _, err := client.CreateDatapointWithDaystamp(context.Background(), req.goalSlug, timestamp, req.daystamp, req.value, req.comment, req.requestid); err != nil {
+		fmt.Fprintf(stderr, "Error: Failed to add datapoint: %s\n", redactError(err))
+		return 1
 	}
 
-	successMsg := fmt.Sprintf("Successfully added datapoint to %s: value=%s, comment=\"%s\"", goalSlug, value, comment)
-	if *daystamp != "" {
-		successMsg += fmt.Sprintf(", daystamp=%s", *daystamp)
+	successMsg := fmt.Sprintf("Successfully added datapoint to %s: value=%s, comment=\"%s\"", req.goalSlug, req.value, req.comment)
+	if req.daystamp != "" {
+		successMsg += fmt.Sprintf(", daystamp=%s", req.daystamp)
 	}
-	if *requestid != "" {
-		successMsg += fmt.Sprintf(", requestid=\"%s\"", *requestid)
+	if req.requestid != "" {
+		successMsg += fmt.Sprintf(", requestid=\"%s\"", req.requestid)
 	}
-	fmt.Println(successMsg)
+	fmt.Fprintln(stdout, successMsg)
 
 	// Signal any running TUI instances to refresh so they pick up the new
-	// datapoint.
+	// datapoint. Don't fail the command if flag creation fails.
 	if err := createRefreshFlag(); err != nil {
-		// Don't fail the command if flag creation fails
-		fmt.Fprintf(os.Stderr, "Warning: Could not create refresh flag: %s\n", redactError(err))
+		fmt.Fprintf(stderr, "Warning: Could not create refresh flag: %s\n", redactError(err))
 	}
-
-	// Check for updates and display message if available
-	fmt.Print(getUpdateMessage())
+	return 0
 }

--- a/charge.go
+++ b/charge.go
@@ -3,24 +3,38 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// handleChargeCommand creates a charge for the authenticated user
+// handleChargeCommand creates a charge for the authenticated user.
 func handleChargeCommand() {
-	// Usage: buzz charge <amount> <note> [--dryrun]
-	if len(os.Args) < 4 {
-		fmt.Fprintln(os.Stderr, "Error: Missing required arguments")
-		fmt.Fprintln(os.Stderr, "Usage: buzz charge <amount> <note> [--dryrun]")
+	client, ok := loadClient(os.Stderr)
+	if !ok {
 		os.Exit(1)
 	}
+	code := runChargeCommand(os.Args[2:], client, os.Stdout, os.Stderr)
+	if code == 0 {
+		fmt.Print(getUpdateMessage())
+	}
+	os.Exit(code)
+}
 
-	args := os.Args[2:]
+// runChargeCommand is the testable core of `buzz charge <amount> <note>
+// [--dryrun]`. It validates the amount and note, creates the charge, and
+// returns the process exit code.
+func runChargeCommand(args []string, client Client, stdout, stderr io.Writer) int {
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, "Error: Missing required arguments")
+		fmt.Fprintln(stderr, "Usage: buzz charge <amount> <note> [--dryrun]")
+		return 1
+	}
+
 	amountStr := args[0]
-	// Collect note parts and allow --dryrun anywhere after amount
+	// Collect note parts and allow --dryrun anywhere after amount.
 	dryrun := false
 	var noteParts []string
 	for _, a := range args[1:] {
@@ -32,58 +46,41 @@ func handleChargeCommand() {
 	}
 	note := strings.Join(noteParts, " ")
 	if strings.TrimSpace(note) == "" {
-		fmt.Fprintln(os.Stderr, "Error: Note is required")
-		fmt.Fprintln(os.Stderr, "Usage: buzz charge <amount> <note> [--dryrun]")
-		os.Exit(1)
+		fmt.Fprintln(stderr, "Error: Note is required")
+		fmt.Fprintln(stderr, "Usage: buzz charge <amount> <note> [--dryrun]")
+		return 1
 	}
 
-	// Validate amount is a number
+	// Validate amount is a number.
 	amount, err := strconv.ParseFloat(amountStr, 64)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Amount must be a valid number, got: %s\n", amountStr)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Amount must be a valid number, got: %s\n", amountStr)
+		return 1
 	}
 	// ParseFloat accepts "NaN"/"+Inf"/"-Inf"; reject those explicitly before
 	// the lower-bound check (NaN comparisons are always false, so NaN would
 	// otherwise sneak past `amount < 1.00` and reach the API).
 	if math.IsNaN(amount) || math.IsInf(amount, 0) {
-		fmt.Fprintf(os.Stderr, "Error: Amount must be a finite number, got: %s\n", amountStr)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Amount must be a finite number, got: %s\n", amountStr)
+		return 1
 	}
-
-	// Validate amount is >= 1.00
+	// Validate amount is >= 1.00.
 	if amount < 1.00 {
-		fmt.Fprintf(os.Stderr, "Error: Amount must be at least 1.00, got: %.2f\n", amount)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Amount must be at least 1.00, got: %.2f\n", amount)
+		return 1
 	}
 
-	// Load config
-	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
-		os.Exit(1)
-	}
-
-	config, err := LoadConfig()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to load config: %s\n", redactError(err))
-		os.Exit(1)
-	}
-
-	client := NewHTTPClient(config)
-
-	// Create the charge (API returns the created/dry-run charge)
+	// Create the charge (API returns the created/dry-run charge).
 	ch, err := client.CreateCharge(context.Background(), amount, note, dryrun)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to create charge: %s\n", redactError(err))
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Failed to create charge: %s\n", redactError(err))
+		return 1
 	}
 
 	if dryrun {
-		fmt.Printf("Dry run: Would charge $%.2f with note: %q for %s\n", ch.Amount, ch.Note, ch.Username)
+		fmt.Fprintf(stdout, "Dry run: Would charge $%.2f with note: %q for %s\n", ch.Amount, ch.Note, ch.Username)
 	} else {
-		fmt.Printf("Successfully created charge %s: $%.2f with note: %q for %s\n", ch.ID, ch.Amount, ch.Note, ch.Username)
+		fmt.Fprintf(stdout, "Successfully created charge %s: $%.2f with note: %q for %s\n", ch.ID, ch.Amount, ch.Note, ch.Username)
 	}
-
-	// Check for updates and display message if available
-	fmt.Print(getUpdateMessage())
+	return 0
 }

--- a/command.go
+++ b/command.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// loadClient runs the shared credential preamble for the authenticated CLI
+// commands: it confirms a config exists, loads it, and builds the API client.
+// On failure it writes the standard message to stderr and returns ok=false (the
+// caller should exit non-zero). Extracting it means the credentialed commands
+// stop repeating the ConfigExists → LoadConfig → NewHTTPClient dance, and their
+// real logic moves into testable run* cores that take a Client.
+func loadClient(stderr io.Writer) (Client, bool) {
+	if !ConfigExists() {
+		fmt.Fprintln(stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
+		return nil, false
+	}
+	config, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: Failed to load config: %s\n", redactError(err))
+		return nil, false
+	}
+	return NewHTTPClient(config), true
+}

--- a/command_test.go
+++ b/command_test.go
@@ -139,6 +139,22 @@ func TestParseAddArgs(t *testing.T) {
 			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
 		}
 	})
+
+	t.Run("flag after positionals warns and is absorbed into comment", func(t *testing.T) {
+		var errb bytes.Buffer
+		// A --daystamp after the positional args is not parsed as a flag; it
+		// warns and is treated as part of the comment.
+		req, code, done := parseAddArgs([]string{"goal", "42", "--daystamp=20240115"}, noStdin, &bytes.Buffer{}, &errb)
+		if done {
+			t.Fatalf("unexpected done (code=%d)", code)
+		}
+		if !strings.Contains(errb.String(), "appears after positional arguments") {
+			t.Errorf("expected misplaced-flag warning, stderr=%q", errb.String())
+		}
+		if req.daystamp != "" || req.comment != "--daystamp=20240115" {
+			t.Errorf("flag should be absorbed into comment, got daystamp=%q comment=%q", req.daystamp, req.comment)
+		}
+	})
 }
 
 func TestRunAddCommand(t *testing.T) {
@@ -266,6 +282,17 @@ func TestRunDeadlineCommand(t *testing.T) {
 		var out, errb bytes.Buffer
 		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000}, strings.NewReader("y\n"), client, &out, &errb)
 		if code != 1 || !strings.Contains(errb.String(), "Failed to fetch goal") {
+			t.Errorf("code=%d err=%q", code, errb.String())
+		}
+	})
+
+	t.Run("update error", func(t *testing.T) {
+		client := &FakeClient{
+			UpdateGoalDeadlineFunc: func(string, int) (*Goal, error) { return nil, errors.New("boom") },
+		}
+		var out, errb bytes.Buffer
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000, skipConfirm: true}, strings.NewReader(""), client, &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "Failed to update deadline") {
 			t.Errorf("code=%d err=%q", code, errb.String())
 		}
 	})

--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// noStdin simulates an unpiped stdin (readValueFromStdin's error path).
+func noStdin() (string, error) { return "", errors.New("stdin is not piped") }
+
+// pipedStdin simulates a piped value on stdin.
+func pipedStdin(v string) func() (string, error) {
+	return func() (string, error) { return v, nil }
+}
+
+func TestRunRefreshCommand(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		fn               func(string) (bool, error)
+		wantCode         int
+		wantOut, wantErr string
+	}{
+		{"missing arg", nil, nil, 1, "", "Missing required argument"},
+		{"too many args", []string{"a", "b"}, nil, 1, "", "Too many arguments"},
+		{"queued", []string{"g"}, func(string) (bool, error) { return true, nil }, 0, "Successfully queued refresh for goal: g", ""},
+		{"not queued", []string{"g"}, func(string) (bool, error) { return false, nil }, 0, "was not queued", ""},
+		{"api error", []string{"g"}, func(string) (bool, error) { return false, errors.New("boom") }, 1, "", "Failed to refresh goal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			code := runRefreshCommand(tt.args, &FakeClient{RefreshGoalFunc: tt.fn}, &out, &errb)
+			checkResult(t, code, out.String(), errb.String(), tt.wantCode, tt.wantOut, tt.wantErr)
+		})
+	}
+}
+
+func TestRunChargeCommand(t *testing.T) {
+	okCharge := func(amount float64, note string, _ bool) (*Charge, error) {
+		return &Charge{ID: "c1", Amount: amount, Note: note, Username: "u"}, nil
+	}
+	tests := []struct {
+		name             string
+		args             []string
+		fn               func(float64, string, bool) (*Charge, error)
+		wantCode         int
+		wantOut, wantErr string
+	}{
+		{"missing args", []string{"5"}, nil, 1, "", "Missing required arguments"},
+		{"bad amount", []string{"abc", "note"}, nil, 1, "", "must be a valid number"},
+		{"NaN amount", []string{"NaN", "note"}, nil, 1, "", "must be a finite number"},
+		{"below minimum", []string{"0.50", "note"}, nil, 1, "", "at least 1.00"},
+		{"empty note", []string{"5", "   "}, nil, 1, "", "Note is required"},
+		{"success", []string{"5", "my", "note"}, okCharge, 0, "Successfully created charge c1", ""},
+		{"dryrun anywhere", []string{"5", "note", "--dryrun"}, okCharge, 0, "Dry run: Would charge", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			code := runChargeCommand(tt.args, &FakeClient{CreateChargeFunc: tt.fn}, &out, &errb)
+			checkResult(t, code, out.String(), errb.String(), tt.wantCode, tt.wantOut, tt.wantErr)
+		})
+	}
+}
+
+func TestParseAddArgs(t *testing.T) {
+	t.Run("help to stdout, no error", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		_, code, done := parseAddArgs([]string{"-h"}, noStdin, &out, &errb)
+		if !done || code != 0 {
+			t.Fatalf("done=%v code=%d, want done=true code=0", done, code)
+		}
+		if !strings.Contains(out.String(), "Usage: buzz add") {
+			t.Errorf("help not printed to stdout: %q", out.String())
+		}
+	})
+
+	t.Run("positional value and comment", func(t *testing.T) {
+		req, _, done := parseAddArgs([]string{"goal", "42", "a", "note"}, noStdin, &bytes.Buffer{}, &bytes.Buffer{})
+		if done {
+			t.Fatal("unexpected done")
+		}
+		if req.goalSlug != "goal" || req.value != "42" || req.comment != "a note" {
+			t.Errorf("got %+v", req)
+		}
+	})
+
+	t.Run("piped value, default comment", func(t *testing.T) {
+		req, _, done := parseAddArgs([]string{"goal"}, pipedStdin("42"), &bytes.Buffer{}, &bytes.Buffer{})
+		if done {
+			t.Fatal("unexpected done")
+		}
+		if req.value != "42" || req.comment != "Added via buzz" {
+			t.Errorf("got %+v", req)
+		}
+	})
+
+	t.Run("piped and positional value rejected", func(t *testing.T) {
+		var errb bytes.Buffer
+		_, code, done := parseAddArgs([]string{"goal", "42"}, pipedStdin("99"), &bytes.Buffer{}, &errb)
+		if !done || code != 1 || !strings.Contains(errb.String(), "not both") {
+			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
+		}
+	})
+
+	t.Run("time-format value converted to decimal", func(t *testing.T) {
+		req, _, done := parseAddArgs([]string{"goal", "1:30:00"}, noStdin, &bytes.Buffer{}, &bytes.Buffer{})
+		if done {
+			t.Fatal("unexpected done")
+		}
+		if strings.Contains(req.value, ":") {
+			t.Errorf("time value not converted to decimal: %q", req.value)
+		}
+	})
+
+	t.Run("invalid daystamp", func(t *testing.T) {
+		var errb bytes.Buffer
+		_, code, done := parseAddArgs([]string{"--daystamp=2024", "goal", "42"}, noStdin, &bytes.Buffer{}, &errb)
+		if !done || code != 1 || !strings.Contains(errb.String(), "Invalid date format") {
+			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
+		}
+	})
+
+	t.Run("non-numeric value rejected", func(t *testing.T) {
+		var errb bytes.Buffer
+		_, code, done := parseAddArgs([]string{"goal", "notanumber"}, noStdin, &bytes.Buffer{}, &errb)
+		if !done || code != 1 || !strings.Contains(errb.String(), "must be a valid number") {
+			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
+		}
+	})
+
+	t.Run("missing value", func(t *testing.T) {
+		var errb bytes.Buffer
+		_, code, done := parseAddArgs([]string{"goal"}, noStdin, &bytes.Buffer{}, &errb)
+		if !done || code != 1 || !strings.Contains(errb.String(), "Missing required value") {
+			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
+		}
+	})
+}
+
+func TestRunAddCommand(t *testing.T) {
+	t.Run("success forwards request and reports daystamp/requestid", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir()) // contain createRefreshFlag's file write
+		var out, errb bytes.Buffer
+		var gotSlug, gotDaystamp, gotValue, gotComment, gotReqID string
+		client := &FakeClient{
+			CreateDatapointWithDaystampFunc: func(slug, _, daystamp, value, comment, requestid string) (*Datapoint, error) {
+				gotSlug, gotDaystamp, gotValue, gotComment, gotReqID = slug, daystamp, value, comment, requestid
+				return &Datapoint{}, nil
+			},
+		}
+		req := addRequest{goalSlug: "g", value: "42", comment: "hi", daystamp: "20240115", requestid: "r1"}
+		if code := runAddCommand(req, client, &out, &errb); code != 0 {
+			t.Fatalf("code=%d err=%q", code, errb.String())
+		}
+		if gotSlug != "g" || gotDaystamp != "20240115" || gotValue != "42" || gotComment != "hi" || gotReqID != "r1" {
+			t.Errorf("client got slug=%q daystamp=%q value=%q comment=%q reqid=%q", gotSlug, gotDaystamp, gotValue, gotComment, gotReqID)
+		}
+		o := out.String()
+		if !strings.Contains(o, "Successfully added datapoint to g") ||
+			!strings.Contains(o, "daystamp=20240115") ||
+			!strings.Contains(o, `requestid="r1"`) {
+			t.Errorf("stdout=%q", o)
+		}
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		var out, errb bytes.Buffer
+		client := &FakeClient{
+			CreateDatapointWithDaystampFunc: func(_, _, _, _, _, _ string) (*Datapoint, error) {
+				return nil, errors.New("boom")
+			},
+		}
+		code := runAddCommand(addRequest{goalSlug: "g", value: "1"}, client, &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "Failed to add datapoint") {
+			t.Errorf("code=%d err=%q", code, errb.String())
+		}
+	})
+}
+
+func TestParseDeadlineArgs(t *testing.T) {
+	t.Run("help", func(t *testing.T) {
+		var out bytes.Buffer
+		_, code, done := parseDeadlineArgs([]string{"-h"}, &out, &bytes.Buffer{})
+		if !done || code != 0 || !strings.Contains(out.String(), "buzz deadline") {
+			t.Errorf("done=%v code=%d out=%q", done, code, out.String())
+		}
+	})
+
+	t.Run("missing args", func(t *testing.T) {
+		var errb bytes.Buffer
+		_, code, done := parseDeadlineArgs([]string{"goal"}, &bytes.Buffer{}, &errb)
+		if !done || code != 1 || !strings.Contains(errb.String(), "Missing required arguments") {
+			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
+		}
+	})
+
+	t.Run("invalid time", func(t *testing.T) {
+		var errb bytes.Buffer
+		_, code, done := parseDeadlineArgs([]string{"goal", "notatime"}, &bytes.Buffer{}, &errb)
+		if !done || code != 1 {
+			t.Errorf("done=%v code=%d err=%q", done, code, errb.String())
+		}
+	})
+
+	t.Run("valid with --yes", func(t *testing.T) {
+		req, _, done := parseDeadlineArgs([]string{"--yes", "goal", "15:00"}, &bytes.Buffer{}, &bytes.Buffer{})
+		if done {
+			t.Fatal("unexpected done")
+		}
+		// offset is Beeminder's seconds-relative-to-midnight (15:00 → -32400);
+		// assert the slug/flag wiring and that a non-zero offset was parsed
+		// rather than re-deriving the deadline convention here.
+		if req.goalSlug != "goal" || !req.skipConfirm || req.offset == 0 {
+			t.Errorf("got %+v", req)
+		}
+	})
+}
+
+func TestRunDeadlineCommand(t *testing.T) {
+	updated := func(slug string, deadline int) (*Goal, error) {
+		return &Goal{Slug: slug, Deadline: deadline}, nil
+	}
+
+	t.Run("skip confirm updates without fetch", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		client := &FakeClient{UpdateGoalDeadlineFunc: updated} // FetchGoal unset → would error if called
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000, skipConfirm: true}, strings.NewReader(""), client, &out, &errb)
+		if code != 0 || !strings.Contains(out.String(), "Updated deadline for g") {
+			t.Errorf("code=%d out=%q err=%q", code, out.String(), errb.String())
+		}
+	})
+
+	t.Run("confirm yes fetches then updates", func(t *testing.T) {
+		fetched := false
+		client := &FakeClient{
+			FetchGoalFunc:          func(s string) (*Goal, error) { fetched = true; return &Goal{Slug: s}, nil },
+			UpdateGoalDeadlineFunc: updated,
+		}
+		var out, errb bytes.Buffer
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000}, strings.NewReader("y\n"), client, &out, &errb)
+		if code != 0 || !fetched || !strings.Contains(out.String(), "Updated deadline") {
+			t.Errorf("code=%d fetched=%v out=%q", code, fetched, out.String())
+		}
+	})
+
+	t.Run("decline cancels without updating", func(t *testing.T) {
+		updateCalled := false
+		client := &FakeClient{
+			FetchGoalFunc:          func(s string) (*Goal, error) { return &Goal{Slug: s}, nil },
+			UpdateGoalDeadlineFunc: func(string, int) (*Goal, error) { updateCalled = true; return &Goal{}, nil },
+		}
+		var out, errb bytes.Buffer
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000}, strings.NewReader("n\n"), client, &out, &errb)
+		if code != 0 || updateCalled || !strings.Contains(out.String(), "Cancelled") {
+			t.Errorf("code=%d updateCalled=%v out=%q", code, updateCalled, out.String())
+		}
+	})
+
+	t.Run("fetch error", func(t *testing.T) {
+		client := &FakeClient{FetchGoalFunc: func(string) (*Goal, error) { return nil, errors.New("boom") }}
+		var out, errb bytes.Buffer
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000}, strings.NewReader("y\n"), client, &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "Failed to fetch goal") {
+			t.Errorf("code=%d err=%q", code, errb.String())
+		}
+	})
+}
+
+// checkResult is a shared assertion for the table-driven run* command tests.
+func checkResult(t *testing.T, code int, out, errOut string, wantCode int, wantOut, wantErr string) {
+	t.Helper()
+	if code != wantCode {
+		t.Errorf("code = %d, want %d (stderr: %q)", code, wantCode, errOut)
+	}
+	if wantOut != "" && !strings.Contains(out, wantOut) {
+		t.Errorf("stdout = %q, want contains %q", out, wantOut)
+	}
+	if wantErr != "" && !strings.Contains(errOut, wantErr) {
+		t.Errorf("stderr = %q, want contains %q", errOut, wantErr)
+	}
+}

--- a/command_test.go
+++ b/command_test.go
@@ -15,6 +15,12 @@ func pipedStdin(v string) func() (string, error) {
 	return func() (string, error) { return v, nil }
 }
 
+// errReader is an io.Reader that always fails with a non-EOF error, for
+// exercising read-error handling in the confirmation prompt.
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
 func TestRunRefreshCommand(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -294,6 +300,34 @@ func TestRunDeadlineCommand(t *testing.T) {
 		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000, skipConfirm: true}, strings.NewReader(""), client, &out, &errb)
 		if code != 1 || !strings.Contains(errb.String(), "Failed to update deadline") {
 			t.Errorf("code=%d err=%q", code, errb.String())
+		}
+	})
+
+	t.Run("piped y without trailing newline confirms", func(t *testing.T) {
+		updateCalled := false
+		client := &FakeClient{
+			FetchGoalFunc:          func(s string) (*Goal, error) { return &Goal{Slug: s}, nil },
+			UpdateGoalDeadlineFunc: func(s string, d int) (*Goal, error) { updateCalled = true; return &Goal{Slug: s, Deadline: d}, nil },
+		}
+		var out, errb bytes.Buffer
+		// "y" with no newline → ReadString returns ("y", io.EOF); EOF content is
+		// still honored, so this confirms (matching the old Scanln behavior).
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000}, strings.NewReader("y"), client, &out, &errb)
+		if code != 0 || !updateCalled || !strings.Contains(out.String(), "Updated deadline") {
+			t.Errorf("code=%d updateCalled=%v out=%q", code, updateCalled, out.String())
+		}
+	})
+
+	t.Run("read error cancels without updating", func(t *testing.T) {
+		updateCalled := false
+		client := &FakeClient{
+			FetchGoalFunc:          func(s string) (*Goal, error) { return &Goal{Slug: s}, nil },
+			UpdateGoalDeadlineFunc: func(string, int) (*Goal, error) { updateCalled = true; return &Goal{}, nil },
+		}
+		var out, errb bytes.Buffer
+		code := runDeadlineCommand(deadlineRequest{goalSlug: "g", offset: 54000}, errReader{err: errors.New("disk gone")}, client, &out, &errb)
+		if code != 0 || updateCalled || !strings.Contains(out.String(), "Cancelled") {
+			t.Errorf("code=%d updateCalled=%v out=%q", code, updateCalled, out.String())
 		}
 	})
 }

--- a/deadline_cmd.go
+++ b/deadline_cmd.go
@@ -98,9 +98,16 @@ func runDeadlineCommand(req deadlineRequest, stdin io.Reader, client Client, std
 		fmt.Fprintf(stdout, "Change deadline for %s from %s to %s? [y/N] ",
 			req.goalSlug, formatDueTime(currentGoal.Deadline), formatDueTime(req.offset))
 
-		// EOF or empty input is treated as "no" so we never change a deadline
-		// without explicit consent.
-		line, _ := bufio.NewReader(stdin).ReadString('\n')
+		// A genuine read error cancels — we never change a deadline without
+		// explicit consent. io.EOF is normal for piped input, so its content is
+		// still evaluated: `printf y` with no trailing newline confirms (as the
+		// previous fmt.Scanln did), while empty input falls through to the
+		// y/yes check below and cancels.
+		line, err := bufio.NewReader(stdin).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			fmt.Fprintln(stdout, "Cancelled.")
+			return 0
+		}
 		response := strings.TrimSpace(strings.ToLower(line))
 		if response != "y" && response != "yes" {
 			fmt.Fprintln(stdout, "Cancelled.")

--- a/deadline_cmd.go
+++ b/deadline_cmd.go
@@ -1,101 +1,119 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
+const deadlineUsage = `Usage: buzz deadline [--yes|-y] <goalslug> <time>
+  <time> can be:
+    - 12-hour format: "3:00 PM", "11:30 AM"
+    - 24-hour format: "15:00", "23:30"`
+
+// deadlineRequest is a parsed, validated `buzz deadline` invocation.
+type deadlineRequest struct {
+	goalSlug    string
+	offset      int // seconds from midnight
+	skipConfirm bool
+}
+
 // handleDeadlineCommand changes the daily deadline for a goal. The wall-clock
 // time parsing and seconds-from-midnight conversion live in timestr.go.
 func handleDeadlineCommand() {
-	// Usage: buzz deadline [--yes] <goalslug> <time>
+	req, code, done := parseDeadlineArgs(os.Args[2:], os.Stdout, os.Stderr)
+	if done {
+		os.Exit(code)
+	}
+
+	client, ok := loadClient(os.Stderr)
+	if !ok {
+		os.Exit(1)
+	}
+
+	code = runDeadlineCommand(req, os.Stdin, client, os.Stdout, os.Stderr)
+	if code == 0 {
+		fmt.Print(getUpdateMessage())
+	}
+	os.Exit(code)
+}
+
+// parseDeadlineArgs parses and validates `buzz deadline` arguments, returning
+// the request, a process exit code, and done=true when the caller should stop
+// (help shown, or a parse/validation error). It touches no config or network,
+// so --help and bad input are handled without authentication.
+func parseDeadlineArgs(args []string, stdout, stderr io.Writer) (deadlineRequest, int, bool) {
 	deadlineFlags := flag.NewFlagSet("deadline", flag.ContinueOnError)
+	// Silence the flag package's own output; we print our own usage.
+	deadlineFlags.SetOutput(io.Discard)
 	yes := deadlineFlags.Bool("yes", false, "Skip confirmation prompt")
 	yesShort := deadlineFlags.Bool("y", false, "Skip confirmation prompt (shorthand)")
-	if err := deadlineFlags.Parse(os.Args[2:]); err != nil {
+	if err := deadlineFlags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			fmt.Fprintln(os.Stderr, "Usage: buzz deadline [--yes|-y] <goalslug> <time>")
-			fmt.Fprintln(os.Stderr, "  <time> can be:")
-			fmt.Fprintln(os.Stderr, "    - 12-hour format: \"3:00 PM\", \"11:30 AM\"")
-			fmt.Fprintln(os.Stderr, "    - 24-hour format: \"15:00\", \"23:30\"")
-			return
+			fmt.Fprintln(stdout, deadlineUsage)
+			return deadlineRequest{}, 0, true
 		}
-		fmt.Fprintf(os.Stderr, "Error parsing flags: %s\n", redactError(err))
-		fmt.Fprintln(os.Stderr, "Usage: buzz deadline [--yes|-y] <goalslug> <time>")
-		os.Exit(2)
+		fmt.Fprintf(stderr, "Error parsing flags: %s\n", redactError(err))
+		fmt.Fprintln(stderr, deadlineUsage)
+		return deadlineRequest{}, 2, true
 	}
 
-	args := deadlineFlags.Args()
-	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, "Error: Missing required arguments")
-		fmt.Fprintln(os.Stderr, "Usage: buzz deadline [--yes|-y] <goalslug> <time>")
-		fmt.Fprintln(os.Stderr, "  <time> can be:")
-		fmt.Fprintln(os.Stderr, "    - 12-hour format: \"3:00 PM\", \"11:30 AM\"")
-		fmt.Fprintln(os.Stderr, "    - 24-hour format: \"15:00\", \"23:30\"")
-		os.Exit(1)
+	rest := deadlineFlags.Args()
+	if len(rest) < 2 {
+		fmt.Fprintln(stderr, "Error: Missing required arguments")
+		fmt.Fprintln(stderr, deadlineUsage)
+		return deadlineRequest{}, 1, true
 	}
 
-	skipConfirm := *yes || *yesShort
-	goalSlug := args[0]
-	timeStr := strings.Join(args[1:], " ")
-
-	offset, err := parseTimeToDeadlineOffset(timeStr)
+	offset, err := parseTimeToDeadlineOffset(strings.Join(rest[1:], " "))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: %s\n", err)
+		return deadlineRequest{}, 1, true
 	}
 
-	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
-		os.Exit(1)
-	}
+	return deadlineRequest{
+		goalSlug:    rest[0],
+		offset:      offset,
+		skipConfirm: *yes || *yesShort,
+	}, 0, false
+}
 
-	config, err := LoadConfig()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to load config: %s\n", redactError(err))
-		os.Exit(1)
-	}
-
-	client := NewHTTPClient(config)
-
-	if !skipConfirm {
+// runDeadlineCommand applies the deadline change, prompting for confirmation on
+// stdin unless skipConfirm is set, and returns the process exit code.
+func runDeadlineCommand(req deadlineRequest, stdin io.Reader, client Client, stdout, stderr io.Writer) int {
+	if !req.skipConfirm {
 		// Fetch the current goal only when we actually need to render the
-		// confirmation prompt — with --yes set, the pre-fetch is just an
-		// extra API call that can fail before UpdateGoalDeadline gets a
-		// chance to run.
-		currentGoal, err := client.FetchGoal(context.Background(), goalSlug)
+		// confirmation prompt — with --yes set, the pre-fetch is just an extra
+		// API call that can fail before UpdateGoalDeadline gets a chance to run.
+		currentGoal, err := client.FetchGoal(context.Background(), req.goalSlug)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to fetch goal: %s\n", redactError(err))
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error: Failed to fetch goal: %s\n", redactError(err))
+			return 1
 		}
-		newTime := formatDueTime(offset)
-		currentTime := formatDueTime(currentGoal.Deadline)
-		fmt.Printf("Change deadline for %s from %s to %s? [y/N] ", goalSlug, currentTime, newTime)
-		var response string
-		if _, err := fmt.Scanln(&response); err != nil {
-			// EOF or read error in non-interactive contexts — treat as
-			// "no" so we never change a deadline without explicit consent.
-			fmt.Println("Cancelled.")
-			return
-		}
-		response = strings.TrimSpace(strings.ToLower(response))
+		fmt.Fprintf(stdout, "Change deadline for %s from %s to %s? [y/N] ",
+			req.goalSlug, formatDueTime(currentGoal.Deadline), formatDueTime(req.offset))
+
+		// EOF or empty input is treated as "no" so we never change a deadline
+		// without explicit consent.
+		line, _ := bufio.NewReader(stdin).ReadString('\n')
+		response := strings.TrimSpace(strings.ToLower(line))
 		if response != "y" && response != "yes" {
-			fmt.Println("Cancelled.")
-			return
+			fmt.Fprintln(stdout, "Cancelled.")
+			return 0
 		}
 	}
 
-	goal, err := client.UpdateGoalDeadline(context.Background(), goalSlug, offset)
+	goal, err := client.UpdateGoalDeadline(context.Background(), req.goalSlug, req.offset)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to update deadline: %s\n", redactError(err))
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Failed to update deadline: %s\n", redactError(err))
+		return 1
 	}
 
-	fmt.Printf("Updated deadline for %s to %s\n", goal.Slug, formatDueTime(goal.Deadline))
-
-	fmt.Print(getUpdateMessage())
+	fmt.Fprintf(stdout, "Updated deadline for %s to %s\n", goal.Slug, formatDueTime(goal.Deadline))
+	return 0
 }

--- a/refresh.go
+++ b/refresh.go
@@ -3,51 +3,47 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 )
 
-// handleRefreshCommand refreshes autodata for a goal
+// handleRefreshCommand refreshes autodata for a goal.
 func handleRefreshCommand() {
-	// Check arguments: buzz refresh <goalslug>
-	if len(os.Args) != 3 {
-		if len(os.Args) < 3 {
-			fmt.Println("Error: Missing required argument")
+	client, ok := loadClient(os.Stderr)
+	if !ok {
+		os.Exit(1)
+	}
+	code := runRefreshCommand(os.Args[2:], client, os.Stdout, os.Stderr)
+	if code == 0 {
+		fmt.Print(getUpdateMessage())
+	}
+	os.Exit(code)
+}
+
+// runRefreshCommand is the testable core of `buzz refresh`. It expects a single
+// <goalslug> argument, queues a refresh, and returns the process exit code.
+func runRefreshCommand(args []string, client Client, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		if len(args) < 1 {
+			fmt.Fprintln(stderr, "Error: Missing required argument")
 		} else {
-			fmt.Printf("Error: Too many arguments: %v\n", os.Args[3:])
+			fmt.Fprintf(stderr, "Error: Too many arguments: %v\n", args[1:])
 		}
-		fmt.Println("Usage: buzz refresh <goalslug>")
-		os.Exit(1)
+		fmt.Fprintln(stderr, "Usage: buzz refresh <goalslug>")
+		return 1
 	}
+	goalSlug := args[0]
 
-	goalSlug := os.Args[2]
-
-	// Load config
-	if !ConfigExists() {
-		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
-		os.Exit(1)
-	}
-
-	config, err := LoadConfig()
-	if err != nil {
-		fmt.Printf("Error: Failed to load config: %s\n", redactError(err))
-		os.Exit(1)
-	}
-
-	client := NewHTTPClient(config)
-
-	// Refresh the goal
 	queued, err := client.RefreshGoal(context.Background(), goalSlug)
 	if err != nil {
-		fmt.Printf("Error: Failed to refresh goal: %s\n", redactError(err))
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: Failed to refresh goal: %s\n", redactError(err))
+		return 1
 	}
 
 	if queued {
-		fmt.Printf("Successfully queued refresh for goal: %s\n", goalSlug)
+		fmt.Fprintf(stdout, "Successfully queued refresh for goal: %s\n", goalSlug)
 	} else {
-		fmt.Printf("Goal %s was not queued for refresh\n", goalSlug)
+		fmt.Fprintf(stdout, "Goal %s was not queued for refresh\n", goalSlug)
 	}
-
-	// Check for updates and display message if available
-	fmt.Print(getUpdateMessage())
+	return 0
 }


### PR DESCRIPTION
Closes #315 — second PR in the architecture refactor sequence (follows #321).

## Problem

The credentialed CLI commands each repeated the same preamble — `ConfigExists() → LoadConfig() → NewHTTPClient()`, each with its own `os.Exit(1)` — and buried `os.Exit`/`os.Args` deep in their logic, so `add`/`refresh`/`charge`/`deadline` had **no unit-test seam**. (`create`/`list`/`api` already split a testable `run*` core from a thin `handle*`; this brings the other four into line.)

## Change

- **`command.go`** — new `loadClient(stderr) (Client, bool)`: the shared auth preamble.
- **`refresh` / `charge`** — extract `runXCommand(args, client, stdout, stderr) int`.
- **`add` / `deadline`** (which have `--help`) — split into a `parseXArgs(...) (req, code, done)` step that runs **before** the preamble (so `--help` and bad input still work without a config) and a `runXCommand(req, …, client, …) int`. `add` takes a lazy `readStdin` func; `deadline` takes an injected stdin for its confirmation prompt.
- `handle*` wrappers are now: parse (if needed) → `loadClient` → run → print the update message on success → `os.Exit(code)`.
- **`command_test.go`** (new) — covers the previously-untestable validation and run logic across all four (arg parsing, piped-vs-positional value resolution, NaN/min-amount guards, daystamp/time-format validation, the confirm/decline/error paths, misplaced-flag absorption).

## Deliberate, minor behavior changes

1. For commands **without** a `--help` path (`refresh`/`charge`), the auth preamble now runs *before* positional-arg validation, so a no-config + bad-args invocation reports the auth error first. (`add`/`deadline` keep arg/`--help` handling before the preamble.)
2. Config-error and usage output now consistently go to **stderr**; `--help` goes to **stdout** (matching `api.go`'s convention).
3. A declined `deadline` confirmation returns exit 0, so the update-check message now prints after a cancel (it's empty unless an update is actually available).

## Result

- 6 files, +570/−232. `client`/`Client` interface untouched.
- Four commands now have real unit tests (`command_test.go`).
- Full suite green; `go vet` and `gofmt` clean.

## Review

Ran the local review loop (6 agents): security clean (auth-token redaction preserved through `loadClient`), no real bugs (arg-index parity and EOF handling verified), behavior confirmed parity-preserving against the pre-refactor code. Added two coverage tests the loop flagged.

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)