### PR TITLE
fix(review): scroll tall goals in a viewport on short terminals

### DIFF
--- a/review.go
+++ b/review.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -59,7 +60,7 @@ func handleReviewCommand() {
 	// Launch the interactive review TUI
 	model := initialReviewModel(goals, config)
 	model.ctx = ctx
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
 		os.Exit(1)
@@ -74,10 +75,12 @@ type reviewModel struct {
 	loading  bool                // a detail fetch for the current goal is in flight
 	ctx      context.Context     // cancelled when the TUI exits; cancels in-flight fetches
 	config   *Config
-	current  int    // current goal index
-	width    int    // terminal width
-	height   int    // terminal height
-	err      string // error message to display
+	current  int            // current goal index
+	width    int            // terminal width
+	height   int            // terminal height
+	err      string         // error message to display
+	viewport viewport.Model // scrollable pane for the goal content (keeps tall goals reachable on short terminals)
+	ready    bool           // viewport has been sized by a WindowSizeMsg
 }
 
 // initialReviewModel creates a new review model. The first goal's details fetch
@@ -151,6 +154,20 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		// Reserve the bottom rows for the pinned help bar; the rest is the
+		// scrollable content pane so tall goals stay reachable on short
+		// terminals (the content used to overflow the alt screen and the top
+		// scrolled off with no way to reach it).
+		helpHeight := lipgloss.Height(m.helpView())
+		contentHeight := max(1, msg.Height-helpHeight)
+		if !m.ready {
+			m.viewport = viewport.New(msg.Width, contentHeight)
+			m.ready = true
+		} else {
+			m.viewport.Width = msg.Width
+			m.viewport.Height = contentHeight
+		}
+		m.refreshContent()
 		return m, nil
 
 	case goalDetailsMsg:
@@ -163,6 +180,10 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if isCurrent {
 				m.loading = false
 				m.err = fmt.Sprintf("Failed to load goal details: %s", redactError(msg.err))
+				// Re-flow so the error replaces the "Loading…" line in the pane;
+				// both are rendered inside contentView, which the viewport only
+				// re-reads on refresh.
+				m.refreshContent()
 			}
 			return m, nil
 		}
@@ -170,6 +191,9 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if isCurrent {
 			m.loading = false
 			m.err = ""
+			// Datapoints/chart just arrived for the goal on screen; re-flow the
+			// content pane so they appear (keeping the current scroll position).
+			m.refreshContent()
 		}
 		return m, nil
 
@@ -184,7 +208,11 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.current++
 			}
 			m.err = ""
-			return m, m.ensureDetails()
+			cmd := m.ensureDetails()
+			// New goal: re-flow and jump back to the top of the pane.
+			m.refreshContent()
+			m.viewport.GotoTop()
+			return m, cmd
 
 		case "left", "h", "p", "k":
 			// Previous goal
@@ -192,7 +220,10 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.current--
 			}
 			m.err = ""
-			return m, m.ensureDetails()
+			cmd := m.ensureDetails()
+			m.refreshContent()
+			m.viewport.GotoTop()
+			return m, cmd
 
 		case "o", "enter":
 			// Open current goal in browser
@@ -203,17 +234,52 @@ func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.err = "" // Clear any previous error
 				}
+				m.refreshContent()
 			}
 			return m, nil
 		}
 	}
 
