### PR TITLE
feat(tomorrow): flag goals with a malformed bright red line (#325)

### DIFF
--- a/filtered.go
+++ b/filtered.go
@@ -204,19 +204,22 @@ type tomorrowView struct {
 	losedate int64
 	// roadMalformed is true when parseRoad rejected the goal's roadall. The
 	// bump silently falls back to g.Rate in that case (slopePerDayAt stays
-	// tolerant), so the view flags it with a ⚠ rather than presenting a
-	// fallback number as if it were authoritative. An absent road (benign,
-	// "not populated") is NOT malformed and carries no marker. See ADR-0003.
+	// tolerant), so the view flags it with a "(!) " marker rather than
+	// presenting a fallback number as if it were authoritative. An absent road
+	// (benign, "not populated") is NOT malformed and carries no marker. See
+	// ADR-0003.
 	roadMalformed bool
 }
 
 // markedBaremin is the baremin string the tomorrow view prints, prefixed with a
-// ⚠ when the goal's bright red line is malformed — the bumped amount silently
-// fell back to g.Rate, so it's flagged rather than shown as if authoritative
-// (#325 / ADR-0003).
+// "(!) " marker when the goal's bright red line is malformed — the bumped amount
+// silently fell back to g.Rate, so it's flagged rather than shown as if
+// authoritative (#325 / ADR-0003). The marker is ASCII so it occupies a known
+// display width and never shifts the goaltable's column alignment (a multi-byte
+// glyph like ⚠ can render 1 or 2 cells wide depending on the terminal/locale).
 func (v tomorrowView) markedBaremin() string {
 	if v.roadMalformed {
-		return "⚠ " + v.baremin
+		return "(!) " + v.baremin
 	}
 	return v.baremin
 }

--- a/filtered.go
+++ b/filtered.go
@@ -60,7 +60,7 @@ func handleTomorrowCommand() {
 		return v
 	}
 	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
-	bareminFor := func(g Goal) string { return viewFor(g).baremin }
+	bareminFor := func(g Goal) string { return viewFor(g).markedBaremin() }
 	losedateFor := func(g Goal) int64 { return viewFor(g).losedate }
 	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor)
 }
@@ -194,20 +194,38 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 	fmt.Print(getUpdateMessage())
 }
 
-// tomorrowView is the pair a goal shows in the "due tomorrow" view: the baremin
-// string and the losedate timestamp. The two are vended together so they always
-// reflect the same horizon — a bumped amount never appears beside an un-bumped
-// deadline, or vice-versa.
+// tomorrowView is what a goal shows in the "due tomorrow" view: the baremin
+// string, the losedate timestamp, and whether the goal's bright red line failed
+// to parse. baremin and losedate are vended together so they always reflect the
+// same horizon — a bumped amount never appears beside an un-bumped deadline, or
+// vice-versa.
 type tomorrowView struct {
 	baremin  string
 	losedate int64
+	// roadMalformed is true when parseRoad rejected the goal's roadall. The
+	// bump silently falls back to g.Rate in that case (slopePerDayAt stays
+	// tolerant), so the view flags it with a ⚠ rather than presenting a
+	// fallback number as if it were authoritative. An absent road (benign,
+	// "not populated") is NOT malformed and carries no marker. See ADR-0003.
+	roadMalformed bool
 }
 
-// goalByEndOfTomorrowAt vends the baremin and losedate a goal should show in the
-// "due tomorrow" view, projected to tomorrow's deadline. The due-today gate and
-// `now` are evaluated once here, so the two fields can't disagree — the
-// coupling the caller previously had to enforce by wiring two closures
-// identically now holds by construction.
+// markedBaremin is the baremin string the tomorrow view prints, prefixed with a
+// ⚠ when the goal's bright red line is malformed — the bumped amount silently
+// fell back to g.Rate, so it's flagged rather than shown as if authoritative
+// (#325 / ADR-0003).
+func (v tomorrowView) markedBaremin() string {
+	if v.roadMalformed {
+		return "⚠ " + v.baremin
+	}
+	return v.baremin
+}
+
+// goalByEndOfTomorrowAt vends the baremin, losedate, and road-malformed flag a
+// goal should show in the "due tomorrow" view, projected to tomorrow's deadline.
+// The due-today gate and `now` are evaluated once here, so baremin and losedate
+// can't disagree — the coupling the caller previously had to enforce by wiring
+// two closures identically now holds by construction.
 //
 // A goal due *later today* is bumped: its baremin gains one day's worth of rate
 // (so the amount reflects what's required to avoid a beemergency tomorrow) and
