### PR TITLE
feat(create): non-interactive goal creation via CLI flags

### DIFF
--- a/create.go
+++ b/create.go
@@ -82,18 +82,11 @@ func handleCreateCommand() {
 		}
 	}
 
-	if !ConfigExists() {
-		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
+	client, ok := loadClient(os.Stderr)
+	if !ok {
 		os.Exit(1)
 	}
 
-	config, err := LoadConfig()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to load config: %s\n", redactError(err))
-		os.Exit(1)
-	}
-
-	client := NewHTTPClient(config)
 	var code int
 	if interactive {
 		code = runCreateCommand(os.Stdin, client, os.Stdout, os.Stderr)
@@ -141,7 +134,7 @@ func parseCreateArgs(args []string, stdout, stderr io.Writer) (createRequest, in
 	})
 
 	return createRequest{
-		slug: *slug, title: *title, goalType: *goalType, gunits: *gunits,
+		slug: *slug, title: *title, goalType: resolveGoalType(*goalType), gunits: *gunits,
 		goaldate: *goaldate, goalval: *goalval, rate: *rate,
 		deadline: *deadline, setDeadline: setDeadline,
 	}, 0, false
@@ -238,7 +231,16 @@ func promptGoalType(r *bufio.Reader, w io.Writer) string {
 	if choice == "" {
 		return defaultGoalType
 	}
+	return resolveGoalType(choice)
+}
 
+// resolveGoalType maps a goal-type choice — a menu number, a canonical name, or
+// a human label (all case-insensitive) — to its canonical goal_type value. Used
+// by both the interactive prompt and the --type flag so `--type=1` or
+// `--type="Do More"` behave the same as picking from the menu. Unrecognized
+// non-empty input is returned unchanged so newly-added Beeminder types still
+// work; the API validates the final value.
+func resolveGoalType(choice string) string {
 	// Numeric selection from the menu.
 	if n, err := strconv.Atoi(choice); err == nil && n >= 1 && n <= len(goalTypeOptions) {
 		return goalTypeOptions[n-1].name

--- a/create.go
+++ b/create.go
@@ -3,12 +3,39 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 )
+
+// createUsage documents the non-interactive flag form of `buzz create`.
+const createUsage = `Usage: buzz create                 (interactive; prompts for each field)
+       buzz create [flags]         (non-interactive; scriptable)
+
+Flags:
+  --slug       Goal slug (required)
+  --units      Goal units (required)
+  --title      Goal title (defaults to the slug if omitted)
+  --type       Goal type name/label/number (default: hustler)
+  --goaldate   Goal date as an epoch timestamp
+  --goalval    Goal value
+  --rate       Rate
+  --deadline   Deadline in seconds from midnight (may be negative)
+
+Provide exactly 2 of --goaldate, --goalval, --rate.`
+
+// createRequest is a fully-gathered `buzz create` invocation, from either the
+// interactive prompts or CLI flags, ready to validate and send.
+type createRequest struct {
+	slug, title, goalType, gunits string
+	goaldate, goalval, rate       string
+	deadline                      int
+	setDeadline                   bool // whether --deadline was explicitly passed
+}
 
 // defaultGoalType is used when the user leaves the goal type prompt blank.
 const defaultGoalType = "hustler"
@@ -40,6 +67,21 @@ var goalTypeOptions = []goalTypeOption{
 // plain CLI command, reusing the same validateCreateGoalInput validation and the
 // client's CreateGoal method.
 func handleCreateCommand() {
+	args := os.Args[2:]
+	interactive := len(args) == 0
+
+	// Parse flags first (when present) so `--help` and bad input are reported
+	// without requiring authentication, matching `buzz add`.
+	var req createRequest
+	if !interactive {
+		var code int
+		var done bool
+		req, code, done = parseCreateArgs(args, os.Stdout, os.Stderr)
+		if done {
+			os.Exit(code)
+		}
+	}
+
 	if !ConfigExists() {
 		fmt.Fprintln(os.Stderr, "Error: No configuration found. Please run 'buzz auth login' to authenticate.")
 		os.Exit(1)
@@ -52,12 +94,57 @@ func handleCreateCommand() {
 	}
 
 	client := NewHTTPClient(config)
-	code := runCreateCommand(os.Stdin, client, os.Stdout, os.Stderr)
+	var code int
+	if interactive {
+		code = runCreateCommand(os.Stdin, client, os.Stdout, os.Stderr)
+	} else {
+		code = doCreate(req, client, os.Stdout, os.Stderr)
+	}
 	if code == 0 {
 		// Check for updates and display message if available
 		fmt.Print(getUpdateMessage())
 	}
 	os.Exit(code)
+}
+
+// parseCreateArgs parses non-interactive `buzz create` flags into a request. It
+// returns a process exit code and done=true when the caller should stop (help
+// shown or a parse error).
+func parseCreateArgs(args []string, stdout, stderr io.Writer) (createRequest, int, bool) {
+	fs := flag.NewFlagSet("create", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // we print our own richer usage
+	slug := fs.String("slug", "", "Goal slug")
+	title := fs.String("title", "", "Goal title (defaults to slug)")
+	goalType := fs.String("type", defaultGoalType, "Goal type")
+	gunits := fs.String("units", "", "Goal units")
+	goaldate := fs.String("goaldate", "", "Goal date (epoch timestamp)")
+	goalval := fs.String("goalval", "", "Goal value")
+	rate := fs.String("rate", "", "Rate")
+	deadline := fs.Int("deadline", 0, "Deadline in seconds from midnight")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(stdout, createUsage)
+			return createRequest{}, 0, true
+		}
+		fmt.Fprintf(stderr, "Error parsing flags: %s\n", redactError(err))
+		fmt.Fprintln(stderr, createUsage)
+		return createRequest{}, 1, true
+	}
+
+	// Detect whether --deadline was explicitly set: 0 (midnight) is a valid
+	// deadline, so we can't infer intent from the value alone.
+	setDeadline := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "deadline" {
+			setDeadline = true
+		}
+	})
+
+	return createRequest{
+		slug: *slug, title: *title, goalType: *goalType, gunits: *gunits,
+		goaldate: *goaldate, goalval: *goalval, rate: *rate,
+		deadline: *deadline, setDeadline: setDeadline,
+	}, 0, false
 }
 
 // runCreateCommand is the testable core of `buzz create`. It prompts for goal
