### PR TITLE
refactor: vend tomorrow-view baremin + losedate as one pair (#318)

### DIFF
--- a/filtered.go
+++ b/filtered.go
@@ -14,7 +14,8 @@ import (
 // Filtered list views: `buzz all`, `buzz today`, `buzz tomorrow`, `buzz due`,
 // `buzz less`. They share an orchestration helper (load → filter → sort →
 // render via the goaltable.Table) and a small family of filter predicates +
-// tomorrow-view baremin bumping helpers.
+// the tomorrow-view projection (goalByEndOfTomorrowAt), which bumps both
+// baremin and losedate together for due-today goals.
 
 // isDoLessFilter returns true if the goal is a do-less type goal
 func isDoLessFilter(g Goal) bool {

--- a/filtered.go
+++ b/filtered.go
@@ -44,12 +44,24 @@ func handleTodayCommand() {
 // bumped baremin is what's needed by *tomorrow's* deadline, not today's.
 func handleTomorrowCommand() {
 	now := time.Now()
+	// Memoize the vended pair per goal: losedateFor is called O(n log n) times
+	// while sorting and again per deadline column, and each goalByEndOfTomorrowAt
+	// runs the relatively expensive bumpedBaremin projection (string parsing +
+	// roadall slope lookup). Caching by slug computes it once per goal. Both
+	// columns still derive from the same pair, so the bumped baremin and bumped
+	// losedate can't disagree (see goalByEndOfTomorrowAt).
+	views := make(map[string]tomorrowView)
+	viewFor := func(g Goal) tomorrowView {
+		if v, ok := views[g.Slug]; ok {
+			return v
+		}
+		v := goalByEndOfTomorrowAt(g, now)
+		views[g.Slug] = v
+		return v
+	}
 	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
-	// Both columns derive from the same vended pair, so the bumped baremin and
-	// the bumped losedate share the due-today gate and `now` by construction —
-	// they can't disagree (see goalByEndOfTomorrowAt).
-	bareminFor := func(g Goal) string { return goalByEndOfTomorrowAt(g, now).baremin }
-	losedateFor := func(g Goal) int64 { return goalByEndOfTomorrowAt(g, now).losedate }
+	bareminFor := func(g Goal) string { return viewFor(g).baremin }
+	losedateFor := func(g Goal) int64 { return viewFor(g).losedate }
 	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor)
 }
 

--- a/filtered.go
+++ b/filtered.go
@@ -44,8 +44,11 @@ func handleTodayCommand() {
 func handleTomorrowCommand() {
 	now := time.Now()
 	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
-	bareminFor := func(g Goal) string { return bareminByEndOfTomorrowAt(g, now) }
-	losedateFor := func(g Goal) int64 { return losedateByEndOfTomorrowAt(g, now) }
+	// Both columns derive from the same vended pair, so the bumped baremin and
+	// the bumped losedate share the due-today gate and `now` by construction —
+	// they can't disagree (see goalByEndOfTomorrowAt).
+	bareminFor := func(g Goal) string { return goalByEndOfTomorrowAt(g, now).baremin }
+	losedateFor := func(g Goal) int64 { return goalByEndOfTomorrowAt(g, now).losedate }
 	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor)
 }
 
@@ -178,17 +181,48 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 	fmt.Print(getUpdateMessage())
 }
 
-// Tomorrow-view baremin bumping helpers. They project a goal's "what's needed
+// tomorrowView is the pair a goal shows in the "due tomorrow" view: the baremin
+// string and the losedate timestamp. The two are vended together so they always
+// reflect the same horizon — a bumped amount never appears beside an un-bumped
+// deadline, or vice-versa.
+type tomorrowView struct {
+	baremin  string
+	losedate int64
+}
+
+// goalByEndOfTomorrowAt vends the baremin and losedate a goal should show in the
+// "due tomorrow" view, projected to tomorrow's deadline. The due-today gate and
+// `now` are evaluated once here, so the two fields can't disagree — the
+// coupling the caller previously had to enforce by wiring two closures
+// identically now holds by construction.
+//
+// A goal due *later today* is bumped: its baremin gains one day's worth of rate
+// (so the amount reflects what's required to avoid a beemergency tomorrow) and
+// its losedate advances one calendar day. A goal not due later today — overdue
+// (losedate already past) or already due tomorrow-or-later — is left as-is:
+// baremin reflects what the API reports for tomorrow's deadline already, and
+// keeping the real losedate preserves the OVERDUE indicator. See bumpedBaremin
+// for the baremin projection and dueLaterTodayAt for the gate.
+func goalByEndOfTomorrowAt(g Goal, now time.Time) tomorrowView {
+	if !dueLaterTodayAt(g, now) {
+		return tomorrowView{baremin: stripTimeWindowSuffix(g.Baremin), losedate: g.Losedate}
+	}
+	// Advance the deadline by one calendar day in the caller's local zone so the
+	// displayed wall-clock deadline stays correct across DST transitions.
+	losedate := time.Unix(g.Losedate, 0).In(now.Location()).AddDate(0, 0, 1).Unix()
+	return tomorrowView{baremin: bumpedBaremin(g, now), losedate: losedate}
+}
+
+// Tomorrow-view baremin bumping. bumpedBaremin projects a goal's "what's needed
 // by tomorrow's deadline" baremin string from the API's "what's needed by
 // today's deadline" string, by adding one day's worth of rate. Beeminder's
 // `dueby` map already carries pre-rounded per-daystamp deltas; we use that
 // when available and fall back to local arithmetic otherwise.
 
-// bareminByEndOfTomorrowAt returns the baremin string to display for a goal in
-// the "due tomorrow" view. For goals already due tomorrow, the goal's existing
-// Baremin string is returned (it already reflects what's needed by tomorrow's
-// deadline). For goals due today, one day's worth of rate is added so the
-// displayed amount reflects what's required to avoid a beemergency tomorrow.
+// bumpedBaremin returns the bumped baremin string for a goal due later today,
+// adding one day's worth of rate so the displayed amount reflects what's
+// required to avoid a beemergency tomorrow. It assumes the due-today gate has
+// already passed (goalByEndOfTomorrowAt is the only caller).
 //
 // The per-day slope is taken from the bright-line segment containing `now`
 // (via roadall) rather than from g.Rate, because g.Rate reports the goal's
@@ -205,10 +239,7 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 // string never carries that qualifier (e.g. " in 1 day", " within 1 day",
 // " today") — every row in the tomorrow view shares the same horizon, so
 // the suffix is just noise.
-func bareminByEndOfTomorrowAt(g Goal, now time.Time) string {
-	if !dueLaterTodayAt(g, now) {
-		return stripTimeWindowSuffix(g.Baremin)
-	}
+func bumpedBaremin(g Goal, now time.Time) string {
 	if bumped, ok := bareminFromDueby(g, now); ok {
 		return stripTimeWindowSuffix(bumped)
 	}
@@ -306,18 +337,4 @@ func todayDaystampFor(g Goal, now time.Time) string {
 func tomorrowDaystampFor(g Goal, now time.Time) string {
 	today, _ := time.ParseInLocation("20060102", todayDaystampFor(g, now), now.Location())
 	return today.AddDate(0, 0, 1).Format("20060102")
-}
-
-// losedateByEndOfTomorrowAt returns the deadline timestamp to display for a
-// goal in the tomorrow view. For goals due later today (whose baremin we're
-// bumping by one day's rate), advance the deadline by one calendar day in
-// the caller's local zone so the displayed wall-clock deadline stays correct
-// across DST transitions. Overdue goals (losedate already in the past) keep
-// their own losedate so the OVERDUE indicator remains visible — bumping them
-// would silently hide the fact that they've already derailed.
-func losedateByEndOfTomorrowAt(g Goal, now time.Time) int64 {
-	if !dueLaterTodayAt(g, now) {
-		return g.Losedate
-	}
-	return time.Unix(g.Losedate, 0).In(now.Location()).AddDate(0, 0, 1).Unix()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -504,9 +504,9 @@ func TestBareminByEndOfTomorrowAt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := bareminByEndOfTomorrowAt(tt.goal, now)
+			got := goalByEndOfTomorrowAt(tt.goal, now).baremin
 			if got != tt.expected {
-				t.Errorf("bareminByEndOfTomorrowAt = %q, want %q", got, tt.expected)
+				t.Errorf("goalByEndOfTomorrowAt().baremin = %q, want %q", got, tt.expected)
 			}
 		})
 	}
@@ -626,9 +626,9 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := losedateByEndOfTomorrowAt(tt.goal, now)
+			got := goalByEndOfTomorrowAt(tt.goal, now).losedate
 			if got != tt.expected {
-				t.Errorf("losedateByEndOfTomorrowAt = %d, want %d (diff %d seconds)",
+				t.Errorf("goalByEndOfTomorrowAt().losedate = %d, want %d (diff %d seconds)",
 					got, tt.expected, got-tt.expected)
 			}
 		})
@@ -646,10 +646,10 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 		// 5:59 PM the day before spring-forward (2025-03-09).
 		losedate := time.Date(2025, 3, 8, 17, 59, 0, 0, ny)
 		nowDST := time.Date(2025, 3, 8, 14, 0, 0, 0, ny)
-		got := losedateByEndOfTomorrowAt(Goal{Losedate: losedate.Unix()}, nowDST)
+		got := goalByEndOfTomorrowAt(Goal{Losedate: losedate.Unix()}, nowDST).losedate
 		want := time.Date(2025, 3, 9, 17, 59, 0, 0, ny).Unix()
 		if got != want {
-			t.Errorf("DST losedateByEndOfTomorrowAt = %d, want %d (diff %d seconds)",
+			t.Errorf("DST goalByEndOfTomorrowAt().losedate = %d, want %d (diff %d seconds)",
 				got, want, got-want)
 		}
 		// Sanity: a naive +86400 would land at the wrong wall-clock hour
@@ -666,7 +666,7 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 // order of goals if we don't resort using the same losedateFor projection.
 func TestSortGoalsByDisplayedLosedate(t *testing.T) {
 	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
-	losedateFor := func(g Goal) int64 { return losedateByEndOfTomorrowAt(g, now) }
+	losedateFor := func(g Goal) int64 { return goalByEndOfTomorrowAt(g, now).losedate }
 
 	// Goal A: due today at 11 PM → displays as tomorrow 11 PM
 	// Goal B: due tomorrow at 9 AM → displays as tomorrow 9 AM (earlier)
@@ -690,7 +690,7 @@ func TestSortGoalsByDisplayedLosedate(t *testing.T) {
 }
 
 // TestParseTimeValue verifies the colon-separated time parser used by
-// bareminByEndOfTomorrowAt for HH:MM and HH:MM:SS baremin values.
+// bumpedBaremin for HH:MM and HH:MM:SS baremin values.
 func TestParseTimeValue(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/main_test.go
+++ b/main_test.go
@@ -249,10 +249,10 @@ func TestRatePerDay(t *testing.T) {
 	}
 }
 
-// TestBareminByEndOfTomorrowAt verifies that due-today goals get their baremin
+// TestGoalByEndOfTomorrowAtBaremin verifies that due-today goals get their baremin
 // bumped by one day's worth of rate, while goals due tomorrow (or later) are
 // returned unchanged.
-func TestBareminByEndOfTomorrowAt(t *testing.T) {
+func TestGoalByEndOfTomorrowAtBaremin(t *testing.T) {
 	f := func(v float64) *float64 { return &v }
 	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
 	todayDeadline := time.Date(2025, 1, 15, 23, 0, 0, 0, time.UTC).Unix()
@@ -572,11 +572,11 @@ func piecewiseRoadall(startT int64, startV float64, segments ...float64) [][]*fl
 	return rows
 }
 
-// TestLosedateByEndOfTomorrowAt verifies that due-today goals get their
+// TestGoalByEndOfTomorrowAtLosedate verifies that due-today goals get their
 // displayed deadline advanced by one calendar day in the tomorrow view (in
 // the caller's local zone, so DST transitions stay aligned), while goals
 // already due tomorrow or later keep their own losedate.
-func TestLosedateByEndOfTomorrowAt(t *testing.T) {
+func TestGoalByEndOfTomorrowAtLosedate(t *testing.T) {
 	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
 	todayDeadline := time.Date(2025, 1, 15, 17, 59, 0, 0, time.UTC).Unix()
 	tomorrowDeadline := time.Date(2025, 1, 16, 17, 59, 0, 0, time.UTC).Unix()

--- a/main_test.go
+++ b/main_test.go
@@ -660,6 +660,60 @@ func TestLosedateByEndOfTomorrowAt(t *testing.T) {
 	})
 }
 
+// TestGoalByEndOfTomorrowAtPairsBareminAndLosedate pins the invariant the whole
+// refactor exists to guarantee: baremin and losedate are vended from a single
+// due-today gate evaluation, so they move together. Either both reflect the
+// one-day bump (due-later-today) or neither does (due tomorrow-or-later, or
+// overdue). Reading both fields off one call makes a re-split of the gate —
+// bumping one field but not the other — fail here.
+func TestGoalByEndOfTomorrowAtPairsBareminAndLosedate(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	todayDeadline := time.Date(2025, 1, 15, 23, 0, 0, 0, time.UTC).Unix()
+	tomorrowDeadline := time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC).Unix()
+	overdue := time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC).Unix() // before now
+
+	// Due later today: BOTH fields bump. Baremin +1 → +2, losedate advances one
+	// calendar day in the local zone.
+	t.Run("due later today bumps both", func(t *testing.T) {
+		g := Goal{Losedate: todayDeadline, Baremin: "+1 today", Rate: f(1), Runits: "d"}
+		view := goalByEndOfTomorrowAt(g, now)
+		wantLosedate := time.Unix(todayDeadline, 0).In(now.Location()).AddDate(0, 0, 1).Unix()
+		if view.baremin != "+2" {
+			t.Errorf("baremin = %q, want %q", view.baremin, "+2")
+		}
+		if view.losedate != wantLosedate {
+			t.Errorf("losedate = %d, want %d (advanced one day)", view.losedate, wantLosedate)
+		}
+	})
+
+	// Due tomorrow already: NEITHER field bumps. Baremin only loses its window
+	// suffix; losedate is unchanged.
+	t.Run("due tomorrow bumps neither", func(t *testing.T) {
+		g := Goal{Losedate: tomorrowDeadline, Baremin: "+3 in 1 day", Rate: f(1), Runits: "d"}
+		view := goalByEndOfTomorrowAt(g, now)
+		if view.baremin != "+3" {
+			t.Errorf("baremin = %q, want %q (suffix stripped, not bumped)", view.baremin, "+3")
+		}
+		if view.losedate != tomorrowDeadline {
+			t.Errorf("losedate = %d, want %d (unchanged)", view.losedate, tomorrowDeadline)
+		}
+	})
+
+	// Overdue: NEITHER field bumps. The losedate stays in the past so the
+	// OVERDUE indicator survives; baremin only loses its window suffix.
+	t.Run("overdue bumps neither", func(t *testing.T) {
+		g := Goal{Losedate: overdue, Baremin: "+1 today", Rate: f(1), Runits: "d"}
+		view := goalByEndOfTomorrowAt(g, now)
+		if view.baremin != "+1" {
+			t.Errorf("baremin = %q, want %q (suffix stripped, not bumped)", view.baremin, "+1")
+		}
+		if view.losedate != overdue {
+			t.Errorf("losedate = %d, want %d (unchanged, stays overdue)", view.losedate, overdue)
+		}
+	})
+}
+
 // TestSortGoalsByDisplayedLosedate locks in the rule that rows render in the
 // order the user actually sees in the deadline column. The tomorrow view
 // bumps due-today losedates by one calendar day, which can flip the relative


### PR DESCRIPTION
Closes #318.

## Problem

The tomorrow view's bumped **baremin** and bumped **losedate** were computed by two independent functions — `bareminByEndOfTomorrowAt` and `losedateByEndOfTomorrowAt` — each re-evaluating the same `dueLaterTodayAt(g, now)` gate. They were wired as two separate closures in `handleTomorrowCommand` and **had** to be called with the same `now` and gate or they'd silently disagree: a goal showing a bumped amount beside an un-bumped deadline, or vice-versa. The coupling was real but unexpressed — enforced only by the caller remembering to wire both closures identically.

## Solution

A single `goalByEndOfTomorrowAt(g, now)` that returns a `tomorrowView{baremin, losedate}`. The due-today gate and `now` are evaluated **once**, so the pair can't disagree by construction:

- **Due later today** → both bump: baremin gains one day's rate (via the existing `bumpedBaremin` helper), losedate advances one calendar day (DST-safe `AddDate(0,0,1)` in the local zone).
- **Not due later today** (overdue, or already due tomorrow-or-later) → neither bumps: baremin is the suffix-stripped original, losedate stays as-is so the OVERDUE indicator survives.

The baremin-bump body moved verbatim into the private `bumpedBaremin` helper (called only after the gate passes). `handleTomorrowCommand`'s two display closures now both derive from the vended pair.

## Tests

- The existing `TestBareminByEndOfTomorrowAt` / `TestLosedateByEndOfTomorrowAt` tables now read `.baremin` / `.losedate` off the struct — **every prior case preserved**.
- New `TestGoalByEndOfTomorrowAtPairsBareminAndLosedate` reads **both** fields off a single call across all three gate branches (due-later-today bumps both; due-tomorrow and overdue bump neither), pinning the coupling so a future re-split of the gate fails here.

Behavior-preserving refactor: net **+72 / −37** across `filtered.go` and `main_test.go`. `go build`, `go vet`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the "tomorrow" view by synchronizing baremin and losedate calculations from a single source, preventing potential inconsistencies between these columns.

* **Tests**
  * Updated test assertions and added validation to ensure baremin and losedate remain synchronized across different deadline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->