### PR TITLE
refactor(grid): extract a single grid-geometry module

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -27,13 +27,11 @@ func RenderGrid(goals []Goal, width, height, scrollRow, cursor int, hasNavigated
 	}
 	s += "\n\n"
 
-	// Calculate grid dimensions based on terminal width
-	cols := calculateColumns(width)
-	totalRows := (len(goals) + cols - 1) / cols
-
-	// Calculate visible rows based on terminal height
-	// Each cell is roughly 4 lines high (3 lines content + 1 line spacing)
-	maxVisibleRows := max(1, (height-4)/4) // -4 for header and footer
+	// Grid geometry (columns, total rows, visible rows) for this size.
+	layout := gridLayout(width, height, len(goals))
+	cols := layout.cols
+	totalRows := layout.totalRows
+	maxVisibleRows := layout.visibleRows
 
 	// Calculate which rows to display
 	startRow := scrollRow
@@ -79,9 +77,9 @@ func RenderGrid(goals []Goal, width, height, scrollRow, cursor int, hasNavigated
 // RenderFooter renders the footer with scroll and refresh information
 func RenderFooter(goals []Goal, width, height, scrollRow int, refreshActive bool) string {
 	// The footer with scroll information
-	footerCols := calculateColumns(width)
-	footerTotalRows := (len(goals) + footerCols - 1) / footerCols
-	footerMaxVisibleRows := max(1, (height-4)/4)
+	layout := gridLayout(width, height, len(goals))
+	footerTotalRows := layout.totalRows
+	footerMaxVisibleRows := layout.visibleRows
 
 	scrollInfo := ""
 	if footerTotalRows > footerMaxVisibleRows {

--- a/gridlayout.go
+++ b/gridlayout.go
@@ -1,0 +1,46 @@
+package main
+
+// Goal-grid geometry. The Browse grid lays goals out in fixed-size cells; these
+// constants and gridLayout are the single source of truth for its shape.
+// Rendering (grid.go), scroll math (utils.go), and navigation/hit-testing
+// (handlers.go) all read from here, so the cell-size and chrome dimensions live
+// in one place instead of being copy-pasted with a "must match" comment.
+const (
+	// gridCellWidth is the minimum terminal columns one cell occupies
+	// (~16 content + 2 border + 2 horizontal padding).
+	gridCellWidth = 20
+	// gridCellHeight is the terminal rows one cell occupies (3 content + 1
+	// spacing).
+	gridCellHeight = 4
+	// gridChromeRows is the rows reserved for the header and footer, excluded
+	// from the scrollable viewport when counting how many cell-rows are visible.
+	gridChromeRows = 4
+	// gridHeaderRows is the header height (title + blank line), used to offset a
+	// mouse-click Y coordinate into a grid row.
+	gridHeaderRows = 2
+)
+
+// gridGeometry is the Browse grid's layout for a given terminal size and goal
+// count. Construct it with gridLayout.
+type gridGeometry struct {
+	cols        int // columns that fit the width (>= 1)
+	totalRows   int // cell-rows needed to show every goal
+	visibleRows int // cell-rows visible at once given the height (>= 1)
+}
+
+// gridLayout computes the grid geometry for the given terminal width/height and
+// number of goals.
+func gridLayout(width, height, goalCount int) gridGeometry {
+	cols := calculateColumns(width)
+	return gridGeometry{
+		cols:        cols,
+		totalRows:   (goalCount + cols - 1) / cols,
+		visibleRows: max(1, (height-gridChromeRows)/gridCellHeight),
+	}
+}
+
+// calculateColumns returns how many cells fit across the given terminal width,
+// always at least 1.
+func calculateColumns(width int) int {
+	return max(1, width/gridCellWidth)
+}

--- a/gridlayout_test.go
+++ b/gridlayout_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestGridLayout(t *testing.T) {
+	tests := []struct {
+		name                             string
+		width, height, goalCount         int
+		wantCols, wantTotalRows, wantVis int
+	}{
+		{"typical 80x24", 80, 24, 10, 4, 3, 5},         // 4 cols, ceil(10/4)=3, (24-4)/4=5
+		{"single column", 20, 8, 3, 1, 3, 1},           // 1 col, 3 rows, (8-4)/4=1
+		{"narrow clamps cols to 1", 5, 24, 3, 1, 3, 5}, // width<cell → 1 col
+		{"no goals → zero total rows", 80, 24, 0, 4, 0, 5},
+		{"short height clamps visible to 1", 80, 4, 5, 4, 2, 1}, // (4-4)/4=0 → max(1,..)=1
+		{"height below chrome stays 1", 80, 3, 5, 4, 2, 1},      // (3-4)/4=0 → 1
+		{"zero size stays sane", 0, 0, 0, 1, 0, 1},
+		{"exact fill", 40, 12, 6, 2, 3, 2}, // 2 cols, ceil(6/2)=3, (12-4)/4=2
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gridLayout(tt.width, tt.height, tt.goalCount)
+			if g.cols != tt.wantCols || g.totalRows != tt.wantTotalRows || g.visibleRows != tt.wantVis {
+				t.Errorf("gridLayout(%d,%d,%d) = {cols:%d totalRows:%d visibleRows:%d}, want {cols:%d totalRows:%d visibleRows:%d}",
+					tt.width, tt.height, tt.goalCount,
+					g.cols, g.totalRows, g.visibleRows,
+					tt.wantCols, tt.wantTotalRows, tt.wantVis)
+			}
+		})
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -546,10 +546,8 @@ func handleScrollUp(m model) (tea.Model, tea.Cmd) {
 func handleScrollDown(m model) (tea.Model, tea.Cmd) {
 	if m.appModel.mode == modeBrowse {
 		displayGoals := m.appModel.getDisplayGoals()
-		cols := calculateColumns(m.appModel.width)
-		totalRows := (len(displayGoals) + cols - 1) / cols
-		maxVisibleRows := max(1, (m.appModel.height-4)/4) // Rough estimate of rows that fit
-		if m.appModel.scrollRow < totalRows-maxVisibleRows {
+		layout := gridLayout(m.appModel.width, m.appModel.height, len(displayGoals))
+		if m.appModel.scrollRow < layout.totalRows-layout.visibleRows {
 			m.appModel.scrollRow++
 		}
 	}
@@ -600,18 +598,14 @@ func handleMouseClick(m model, msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Calculate which goal was clicked based on coordinates
-	// Header is 2 lines (title + empty line), so content starts at line 2 (0-indexed)
-	headerHeight := 2
-	clickRow := msg.Y - headerHeight
-
-	// Each grid cell is 4 lines high (3 lines content + 1 line spacing)
-	cellHeight := 4
+	// Calculate which goal was clicked based on coordinates. The header offset
+	// and cell height come from the shared grid geometry (gridlayout.go).
+	clickRow := msg.Y - gridHeaderRows
 	if clickRow < 0 {
 		// Clicked on header area
 		return m, nil
 	}
-	gridRow := clickRow / cellHeight
+	gridRow := clickRow / gridCellHeight
 
 	// Calculate column based on terminal width
 	cols := calculateColumns(m.appModel.width)

--- a/utils.go
+++ b/utils.go
@@ -54,24 +54,6 @@ func redactError(err error) string {
 	return redactAuthToken(err.Error())
 }
 
-// calculateColumns determines the optimal number of columns based on terminal width
-func calculateColumns(width int) int {
-	// Each cell needs approximately:
-	// - 16 chars for content (inner width)
-	// - 2 chars for left/right borders
-	// - 2 chars for horizontal padding
-	// Total: ~20 chars per cell
-	const minCellWidth = 20
-	const minCols = 1
-
-	if width < minCellWidth {
-		return minCols
-	}
-
-	cols := width / minCellWidth
-	return max(minCols, cols)
-}
-
 // truncateString truncates a string to maxLen characters
 func truncateString(s string, maxLen int) string {
 	if len(s) <= maxLen {
@@ -252,17 +234,9 @@ func ensureRowVisible(selectedRow, firstRow, visibleRows, totalRows int) int {
 // updateScrollForCursor adjusts scrollRow to keep the cursor visible after navigation
 // This function should be called after cursor changes from arrow key navigation
 func updateScrollForCursor(m *model, displayLen int) {
-	cols := calculateColumns(m.appModel.width)
-	if cols < 1 {
-		cols = 1
-	}
-	totalRows := (displayLen + cols - 1) / cols
-	visibleRows := max(1, (m.appModel.height-4)/4) // Must match grid.go calculation
-	selRow := 0
-	if cols > 0 {
-		selRow = m.appModel.cursor / cols
-	}
-	m.appModel.scrollRow = ensureRowVisible(selRow, m.appModel.scrollRow, visibleRows, totalRows)
+	layout := gridLayout(m.appModel.width, m.appModel.height, displayLen)
+	selRow := m.appModel.cursor / layout.cols
+	m.appModel.scrollRow = ensureRowVisible(selRow, m.appModel.scrollRow, layout.visibleRows, layout.totalRows)
 }
 
 // readValueFromStdin reads a value from stdin if it's being piped (non-interactive input)


### PR DESCRIPTION
Closes #316 — third PR in the architecture refactor sequence (follows #321, #322).

## Problem

The Browse grid's layout math was copy-pasted across four sites:
- **columns**: `calculateColumns(width)` (already one function — fine)
- **total rows**: `(n + cols - 1) / cols` — in `RenderGrid`, `RenderFooter`, `updateScrollForCursor`, `handleScrollDown`
- **visible rows**: `max(1, (height-4)/4)` — same four sites, with `utils.go` literally carrying a `// Must match grid.go calculation` comment
- **magic numbers**: the cell height (`/4`), header+footer reserve (`-4`), and the mouse hit-test's `headerHeight := 2` / `cellHeight := 4`

Changing the cell height meant hunting through three files and hoping they stayed in sync by hand.

## Change

New **`gridlayout.go`**:
- Named constants: `gridCellWidth` (20), `gridCellHeight` (4), `gridChromeRows` (4), `gridHeaderRows` (2) — each documenting what the old scattered literals meant.
- `gridLayout(width, height, goalCount) → gridGeometry{cols, totalRows, visibleRows}` — the single source of truth.
- `calculateColumns` moves here and shares `gridCellWidth` (its `if width<20` special case collapses cleanly to `max(1, width/gridCellWidth)`).

Every renderer / scroll / navigation / hit-test site now reads from `gridLayout`. The `(n+cols-1)/cols` ceil-formula and the `max(1,(height-4)/4)` clamp now exist in exactly one place.

## Why it's better

- **Locality**: the cell-size and chrome dimensions live in one file; the "keep these in sync by hand" coupling (previously a comment) is gone.
- **Testability**: `gridlayout_test.go` tests the geometry directly — multi/single column, zero goals, tiny/zero width, and the height-at/below-chrome cases where `visibleRows` clamps to 1 — instead of it being observable only through rendered output.
- A defensive `if cols < 1` guard in `updateScrollForCursor` is removed because `gridLayout` guarantees `cols >= 1` by construction.

## Result

- 5 files, +94/−51. No behavior change (pure refactor).
- `TestGridLayout` added; existing `TestCalculateColumns` still passes (confirms the moved/simplified function is equivalent).
- Full suite green; `go vet` and `gofmt` clean.

## Review

Local review loop: behavior parity verified at every converted site, comments preserved, and `git blame` confirmed the removed `cols<1` guard is safe under the new invariant. No findings.

Refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal grid layout calculations for improved code maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->