@@ -71,18 +158,31 @@ func runCreateCommand(stdin io.Reader, client Client, stdout, stderr io.Writer) 
 	fmt.Fprintln(stdout, "===========================")
 	fmt.Fprintln(stdout, "")
 
-	slug := promptField(r, stdout, "Goal slug: ")
-	title := promptField(r, stdout, "Goal title: ")
-	goalType := promptGoalType(r, stdout)
-	gunits := promptField(r, stdout, "Goal units: ")
+	req := createRequest{
+		slug:     promptField(r, stdout, "Goal slug: "),
+		title:    promptField(r, stdout, "Goal title (defaults to slug): "),
+		goalType: promptGoalType(r, stdout),
+		gunits:   promptField(r, stdout, "Goal units: "),
+	}
 
 	fmt.Fprintln(stdout, "")
 	fmt.Fprintln(stdout, "Provide exactly 2 of the next 3 (leave one blank):")
-	goaldate := promptField(r, stdout, "Goal date (epoch timestamp): ")
-	goalval := promptField(r, stdout, "Goal value: ")
-	rate := promptField(r, stdout, "Rate: ")
+	req.goaldate = promptField(r, stdout, "Goal date (epoch timestamp): ")
+	req.goalval = promptField(r, stdout, "Goal value: ")
+	req.rate = promptField(r, stdout, "Rate: ")
 
-	if errMsg := validateCreateGoalInput(slug, title, goalType, gunits, goaldate, goalval, rate); errMsg != "" {
+	return doCreate(req, client, stdout, stderr)
+}
+
+// doCreate validates a gathered request, creates the goal, and (if requested)
+// sets its deadline. Shared by the interactive and non-interactive paths. Title
+// defaults to the slug when omitted, so callers needn't supply one.
+func doCreate(req createRequest, client Client, stdout, stderr io.Writer) int {
+	if req.title == "" {
+		req.title = req.slug
+	}
+
+	if errMsg := validateCreateGoalInput(req.slug, req.title, req.goalType, req.gunits, req.goaldate, req.goalval, req.rate); errMsg != "" {
 		fmt.Fprintf(stderr, "Error: %s\n", errMsg)
 		return 1
 	}
@@ -90,13 +190,22 @@ func runCreateCommand(stdin io.Reader, client Client, stdout, stderr io.Writer) 
 	fmt.Fprintln(stdout, "")
 	fmt.Fprintln(stdout, "Creating goal...")
 
-	goal, err := client.CreateGoal(context.Background(), slug, title, goalType, gunits, goaldate, goalval, rate)
+	goal, err := client.CreateGoal(context.Background(), req.slug, req.title, req.goalType, req.gunits, req.goaldate, req.goalval, req.rate)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error: Failed to create goal: %s\n", redactError(err))
 		return 1
 	}
 
 	fmt.Fprintf(stdout, "Successfully created goal: %s\n", goal.Slug)