@@ -217,13 +235,20 @@ type tomorrowView struct {
 // keeping the real losedate preserves the OVERDUE indicator. See bumpedBaremin
 // for the baremin projection and dueLaterTodayAt for the gate.
 func goalByEndOfTomorrowAt(g Goal, now time.Time) tomorrowView {
+	// A malformed roadall is surfaced regardless of the gate: the bump path
+	// swallows the parse error (falling back to g.Rate), so this is the tomorrow
+	// view's chance to signal it. An absent road parses without error and is not
+	// flagged.
+	_, roadErr := parseRoad(g.Roadall, g.Runits)
+	malformed := roadErr != nil
+
 	if !dueLaterTodayAt(g, now) {
-		return tomorrowView{baremin: stripTimeWindowSuffix(g.Baremin), losedate: g.Losedate}
+		return tomorrowView{baremin: stripTimeWindowSuffix(g.Baremin), losedate: g.Losedate, roadMalformed: malformed}
 	}
 	// Advance the deadline by one calendar day in the caller's local zone so the
 	// displayed wall-clock deadline stays correct across DST transitions.
 	losedate := time.Unix(g.Losedate, 0).In(now.Location()).AddDate(0, 0, 1).Unix()
-	return tomorrowView{baremin: bumpedBaremin(g, now), losedate: losedate}
+	return tomorrowView{baremin: bumpedBaremin(g, now), losedate: losedate, roadMalformed: malformed}
 }
 
 // Tomorrow-view baremin bumping. bumpedBaremin projects a goal's "what's needed

--- a/filtered.go
+++ b/filtered.go
@@ -62,8 +62,22 @@ func handleTomorrowCommand() {
 	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
 	bareminFor := func(g Goal) string { return viewFor(g).markedBaremin() }
 	losedateFor := func(g Goal) int64 { return viewFor(g).losedate }
-	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor)
+	// Explain the "(!)" marker, but only when a flagged goal is actually shown.
+	legendFor := func(goals []Goal) string {
+		for _, g := range goals {
+			if viewFor(g).roadMalformed {
+				return tomorrowMalformedLegend
+			}
+		}
+		return ""
+	}
+	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor, legendFor)
 }
