### PR TITLE
fix(review): wrap error messages to terminal width

### DIFF
--- a/review.go
+++ b/review.go
@@ -360,11 +360,16 @@ func (m reviewModel) contentView() string {
 		view += loadingStyle.Render("Loading datapoints…") + "\n"
 	}
 
-	// Error message section (if any)
+	// Error message section (if any). Errors are free-form (e.g. a full API URL
+	// in a fetch failure), so wrap to the terminal width instead of letting the
+	// line overflow and get cut off. Width includes the horizontal padding.
 	if m.err != "" {
 		errorStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("9")).
 			Padding(0, 2)
+		if m.width > 0 {
+			errorStyle = errorStyle.Width(m.width)
+		}
 		view += errorStyle.Render(fmt.Sprintf("⚠ %s", m.err)) + "\n"
 	}
 

--- a/review_test.go
+++ b/review_test.go
@@ -1619,6 +1619,37 @@ func TestReviewModelDetailsErrorReflows(t *testing.T) {
 	}
 }
 
+// TestReviewModelErrorWraps verifies a long error message wraps to the terminal
+// width instead of overflowing and getting cut off (issue #339).
+func TestReviewModelErrorWraps(t *testing.T) {
+	goals := []Goal{{Slug: "g", Title: "A goal", Limsum: "+1 in 2 days"}}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+	m = updated.(reviewModel)
+	m.err = "Failed to load goal details: failed to fetch goal details: " +
+		"Get \"https://www.beeminder.com/api/v1/users/x/goals/y.json\": dial tcp: timeout"
+
+	// The error block is the last thing contentView appends, so every line from
+	// the ⚠ marker onward belongs to it.
+	inError := false
+	for _, line := range strings.Split(m.contentView(), "\n") {
+		if strings.Contains(line, "⚠") {
+			inError = true
+		}
+		if !inError {
+			continue
+		}
+		if w := lipgloss.Width(line); w > 40 {
+			t.Errorf("expected error to wrap within width 40, got line width %d: %q", w, line)
+		}
+	}
+	if !inError {
+		t.Fatal("expected the error to render, but no ⚠ line was found")
+	}
+}
+
 // TestReviewModelNoScrollIndicatorWhenContentFits verifies the help bar omits the
 // scroll-position indicator when the goal fits the terminal (nothing to scroll).
 func TestReviewModelNoScrollIndicatorWhenContentFits(t *testing.T) {

--- a/review_test.go
+++ b/review_test.go
@@ -1650,6 +1650,21 @@ func TestReviewModelErrorWraps(t *testing.T) {
 	}
 }
 
+// TestReviewModelErrorRendersBeforeResize verifies the width guard: before any
+// WindowSizeMsg (m.width == 0), the error must render in full. Without the
+// `if m.width > 0` guard, lipgloss Width(0) would collapse it to nothing.
+func TestReviewModelErrorRendersBeforeResize(t *testing.T) {
+	goals := []Goal{{Slug: "g", Title: "A goal", Limsum: "+1 in 2 days"}}
+	config := &Config{Username: "testuser", AuthToken: "testtoken"}
+
+	m := initialReviewModel(goals, config) // no WindowSizeMsg → m.width == 0
+	m.err = "Failed to load goal details: boom"
+
+	if !strings.Contains(m.contentView(), "Failed to load goal details: boom") {
+		t.Errorf("expected the full error to render before resize, got:\n%s", m.contentView())
+	}
+}
+
 // TestReviewModelNoScrollIndicatorWhenContentFits verifies the help bar omits the
 // scroll-position indicator when the goal fits the terminal (nothing to scroll).
 func TestReviewModelNoScrollIndicatorWhenContentFits(t *testing.T) {


### PR DESCRIPTION
Closes #339.

## Problem

Long error messages in `buzz review` overflowed the line and got cut off:

```
  ⚠ Failed to load goal details: failed to fetch goal details: Get "ht
```

## Fix

The error style in `contentView` had no width set, so lipgloss never wrapped it. Set `Width(m.width)` on the error style (guarded by `m.width > 0` so the pre-resize zero-width case is skipped, which would otherwise collapse the text). lipgloss force-wraps even an unbroken URL to the content area.

The goal detail table is intentionally left unwrapped — it's a fixed-width layout, not free-form text.

## Tests

- `TestReviewModelErrorWraps` — long error wraps within a 40-col terminal (verified it fails without the fix: line width 143).
- `TestReviewModelErrorRendersBeforeResize` — the `m.width == 0` guard renders the full error before the first resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long goal-detail error messages now wrap within the available terminal width instead of overflowing horizontally.
  - Error messages display correctly even before the terminal size has been detected.
  - Warning text remains fully readable across different terminal sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->