+
+	if req.setDeadline {
+		if _, err := client.UpdateGoalDeadline(context.Background(), goal.Slug, req.deadline); err != nil {
+			fmt.Fprintf(stderr, "Error: Goal created but failed to set deadline: %s\n", redactError(err))
+			return 1
+		}
+		fmt.Fprintf(stdout, "Set deadline: %d seconds from midnight\n", req.deadline)
+	}
+
 	return 0
 }
 

--- a/create.go
+++ b/create.go
@@ -124,6 +124,14 @@ func parseCreateArgs(args []string, stdout, stderr io.Writer) (createRequest, in
 		return createRequest{}, 1, true
 	}
 
+	// `buzz create` takes no positional arguments; leftovers usually mean a
+	// typo'd flag or a stray value that would otherwise be silently ignored.
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "Error: unexpected argument(s): %s\n", strings.Join(fs.Args(), " "))
+		fmt.Fprintln(stderr, createUsage)
+		return createRequest{}, 1, true
+	}
+
 	// Detect whether --deadline was explicitly set: 0 (midnight) is a valid
 	// deadline, so we can't infer intent from the value alone.
 	setDeadline := false

--- a/create_test.go
+++ b/create_test.go
@@ -275,6 +275,62 @@ func TestRunCreateCommandValidationError(t *testing.T) {
 	}
 }
 
+// TestParseCreateArgsNonInteractive verifies flags are parsed into a request,
+// title defaults to the slug when omitted (#335), and --deadline is threaded
+// through to UpdateGoalDeadline (#332).
+func TestParseCreateArgsNonInteractive(t *testing.T) {
+	req, code, done := parseCreateArgs(
+		[]string{"--slug=reading", "--units=pages", "--goalval=365", "--rate=1", "--deadline=-3600"},
+		&bytes.Buffer{}, &bytes.Buffer{},
+	)
+	if done || code != 0 {
+		t.Fatalf("unexpected parse result: code=%d done=%v", code, done)
+	}
+	if req.slug != "reading" || req.gunits != "pages" || req.goalType != defaultGoalType {
+		t.Errorf("unexpected fields: %+v", req)
+	}
+	if !req.setDeadline || req.deadline != -3600 {
+		t.Errorf("deadline not captured: set=%v val=%d", req.setDeadline, req.deadline)
+	}
+
+	var gotTitle string
+	var gotDeadline int
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			gotTitle = title
+			return &Goal{Slug: slug}, nil
+		},
+		UpdateGoalDeadlineFunc: func(goalSlug string, deadline int) (*Goal, error) {
+			gotDeadline = deadline
+			return &Goal{Slug: goalSlug}, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	if c := doCreate(req, client, &stdout, &stderr); c != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", c, stderr.String())
+	}
+	if gotTitle != "reading" {
+		t.Errorf("title should default to slug, got %q", gotTitle)
+	}
+	if gotDeadline != -3600 {
+		t.Errorf("deadline not forwarded, got %d", gotDeadline)
+	}
+}
+
+// TestParseCreateArgsHelp verifies --help prints usage and signals done without
+// error.
+func TestParseCreateArgsHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	_, code, done := parseCreateArgs([]string{"--help"}, &stdout, &stderr)
+	if !done || code != 0 {
+		t.Fatalf("expected help to finish cleanly: code=%d done=%v", code, done)
+	}
+	if !strings.Contains(stdout.String(), "buzz create") {
+		t.Errorf("usage not printed, got: %s", stdout.String())
+	}
+}
+
 // TestRunCreateCommandAPIError verifies that an error from CreateGoal is
 // reported and produces a non-zero exit code.
 func TestRunCreateCommandAPIError(t *testing.T) {

--- a/create_test.go
+++ b/create_test.go
@@ -318,6 +318,44 @@ func TestParseCreateArgsNonInteractive(t *testing.T) {
 	}
 }
 