-	return m, nil
+	// Anything else (↑/↓, PgUp/PgDn, Home/End, mouse wheel, …) scrolls the
+	// content pane. Goal-navigation and action keys returned above, so they
+	// never reach the viewport.
+	if !m.ready {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// refreshContent re-renders the goal content into the scroll pane. No-op until
+// the viewport has been sized (e.g. before the first WindowSizeMsg, or in tests
+// that call View directly), where View falls back to rendering content inline.
+func (m *reviewModel) refreshContent() {
+	if m.ready {
+		m.viewport.SetContent(m.contentView())
+	}
 }
 
 func (m reviewModel) View() string {
 	if len(m.goals) == 0 {
 		return "No goals to review.\n\nPress q to quit."
+	}
+
+	// Once sized by a WindowSizeMsg, render the content through the scroll pane
+	// so tall goals stay reachable. Before that (and in tests that call View
+	// directly) fall back to rendering the full content inline, unscrolled.
+	if m.ready {
+		return m.viewport.View() + "\n" + m.helpView()
+	}
+	return m.contentView() + "\n" + m.helpView()
+}
+
+// contentView renders the scrollable portion of the review screen: the goal
+// title, details, chart, loading indicator, and any error. The help bar is
+// rendered separately (helpView) and pinned below the scroll pane.
+func (m reviewModel) contentView() string {
+	if len(m.goals) == 0 {
+		return ""
 	}
 
 	// Start from the bulk summary goal, then merge in only the fields the
@@ -299,15 +365,22 @@ func (m reviewModel) View() string {
 		view += errorStyle.Render(fmt.Sprintf("⚠ %s", m.err)) + "\n"
 	}
 
-	// Help section
+	return view
+}
+
+// helpView renders the key hints pinned below the scroll pane. When the content
+// overflows the pane, it also shows a scroll position so the user knows there's
+// more above or below.
+func (m reviewModel) helpView() string {
 	helpStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("241")).
 		Padding(1, 2)
 
-	help := "Navigation: ← → (or h l, or j k, or p n)  |  Open in browser: o or Enter  |  Quit: q or Esc"
-	view += helpStyle.Render(help)
-
-	return view
+	help := "Navigation: ← → (or h l, or j k, or p n)  |  Scroll: ↑ ↓ PgUp PgDn  |  Open in browser: o or Enter  |  Quit: q or Esc"
+	if m.ready && (!m.viewport.AtTop() || !m.viewport.AtBottom()) {
+		help += fmt.Sprintf("  |  %3.0f%%", m.viewport.ScrollPercent()*100)
+	}
+	return helpStyle.Render(help)
 }
 
 // openBrowser opens the goal page in the default browser

--- a/review.go
+++ b/review.go
@@ -271,7 +271,10 @@ func (m reviewModel) View() string {
 	if m.ready {
 		return m.viewport.View() + "\n" + m.helpView()
 	}
-	return m.contentView() + "\n" + m.helpView()
+	// contentView can end with a trailing newline (e.g. the loading/error line);
+	// trim it so the inline fallback doesn't stack a blank row before the help
+	// bar, matching the viewport path (viewport.View has no trailing newline).
+	return strings.TrimRight(m.contentView(), "\n") + "\n" + m.helpView()
 }
 
 // contentView renders the scrollable portion of the review screen: the goal

--- a/review.go
+++ b/review.go
@@ -380,8 +380,14 @@ func (m reviewModel) helpView() string {
 		Padding(1, 2)
 
 	help := "Navigation: ← → (or h l, or j k, or p n)  |  Scroll: ↑ ↓ PgUp PgDn  |  Open in browser: o or Enter  |  Quit: q or Esc"
+	// Reserve the indicator's slot whether or not the percentage is shown, so the
+	// help bar keeps a constant width as the user moves between goals that do and
+	// don't overflow (a varying width could shift terminal wrapping on narrow
+	// widths). %3.0f%% is always 4 chars, so the slot is a fixed "  |  100%" wide.
 	if m.ready && (!m.viewport.AtTop() || !m.viewport.AtBottom()) {
 		help += fmt.Sprintf("  |  %3.0f%%", m.viewport.ScrollPercent()*100)
+	} else {
+		help += strings.Repeat(" ", len("  |  100%"))
 	}
 	return helpStyle.Render(help)
 }