+
+// tomorrowMalformedLegend is the footnote shown beneath the tomorrow table when
+// at least one goal carries the "(!)" marker (a malformed bright red line). It
+// explains that the marked amount is a fallback, not a value read off the line.
+const tomorrowMalformedLegend = "\n(!) couldn't read the goal's bright red line; the amount shown is estimated from the goal's overall rate.\n"
 
 // handleLessCommand outputs all do-less type goals
 func handleLessCommand() {
@@ -110,6 +124,7 @@ func handleFilteredCommand(filterName string, filter func(Goal) bool) {
 	handleFilteredCommandWithDisplay(filterName, filter,
 		func(g Goal) string { return g.Baremin },
 		func(g Goal) int64 { return g.Losedate },
+		nil,
 	)
 }
 
@@ -128,7 +143,12 @@ func sortGoalsByDisplayedLosedate(goals []Goal, losedateFor func(Goal) int64) {
 // timestamp used for the timeframe/absolute-deadline columns. The tomorrow
 // view uses this to bump both for due-today goals so the bumped baremin and
 // the displayed deadline are aligned to the same target moment.
-func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool, bareminFor func(Goal) string, losedateFor func(Goal) int64) {
+//
+// legendFor, when non-nil, is called with the rendered goals after the table
+// and may return a footnote (e.g. explaining a marker the cells carry); an
+// empty string prints nothing. The tomorrow view uses it to explain its "(!)"
+// malformed-bright-red-line marker only when a flagged goal is actually shown.
+func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool, bareminFor func(Goal) string, losedateFor func(Goal) int64, legendFor func([]Goal) string) {
 	// Load config
 	if !ConfigExists() {
 		fmt.Println("Error: No configuration found. Please run 'buzz auth login' to authenticate.")
@@ -189,6 +209,12 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 		},
 	}
 	fmt.Print(table.Render(filteredGoals))
+
+	if legendFor != nil {
+		if legend := legendFor(filteredGoals); legend != "" {
+			fmt.Print(legend)
+		}
+	}
 
 	// Check for updates and display message if available
 	fmt.Print(getUpdateMessage())

--- a/filtered.go
+++ b/filtered.go
@@ -63,14 +63,7 @@ func handleTomorrowCommand() {
 	bareminFor := func(g Goal) string { return viewFor(g).markedBaremin() }
 	losedateFor := func(g Goal) int64 { return viewFor(g).losedate }
 	// Explain the "(!)" marker, but only when a flagged goal is actually shown.
-	legendFor := func(goals []Goal) string {
-		for _, g := range goals {
-			if viewFor(g).roadMalformed {
-				return tomorrowMalformedLegend
-			}
-		}
-		return ""
-	}
+	legendFor := func(goals []Goal) string { return tomorrowLegend(goals, viewFor) }
 	handleFilteredCommandWithDisplay("tomorrow", filter, bareminFor, losedateFor, legendFor)
 }
 
@@ -78,6 +71,19 @@ func handleTomorrowCommand() {
 // at least one goal carries the "(!)" marker (a malformed bright red line). It
 // explains that the marked amount is a fallback, not a value read off the line.
 const tomorrowMalformedLegend = "\n(!) couldn't read the goal's bright red line; the amount shown is estimated from the goal's overall rate.\n"
+
+// tomorrowLegend returns the malformed-road footnote when at least one of the
+// shown goals carries the "(!)" marker, else "". viewOf resolves each goal's
+// tomorrow view; the caller passes its memoized resolver so this adds no extra
+// parsing.
+func tomorrowLegend(goals []Goal, viewOf func(Goal) tomorrowView) string {
+	for _, g := range goals {
+		if viewOf(g).roadMalformed {
+			return tomorrowMalformedLegend
+		}
+	}
+	return ""
+}
 
 // handleLessCommand outputs all do-less type goals
 func handleLessCommand() {

--- a/main_test.go
+++ b/main_test.go
@@ -714,6 +714,60 @@ func TestGoalByEndOfTomorrowAtPairsBareminAndLosedate(t *testing.T) {
 	})
 }
 
+// TestGoalByEndOfTomorrowAtFlagsMalformedRoad pins #325: a goal whose roadall is
+// malformed is flagged (roadMalformed → a ⚠ prefix on the displayed baremin),
+// while a valid road and an absent road ("not populated", benign) are not. The
+// flag is independent of the due-today bump gate.
+func TestGoalByEndOfTomorrowAtFlagsMalformedRoad(t *testing.T) {
+	now := time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC)
+	t0 := float64(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Unix())
+	t1 := float64(time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC).Unix())
+
+	malformedRoad := [][]*float64{
+		roadallRow(t0, fptr(0), nil),
+		roadallRow(t1, fptr(5), fptr(1)), // both value and rate set → malformed
+	}
+	validRoad := [][]*float64{
+		roadallRow(t0, fptr(0), nil),
+		roadallRow(t1, fptr(5), nil), // value row
+	}
+
+	t.Run("malformed road sets the flag and marks the baremin", func(t *testing.T) {
+		g := Goal{Baremin: "+1 today", Roadall: malformedRoad, Runits: "d"}
+		view := goalByEndOfTomorrowAt(g, now)
+		if !view.roadMalformed {
+			t.Error("expected roadMalformed = true for a malformed roadall")
+		}
+		if got := view.markedBaremin(); got != "⚠ +1" {
+			t.Errorf("markedBaremin = %q, want %q", got, "⚠ +1")
+		}
+	})
+
+	t.Run("valid road is not flagged", func(t *testing.T) {
+		g := Goal{Baremin: "+1 today", Roadall: validRoad, Runits: "d"}
+		view := goalByEndOfTomorrowAt(g, now)
+		if view.roadMalformed {
+			t.Error("expected roadMalformed = false for a valid roadall")
+		}
+		if got := view.markedBaremin(); got != "+1" {
+			t.Errorf("markedBaremin = %q, want %q (no marker)", got, "+1")
+		}
+	})
+
+	t.Run("absent road is benign, not flagged", func(t *testing.T) {
+		// No roadall at all → parseRoad returns (nil, nil): "not populated", not
+		// malformed. The issue explicitly keeps this distinct from the error case.
+		g := Goal{Baremin: "+1 today"}
+		view := goalByEndOfTomorrowAt(g, now)
+		if view.roadMalformed {
+			t.Error("expected roadMalformed = false for an absent roadall")
+		}
+		if got := view.markedBaremin(); got != "+1" {
+			t.Errorf("markedBaremin = %q, want %q (no marker)", got, "+1")
+		}
+	})
+}
+
 // TestSortGoalsByDisplayedLosedate locks in the rule that rows render in the
 // order the user actually sees in the deadline column. The tomorrow view
 // bumps due-today losedates by one calendar day, which can flip the relative

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -784,6 +785,23 @@ func TestGoalByEndOfTomorrowAtFlagsMalformedRoad(t *testing.T) {
 			t.Errorf("markedBaremin = %q, want %q (bumped via g.Rate fallback)", got, "(!) +2")
 		}
 	})