+// TestParseCreateArgsMidnightDeadline verifies that --deadline=0 (midnight) is
+// treated as an explicitly-set deadline: setDeadline must be true even though
+// the value is the zero value, since intent can't be inferred from the value.
+func TestParseCreateArgsMidnightDeadline(t *testing.T) {
+	req, code, done := parseCreateArgs(
+		[]string{"--slug=reading", "--units=pages", "--goalval=365", "--rate=1", "--deadline=0"},
+		&bytes.Buffer{}, &bytes.Buffer{},
+	)
+	if done || code != 0 {
+		t.Fatalf("unexpected parse result: code=%d done=%v", code, done)
+	}
+	if !req.setDeadline || req.deadline != 0 {
+		t.Errorf("midnight deadline not captured: set=%v val=%d", req.setDeadline, req.deadline)
+	}
+}
+
+// TestParseCreateArgsRejectsTrailingArgs verifies that stray positional
+// arguments (e.g. a typo'd flag) are rejected rather than silently ignored,
+// while valid flag-only input still parses.
+func TestParseCreateArgsRejectsTrailingArgs(t *testing.T) {
+	var stderr bytes.Buffer
+	_, code, done := parseCreateArgs(
+		[]string{"--slug=x", "--units=y", "--goalval=1", "--rate=1", "typo"},
+		&bytes.Buffer{}, &stderr,
+	)
+	if !done || code != 1 {
+		t.Fatalf("expected trailing arg to be rejected: code=%d done=%v", code, done)
+	}
+	if !strings.Contains(stderr.String(), "unexpected argument") {
+		t.Errorf("missing unexpected-argument error, got: %s", stderr.String())
+	}
+
+	// Flag-only input remains valid.
+	if _, code, done := parseCreateArgs([]string{"--slug=x", "--units=y"}, &bytes.Buffer{}, &bytes.Buffer{}); done || code != 0 {
+		t.Errorf("valid flag-only input rejected: code=%d done=%v", code, done)
+	}
+}
+
 // TestParseCreateArgsTypeResolution verifies that --type accepts a menu number
 // or human label and resolves it to the canonical goal_type, matching the
 // interactive prompt (so `--type=1` and `--type="Do Less"` both work).

--- a/create_test.go
+++ b/create_test.go
@@ -318,6 +318,85 @@ func TestParseCreateArgsNonInteractive(t *testing.T) {
 	}
 }
 
