### PR TITLE
Show progress chart in `buzz view`

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/term"
 	"github.com/muesli/termenv"
 )
 
@@ -274,13 +273,7 @@ func displayTimeline(slots []timeSlot) {
 		const prefixVisualWidth = 9
 
 		// Determine terminal width; fallback to 80 if unavailable
-		width := 80
-		fd := os.Stdout.Fd()
-		if term.IsTerminal(fd) {
-			if w, _, err := term.GetSize(fd); err == nil && w > 0 {
-				width = w
-			}
-		}
+		width := terminalWidth()
 
 		// Simple wrapping: break on commas before exceeding width
 		available := width

--- a/schedule.go
+++ b/schedule.go
@@ -263,6 +263,10 @@ func displayTimeline(slots []timeSlot) {
 		treeStyle = treeStyle.Foreground(lipgloss.Color("8")) // Gray for tree structure (├─ and │)
 	}
 
+	// Determine terminal width once; it doesn't change across slots.
+	// Fallback to 80 if unavailable.
+	width := terminalWidth()
+
 	for _, slot := range slots {
 		timeStr := fmt.Sprintf("%02d:%02d", slot.hour, slot.minute)
 
@@ -271,9 +275,6 @@ func displayTimeline(slots []timeSlot) {
 		prefix := timeStyle.Render(timeStr) + " " + treeStyle.Render("├─") + " "
 		// Visual width of prefix: "HH:MM ├─ " = 9 characters (ANSI codes have zero width)
 		const prefixVisualWidth = 9
-
-		// Determine terminal width; fallback to 80 if unavailable
-		width := terminalWidth()
 
 		// Simple wrapping: break on commas before exceeding width
 		available := width

--- a/view.go
+++ b/view.go
@@ -9,7 +9,21 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/charmbracelet/x/term"
 )
+
+// terminalWidth returns the width of stdout in columns, falling back to 80 when
+// stdout isn't a terminal (piped, redirected) or the size can't be determined.
+func terminalWidth() int {
+	fd := os.Stdout.Fd()
+	if term.IsTerminal(fd) {
+		if w, _, err := term.GetSize(fd); err == nil && w > 0 {
+			return w
+		}
+	}
+	return 80
+}
 
 // handleViewCommand displays detailed information about a specific goal
 func handleViewCommand() {
@@ -119,6 +133,10 @@ func handleViewCommand() {
 	// Display goal information (human-readable format)
 	fmt.Printf("Goal: %s\n", goal.Slug)
 	fmt.Print(formatGoalDetails(goal, config, time.Now()))
+
+	// Progress chart, matching `buzz review`. Empty when the goal has no
+	// datapoints inside the charted window.
+	fmt.Print(renderGoalChart(*goal, terminalWidth()))
 
 	// Check for updates and display message if available
 	fmt.Print(getUpdateMessage())


### PR DESCRIPTION
## Problem

`buzz view <slug>` showed a goal's details but not the progress chart, even though `buzz review` renders one for the same goal. Nathan noticed the inconsistency.

## Fix

- Call `renderGoalChart` at the end of `handleViewCommand`, right after the details — the same chart `buzz review` shows (`review.go`).
- Add a shared `terminalWidth()` helper (stdout columns, falling back to 80 when not a TTY) and use it to size the chart. `schedule.go` had the same terminal-width logic inlined; it now uses the helper too, removing the duplicate and its now-unused `x/term` import.

## Verification

```
$ buzz view active
...
  Goal Progress Chart - Do More (Cumulative)
  Timeframe: Dec 30 to Jul 5, 2026
   65730 ┤ ... (blue datapoints vs red bright line) ...
  Blue: datapoints, Red: bright red line
```

`go build`, `go vet`, and `go test ./...` all pass. Empty output when the goal has no datapoints in the charted window (same as review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal width handling so timeline and progress charts render more reliably across different terminal sizes.
  * Output now adapts to the current terminal when available, with a consistent fallback for environments where size can’t be detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->