--- a/review_test.go
+++ b/review_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestSortGoalsBySlug(t *testing.T) {
@@ -1419,5 +1420,198 @@ func TestFormatGoalDetailsIncludesForecastBeforeDatapoints(t *testing.T) {
 	}
 	if fi > di {
 		t.Errorf("expected forecast (at %d) before recent datapoints (at %d):\n%s", fi, di, out)
+	}
+}
+
+// TestReviewModelShortTerminalScroll verifies that on a terminal too short to
+// fit a goal, the content is paged into a scrollable viewport (so the top stays
+// reachable) rather than overflowing the alt screen and scrolling off.
+func TestReviewModelShortTerminalScroll(t *testing.T) {
+	goals := []Goal{
+		{
+			Slug:     "tallgoal",
+			Title:    "A goal with enough detail to overflow a short terminal",
+			Safebuf:  5,
+			Pledge:   10.0,
+			Losedate: 1234567890,
+			Limsum:   "+1 in 2 days",
+		},
+	}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+
+	// Simulate a short terminal: full content is many lines, window is tiny.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 6})
+	m = updated.(reviewModel)
+
+	if !m.ready {
+		t.Fatal("expected viewport to be ready after WindowSizeMsg")
+	}
+
+	// The goal's content must exceed the pane height — otherwise this test
+	// isn't exercising scrolling at all.
+	if m.viewport.TotalLineCount() <= m.viewport.Height {
+		t.Fatalf("expected content (%d lines) to overflow pane (%d rows)",
+			m.viewport.TotalLineCount(), m.viewport.Height)
+	}
+
+	// We start pinned at the top, with more below.
+	if !m.viewport.AtTop() {
+		t.Error("expected viewport to start at the top")
+	}
+	if m.viewport.AtBottom() {
+		t.Error("expected more content below the fold on a short terminal")
+	}
+
+	// Scrolling down reveals lower content and leaves the top.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(reviewModel)
+	if m.viewport.AtTop() {
+		t.Error("expected viewport to move off the top after scrolling down")
+	}
+
+	// The help bar advertises scroll keys and a position indicator.
+	help := m.helpView()
+	if !strings.Contains(help, "Scroll:") {
+		t.Errorf("expected help to mention scrolling, got: %s", help)
+	}
+	if !strings.Contains(help, "%") {
+		t.Errorf("expected help to show a scroll position, got: %s", help)
+	}
+}
+
+// TestReviewModelNavigationResetsScroll verifies that moving to another goal
+// jumps the scroll pane back to the top instead of stranding the user mid-goal.
+func TestReviewModelNavigationResetsScroll(t *testing.T) {
+	goals := []Goal{
+		{Slug: "goal1", Title: "First goal with plenty of detail to scroll", Limsum: "+1 in 2 days"},
+		{Slug: "goal2", Title: "Second goal with plenty of detail to scroll", Limsum: "+2 in 3 days"},
+	}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 6})
+	m = updated.(reviewModel)
+
+	// Scroll down within the first goal.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(reviewModel)
+	if m.viewport.AtTop() {
+		t.Fatal("precondition: expected to have scrolled off the top")
+	}
+
+	// Navigate to the next goal; the pane should reset to the top.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(reviewModel)
+	if m.current != 1 {
+		t.Fatalf("expected to advance to goal index 1, got %d", m.current)
+	}
+	if !m.viewport.AtTop() {
+		t.Error("expected scroll pane to reset to the top on goal navigation")
+	}
+}
+
+// TestReviewModelResizeReusesViewport verifies a later WindowSizeMsg resizes the
+// existing scroll pane (rather than recreating it) and re-flows its dimensions.
+func TestReviewModelResizeReusesViewport(t *testing.T) {
+	goals := []Goal{{Slug: "g", Title: "A goal to scroll", Limsum: "+1 in 2 days"}}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 6})
+	m = updated.(reviewModel)
+	if !m.ready {
+		t.Fatal("expected viewport ready after first WindowSizeMsg")
+	}
+
+	// Grow the terminal; the pane should track the new size.
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	m = updated.(reviewModel)
+
+	if !m.ready {
+		t.Fatal("expected viewport to stay ready after resize")
+	}
+	if m.viewport.Width != 100 {
+		t.Errorf("expected viewport width 100 after resize, got %d", m.viewport.Width)
+	}
+	wantHeight := 20 - lipgloss.Height(m.helpView())
+	if m.viewport.Height != wantHeight {
+		t.Errorf("expected viewport height %d after resize, got %d", wantHeight, m.viewport.Height)
+	}
+}
+
+// TestReviewModelDetailsArrivalReflows verifies that when a goal's datapoints
+// arrive, the scroll pane re-flows to include the now-renderable chart/datapoints
+// instead of stranding the user on the pre-fetch content.
+func TestReviewModelDetailsArrivalReflows(t *testing.T) {
+	goals := []Goal{{Slug: "g", Title: "A goal", Limsum: "+1 in 2 days"}}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(reviewModel)
+
+	before := m.viewport.TotalLineCount()
+
+	// Details (datapoints) arrive for the on-screen goal.
+	updated, _ = m.Update(goalDetailsMsg{
+		slug: "g",
+		goal: &Goal{
+			Slug:       "g",
+			Datapoints: []Datapoint{{Daystamp: "20260609", Value: 1, Comment: "first"}},
+		},
+	})
+	m = updated.(reviewModel)
+
+	if m.loading {
+		t.Error("expected loading to clear once details arrived")
+	}
+	after := m.viewport.TotalLineCount()
+	if after <= before {
+		t.Errorf("expected pane content to grow when datapoints arrive (before=%d, after=%d)", before, after)
+	}
+	if !strings.Contains(m.viewport.View()+m.contentView(), "first") {
+		t.Error("expected the newly-arrived datapoint comment to render in the pane")
+	}
+}
+
+// TestReviewModelDetailsErrorReflows verifies that a failed details fetch for the
+// on-screen goal surfaces its error in the pane (not just in model state).
+func TestReviewModelDetailsErrorReflows(t *testing.T) {
+	goals := []Goal{{Slug: "g", Title: "A goal", Limsum: "+1 in 2 days"}}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(reviewModel)
+
+	updated, _ = m.Update(goalDetailsMsg{slug: "g", err: fmt.Errorf("boom")})
+	m = updated.(reviewModel)
+
+	if m.loading {
+		t.Error("expected loading to clear after a failed fetch")
+	}
+	if !strings.Contains(m.viewport.View(), "Failed to load goal details") {
+		t.Errorf("expected the fetch error to render in the scroll pane, got:\n%s", m.viewport.View())
+	}
+}
+
+// TestReviewModelNoScrollIndicatorWhenContentFits verifies the help bar omits the
+// scroll-position indicator when the goal fits the terminal (nothing to scroll).
+func TestReviewModelNoScrollIndicatorWhenContentFits(t *testing.T) {
+	goals := []Goal{{Slug: "g", Title: "A short goal", Limsum: "+1 in 2 days"}}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+	// A very tall terminal: the goal content fits with room to spare.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 200})
+	m = updated.(reviewModel)
+
+	if !m.viewport.AtTop() || !m.viewport.AtBottom() {
+		t.Fatal("precondition: expected content to fully fit the pane")
+	}
+	if strings.Contains(m.helpView(), "%") {
+		t.Errorf("expected no scroll indicator when content fits, got: %s", m.helpView())
 	}
 }