+}
+
+// TestTomorrowMalformedLegend keeps the footnote and the cell marker in sync:
+// the legend must reference the same "(!)" the marked baremin uses and name the
+// bright red line, so a user seeing "(!)" can connect it to its explanation.
+func TestTomorrowMalformedLegend(t *testing.T) {
+	marked := tomorrowView{roadMalformed: true, baremin: "+2"}.markedBaremin()
+	marker := strings.TrimSuffix(marked, "+2") // "(!) "
+	if strings.TrimSpace(marker) == "" {
+		t.Fatalf("expected a non-empty marker prefix, got %q", marked)
+	}
+	if !strings.Contains(tomorrowMalformedLegend, strings.TrimSpace(marker)) {
+		t.Errorf("legend %q should reference the marker %q", tomorrowMalformedLegend, strings.TrimSpace(marker))
+	}
+	if !strings.Contains(tomorrowMalformedLegend, "bright red line") {
+		t.Errorf("legend should name the bright red line, got %q", tomorrowMalformedLegend)
+	}
 }
 
 // TestSortGoalsByDisplayedLosedate locks in the rule that rows render in the

--- a/main_test.go
+++ b/main_test.go
@@ -804,6 +804,25 @@ func TestTomorrowMalformedLegend(t *testing.T) {
 	}
 }
 
+// TestTomorrowLegendGating pins the visibility rule the footnote ships: it
+// appears only when at least one displayed goal carries the "(!)" marker, and
+// is suppressed otherwise (so a clean tomorrow view stays uncluttered).
+func TestTomorrowLegendGating(t *testing.T) {
+	viewOf := func(g Goal) tomorrowView {
+		return tomorrowView{roadMalformed: g.Slug == "bad"}
+	}
+
+	if got := tomorrowLegend([]Goal{{Slug: "ok"}, {Slug: "bad"}}, viewOf); got != tomorrowMalformedLegend {
+		t.Errorf("expected the legend when a shown goal is flagged, got %q", got)
+	}
+	if got := tomorrowLegend([]Goal{{Slug: "ok"}, {Slug: "ok2"}}, viewOf); got != "" {
+		t.Errorf("expected no legend when no goal is flagged, got %q", got)
+	}
+	if got := tomorrowLegend(nil, viewOf); got != "" {
+		t.Errorf("expected no legend for an empty goal list, got %q", got)
+	}
+}
+
 // TestSortGoalsByDisplayedLosedate locks in the rule that rows render in the
 // order the user actually sees in the deadline column. The tomorrow view
 // bumps due-today losedates by one calendar day, which can flip the relative

--- a/main_test.go
+++ b/main_test.go
@@ -715,7 +715,7 @@ func TestGoalByEndOfTomorrowAtPairsBareminAndLosedate(t *testing.T) {
 }
 
 // TestGoalByEndOfTomorrowAtFlagsMalformedRoad pins #325: a goal whose roadall is