+// TestParseCreateArgsTypeResolution verifies that --type accepts a menu number
+// or human label and resolves it to the canonical goal_type, matching the
+// interactive prompt (so `--type=1` and `--type="Do Less"` both work).
+func TestParseCreateArgsTypeResolution(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"2", "drinker"},
+		{"Do Less", "drinker"},
+		{"HUSTLER", "hustler"},
+		{"whittler", "whittler"}, // unknown passes through
+	} {
+		req, code, done := parseCreateArgs([]string{"--slug=x", "--type=" + tc.in}, &bytes.Buffer{}, &bytes.Buffer{})
+		if done || code != 0 {
+			t.Fatalf("--type=%q: parse failed code=%d done=%v", tc.in, code, done)
+		}
+		if req.goalType != tc.want {
+			t.Errorf("--type=%q resolved to %q, want %q", tc.in, req.goalType, tc.want)
+		}
+	}
+}
+
+// TestDoCreateDeadlineFailure verifies the partial-failure path: the goal is
+// created but setting its deadline fails, so a distinct error is reported and
+// the exit code is non-zero.
+func TestDoCreateDeadlineFailure(t *testing.T) {
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			return &Goal{Slug: slug}, nil
+		},
+		UpdateGoalDeadlineFunc: func(goalSlug string, deadline int) (*Goal, error) {
+			return nil, errors.New("boom")
+		},
+	}
+	req := createRequest{slug: "reading", gunits: "pages", goalType: "hustler", goalval: "365", rate: "1", deadline: -3600, setDeadline: true}
+	var stdout, stderr bytes.Buffer
+	if code := doCreate(req, client, &stdout, &stderr); code != 1 {
+		t.Fatalf("expected exit 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "Goal created but failed to set deadline") {
+		t.Errorf("missing partial-failure message, got: %s", stderr.String())
+	}
+}
+
+// TestDoCreateNoDeadlineSkipsUpdate verifies that when --deadline was not passed
+// (setDeadline false), UpdateGoalDeadline is never called — the reason the
+// setDeadline flag exists, since 0 is itself a valid deadline.
+func TestDoCreateNoDeadlineSkipsUpdate(t *testing.T) {
+	deadlineCalled := false
+	client := &FakeClient{
+		CreateGoalFunc: func(slug, title, goalType, gunits, goaldate, goalval, rate string) (*Goal, error) {
+			return &Goal{Slug: slug}, nil
+		},
+		UpdateGoalDeadlineFunc: func(goalSlug string, deadline int) (*Goal, error) {
+			deadlineCalled = true
+			return &Goal{Slug: goalSlug}, nil
+		},
+	}
+	req := createRequest{slug: "reading", gunits: "pages", goalType: "hustler", goalval: "365", rate: "1"}
+	var stdout, stderr bytes.Buffer
+	if code := doCreate(req, client, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if deadlineCalled {
+		t.Error("UpdateGoalDeadline should not be called when setDeadline is false")
+	}
+}
+
+// TestParseCreateArgsBadFlag verifies an unrecognized flag is reported on stderr
+// with a non-zero exit, distinct from the --help path.
+func TestParseCreateArgsBadFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	_, code, done := parseCreateArgs([]string{"--bogus"}, &stdout, &stderr)
+	if !done || code != 1 {
+		t.Fatalf("expected error exit: code=%d done=%v", code, done)
+	}
+	if !strings.Contains(stderr.String(), "Error parsing flags") {
+		t.Errorf("missing parse-error message, got: %s", stderr.String())
+	}
+}
+
 // TestParseCreateArgsHelp verifies --help prints usage and signals done without
 // error.
 func TestParseCreateArgsHelp(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -51,6 +51,8 @@ func printHelp() {
 	fmt.Println("  buzz charge <amount> <note> [--dryrun]")
 	fmt.Println("                                    Create a charge for the authenticated user")
 	fmt.Println("  buzz create                       Interactively create a new Beeminder goal")
+	fmt.Println("  buzz create --slug=<s> --units=<u> [--title --type --goaldate --goalval --rate --deadline]")
+	fmt.Println("                                    Non-interactively create a goal (see --help)")
 	fmt.Println("  buzz deadline [--yes] <goalslug> <time>")
 	fmt.Println("                                    Change a goal's deadline (e.g., \"3:00 PM\" or \"15:00\")")
 	fmt.Println("  buzz schedule                     Display goal deadline distribution throughout a 24-hour day")


### PR DESCRIPTION
Adds a flag-based form of `buzz create` alongside the existing interactive prompts, closing three related issues.

## What

- **Non-interactive create (#331):** `buzz create --slug=reading --units=pages --goalval=365 --rate=1` — no prompts. Flags: `--slug --units --title --type --goaldate --goalval --rate --deadline`. Running `buzz create` with no flags keeps the interactive flow unchanged.
- **Optional title (#335):** title now defaults to the slug when omitted, in both paths.
- **Deadline support (#332):** `--deadline=<seconds-from-midnight>` sets the goal's deadline after creation (reuses the existing `UpdateGoalDeadline` path). `--deadline=0` (midnight) is honored — explicit-set is detected via `flag.Visit`, not the value.

`--type` accepts a menu number, canonical name, or human label (e.g. `--type=1`, `--type="Do Less"`, `--type=drinker`) — the same resolution the interactive prompt does. `--help` and bad flags report without requiring auth, matching `buzz add`.

Config loading now goes through the shared `loadClient()` helper, consistent with the other credentialed commands.

## Test

`go build`, `go test ./...`, `go vet ./...` all green. New tests cover flag parsing, `--type` resolution, title-defaults-to-slug, the deadline partial-failure path, the no-deadline skip, and `--help` / bad-flag branches.

Closes #331
Closes #332
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-interactive options for creating goals with command-line flags.
  * Added support for setting deadlines during goal creation.
  * Improved goal type handling across menu selections and text labels.
  * Added detailed usage information for `buzz create`.

* **Bug Fixes**
  * Improved error reporting for invalid flags and deadline update failures.
  * Titles now default to the provided slug when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->