--- a/review_test.go
+++ b/review_test.go
@@ -1525,8 +1525,21 @@ func TestReviewModelResizeReusesViewport(t *testing.T) {
 		t.Fatal("expected viewport ready after first WindowSizeMsg")
 	}
 
-	// Grow the terminal; the pane should track the new size.
-	updated, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	// Scroll off the top before resizing. A reused viewport preserves this
+	// offset across the resize; a freshly-recreated one would reset it to 0 —
+	// so asserting the offset survives is what actually pins "reuse".
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(reviewModel)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(reviewModel)
+	scrolledOffset := m.viewport.YOffset
+	if scrolledOffset == 0 {
+		t.Fatal("precondition: expected to have scrolled off the top before resize")
+	}
+
+	// Resize to another size where the content still overflows the pane (so the
+	// preserved offset isn't clamped away); the pane should track the new size.
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 9})
 	m = updated.(reviewModel)
 
 	if !m.ready {
@@ -1535,9 +1548,13 @@ func TestReviewModelResizeReusesViewport(t *testing.T) {
 	if m.viewport.Width != 100 {
 		t.Errorf("expected viewport width 100 after resize, got %d", m.viewport.Width)
 	}
-	wantHeight := 20 - lipgloss.Height(m.helpView())
+	wantHeight := 9 - lipgloss.Height(m.helpView())
 	if m.viewport.Height != wantHeight {
 		t.Errorf("expected viewport height %d after resize, got %d", wantHeight, m.viewport.Height)
+	}
+	if m.viewport.YOffset != scrolledOffset {
+		t.Errorf("expected resize to preserve scroll offset %d (viewport reused, not recreated), got %d",
+			scrolledOffset, m.viewport.YOffset)
 	}
 }
 
@@ -1594,6 +1611,11 @@ func TestReviewModelDetailsErrorReflows(t *testing.T) {
 	}
 	if !strings.Contains(m.viewport.View(), "Failed to load goal details") {
 		t.Errorf("expected the fetch error to render in the scroll pane, got:\n%s", m.viewport.View())
+	}
+	// The error must *replace* the loading line, not sit alongside a stale one —
+	// that re-flow is the regression this test guards.
+	if strings.Contains(m.viewport.View(), "Loading datapoints…") {
+		t.Errorf("expected the stale loading line to be gone once the fetch failed, got:\n%s", m.viewport.View())
 	}
 }
 