-// malformed is flagged (roadMalformed → a ⚠ prefix on the displayed baremin),
+// malformed is flagged (roadMalformed → a "(!) " prefix on the displayed baremin),
 // while a valid road and an absent road ("not populated", benign) are not. The
 // flag is independent of the due-today bump gate.
 func TestGoalByEndOfTomorrowAtFlagsMalformedRoad(t *testing.T) {
@@ -738,8 +738,8 @@ func TestGoalByEndOfTomorrowAtFlagsMalformedRoad(t *testing.T) {
 		if !view.roadMalformed {
 			t.Error("expected roadMalformed = true for a malformed roadall")
 		}
-		if got := view.markedBaremin(); got != "⚠ +1" {
-			t.Errorf("markedBaremin = %q, want %q", got, "⚠ +1")
+		if got := view.markedBaremin(); got != "(!) +1" {
+			t.Errorf("markedBaremin = %q, want %q", got, "(!) +1")
 		}
 	})
 
@@ -764,6 +764,24 @@ func TestGoalByEndOfTomorrowAtFlagsMalformedRoad(t *testing.T) {
 		}
 		if got := view.markedBaremin(); got != "+1" {
 			t.Errorf("markedBaremin = %q, want %q (no marker)", got, "+1")
+		}
+	})
+
+	t.Run("malformed road on a bumped (due-later-today) goal", func(t *testing.T) {
+		// The gate-independence case that matters most: a due-later-today goal is
+		// bumped, and the bump silently falls back to g.Rate because the road
+		// won't parse. The marker warns that the bumped figure is a fallback.
+		// (Pins the roadMalformed flag on the bumped return branch, which is a
+		// separate struct literal from the not-bumped one.)
+		todayDeadline := time.Date(2025, 1, 15, 23, 0, 0, 0, time.UTC).Unix() // later today → bumped
+		g := Goal{Losedate: todayDeadline, Baremin: "+1 today", Rate: fptr(1), Runits: "d", Roadall: malformedRoad}
+		view := goalByEndOfTomorrowAt(g, now)
+		if !view.roadMalformed {
+			t.Error("expected roadMalformed = true on the bumped branch")
+		}
+		// Malformed road → slopePerDayAt falls back to g.Rate (1/day): +1 → +2.
+		if got := view.markedBaremin(); got != "(!) +2" {
+			t.Errorf("markedBaremin = %q, want %q (bumped via g.Rate fallback)", got, "(!) +2")
 		}
 	})
 }


### PR DESCRIPTION
Closes #325.

## Problem

The slope path (`slopePerDayAt`) deliberately stays **tolerant**: a malformed `roadall` falls back to `g.Rate` rather than erroring, so one bad goal doesn't break the tomorrow view's bump for every other goal (ADR-0003). But that left `buzz tomorrow` with **no signal** that a goal's bumped amount is a `g.Rate` fallback rather than a real per-segment rate — the user saw a number with no hint it was a fallback.

## Solution

Surface it as a per-goal marker:

- `tomorrowView` gains a `roadMalformed bool`, computed once in `goalByEndOfTomorrowAt` via `parseRoad(g.Roadall, g.Runits)` — **independent of the due-today bump gate**, so any malformed-road goal in the view is flagged.
- `markedBaremin()` prefixes a **`(!) `** marker to the displayed baremin when the road is malformed.
- An **absent** road (`parseRoad` returns `(nil, nil)` — the benign "not populated" state) parses without error and is kept **distinct**: no marker, exactly as the issue requires.

### Why `(!) ` and not `⚠`

The original `⚠` (U+26A0) is East-Asian *ambiguous width* — 1 terminal cell on a standard terminal but 2 under a CJK locale or emoji presentation. `goaltable` measures column width in bytes and pads non-last columns, so a variable-width glyph could shift the marked row's later columns. An ASCII `(!) ` has a known display width and aligns on every terminal, without touching the shared renderer used by all the list views (`all`/`today`/`tomorrow`/`due`/`less`).

## Output

```
weight   (!) +2   due Jan 16   Jan 16, 2025   ← road won't parse; bump is a g.Rate fallback
read     +1       due Jan 16   Jan 16, 2025
floss    +0       due Jan 16   Jan 16, 2025
```

## Tests

`TestGoalByEndOfTomorrowAtFlagsMalformedRoad` covers all four cases: malformed (flag + `(!) ` marker), valid (no flag), absent (benign, no flag), and a **bumped** (due-later-today) malformed goal — the branch where the silent `g.Rate` fallback actually changes the number (`+1` → `(!) +2`). `markedBaremin()` is asserted directly for both branches.

`go build`, `go vet`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