### PR DESCRIPTION
## Problem

Running `buzz review` in a terminal too short to fit a goal cut off the top of the content with no way to reach it. The command rendered each goal as one big string on the alt screen, and Bubble Tea's renderer shows the *bottom* of an over-tall frame, so the title/rate/limsum scrolled off the top irretrievably.

## Fix

Wrap the goal content in a `viewport` — a scrollable pane from `bubbles` (already a transitive dependency, so no new module). The help bar is pinned at the bottom; everything above it scrolls.

- **Scroll within a goal:** ↑/↓, PgUp/PgDn, Home/End, and the mouse wheel (enabled `WithMouseCellMotion`).
- **Goal navigation** (←/→, h/l, j/k, p/n) is unchanged and now resets the pane to the top.
- The help bar advertises the scroll keys and shows a scroll-position `%` when content overflows.

`View()` was split into `contentView()` (scrollable) and `helpView()` (pinned). It renders through the viewport once sized by a `WindowSizeMsg`, and falls back to inline rendering before that — which also keeps the existing `View()` tests valid.

A pre-existing pattern bug surfaced during review and is fixed here: a *failed* detail fetch now re-flows the pane, so its error replaces the "Loading…" line instead of staying hidden until the next event (the success branch already re-flowed).

## Why a viewport rather than an external pager (`less`/`$PAGER`)

`review` is an interactive TUI with live goal-to-goal navigation and lazy per-goal fetching, not static output — shelling out to a pager doesn't fit that model. The in-TUI viewport is the idiomatic Charm solution and preserves every existing interaction.

## Tests

Added coverage for short-terminal scrolling, navigation-resets-scroll, resize-reuses-viewport, details-arrival reflow, fetch-error reflow, and no-scroll-indicator-when-content-fits. Full suite + `go vet` pass.

## Manual verification

The behavior is visual and couldn't be driven from the dev environment — worth a quick look in a genuinely short terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Review interface now supports scrollable content, enabling better navigation of long goal details on small terminals.
  * Added pinned help bar with scroll-position indicator for improved navigation awareness.
  * Scroll position automatically resets when navigating between goals.
  * Error messages now display within the scroll pane.

* **Tests**
  * Added unit tests for viewport scrolling, navigation, and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->