### PR TITLE
feat(cli): add global --format flag (table/json/csv)

### DIFF
--- a/data.go
+++ b/data.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -10,7 +9,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -21,7 +19,8 @@ func handleDataCommand() {
 		os.Exit(1)
 	}
 	code := runDataCommand(os.Args[2:], client, outputFormat, os.Stdout, os.Stderr)
-	if code == 0 {
+	if code == 0 && outputFormat == "table" {
+		// Skip the update banner for json/csv so it never corrupts machine output.
 		fmt.Print(getUpdateMessage())
 	}
 	os.Exit(code)
@@ -137,19 +136,11 @@ func renderDatapointsAs(format string, dps []Datapoint) (string, error) {
 		}
 		return string(b) + "\n", nil
 	case "csv":
-		var buf strings.Builder
-		w := csv.NewWriter(&buf)
-		if err := w.Write([]string{"date", "value", "comment"}); err != nil {
-			return "", err
+		rows := make([][]string, len(dps))
+		for i, dp := range dps {
+			rows[i] = []string{datapointDate(dp), fmt.Sprintf("%.6g", dp.Value), dp.Comment}
 		}
-		for _, dp := range dps {
-			row := []string{datapointDate(dp), fmt.Sprintf("%.6g", dp.Value), dp.Comment}
-			if err := w.Write(row); err != nil {
-				return "", err
-			}
-		}
-		w.Flush()
-		return buf.String(), w.Error()
+		return encodeCSV([]string{"date", "value", "comment"}, rows)
 	default:
 		return "", fmt.Errorf("unknown format %q (want table, json, or csv)", format)
 	}

--- a/data.go
+++ b/data.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -17,7 +20,7 @@ func handleDataCommand() {
 	if !ok {
 		os.Exit(1)
 	}
-	code := runDataCommand(os.Args[2:], client, os.Stdout, os.Stderr)
+	code := runDataCommand(os.Args[2:], client, outputFormat, os.Stdout, os.Stderr)
 	if code == 0 {
 		fmt.Print(getUpdateMessage())
 	}
@@ -27,7 +30,7 @@ func handleDataCommand() {
 // runDataCommand is the testable core of `buzz data`. It expects a single
 // <goalslug> argument and prints that goal's datapoints one per line as
 // "date  value  comment", oldest-first by default or newest-first with --desc.
-func runDataCommand(args []string, client Client, stdout, stderr io.Writer) int {
+func runDataCommand(args []string, client Client, format string, stdout, stderr io.Writer) int {
 	const usage = "Usage: buzz data [--asc|--desc] <goalslug>"
 
 	// Parse flags on either side of the positional slug (as `view` does), so
@@ -81,11 +84,6 @@ func runDataCommand(args []string, client Client, stdout, stderr io.Writer) int 
 		return 1
 	}
 
-	if len(goal.Datapoints) == 0 {
-		fmt.Fprintf(stdout, "No datapoints found for goal: %s\n", goalSlug)
-		return 0
-	}
-
 	// The API's datapoint order isn't guaranteed; sort by timestamp so the
 	// output is deterministic. Default oldest-first; --desc flips to newest-first.
 	dps := append([]Datapoint(nil), goal.Datapoints...)
@@ -96,6 +94,23 @@ func runDataCommand(args []string, client Client, stdout, stderr io.Writer) int 
 		return dps[i].Timestamp < dps[j].Timestamp
 	})
 
+	// Machine-readable formats emit valid output even when empty ([] / header
+	// row), so they run before the human "No datapoints" short-circuit.
+	if format != "table" {
+		rendered, err := renderDatapointsAs(format, dps)
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %s\n", redactError(err))
+			return 1
+		}
+		fmt.Fprint(stdout, rendered)
+		return 0
+	}
+
+	if len(dps) == 0 {
+		fmt.Fprintf(stdout, "No datapoints found for goal: %s\n", goalSlug)
+		return 0
+	}
+
 	dates, values, maxValueLen := formatDatapointRows(dps)
 	for i, dp := range dps {
 		if dp.Comment != "" {
@@ -105,6 +120,39 @@ func runDataCommand(args []string, client Client, stdout, stderr io.Writer) int 
 		}
 	}
 	return 0
+}
+
+// renderDatapointsAs renders datapoints as json (the raw datapoint objects) or
+// csv (date, value, comment — matching the human table's columns). The date and
+// value formatting mirror the text output so all three formats agree.
+func renderDatapointsAs(format string, dps []Datapoint) (string, error) {
+	switch format {
+	case "json":
+		if dps == nil {
+			dps = []Datapoint{} // marshal an empty list as [] rather than null
+		}
+		b, err := json.MarshalIndent(dps, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(b) + "\n", nil
+	case "csv":
+		var buf strings.Builder
+		w := csv.NewWriter(&buf)
+		if err := w.Write([]string{"date", "value", "comment"}); err != nil {
+			return "", err
+		}
+		for _, dp := range dps {
+			row := []string{datapointDate(dp), fmt.Sprintf("%.6g", dp.Value), dp.Comment}
+			if err := w.Write(row); err != nil {
+				return "", err
+			}
+		}
+		w.Flush()
+		return buf.String(), w.Error()
+	default:
+		return "", fmt.Errorf("unknown format %q (want table, json, or csv)", format)
+	}
 }
 
 // formatDatapointRows renders per-datapoint date and value strings (parallel to

--- a/data_test.go
+++ b/data_test.go
@@ -49,6 +49,33 @@ func TestRunDataCommand(t *testing.T) {
 			checkResult(t, code, out.String(), errb.String(), tt.wantCode, tt.wantOut, tt.wantErr)
 		})
 	}
+
+	t.Run("json format emits datapoint objects", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := runDataCommand([]string{"g"}, &FakeClient{FetchGoalWithDatapointsFunc: twoPoints}, "json", &out, &errb)
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", code, errb.String())
+		}
+		var dps []Datapoint
+		if err := json.Unmarshal([]byte(out.String()), &dps); err != nil {
+			t.Fatalf("json output not valid: %v\n%s", err, out.String())
+		}
+		if len(dps) != 2 {
+			t.Errorf("expected 2 datapoints, got %d", len(dps))
+		}
+	})
+
+	t.Run("json format emits [] for no datapoints", func(t *testing.T) {
+		empty := func(string) (*Goal, error) { return &Goal{}, nil }
+		var out, errb bytes.Buffer
+		code := runDataCommand([]string{"g"}, &FakeClient{FetchGoalWithDatapointsFunc: empty}, "json", &out, &errb)
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+		if got := out.String(); got != "[]\n" {
+			t.Errorf("empty json = %q, want %q", got, "[]\n")
+		}
+	})
 }
 
 // TestRenderDatapointsAs covers the --format json/csv output for `buzz data`:
@@ -86,5 +113,9 @@ func TestRenderDatapointsAs(t *testing.T) {
 	}
 	if got, _ := renderDatapointsAs("csv", nil); got != "date,value,comment\n" {
 		t.Errorf("empty csv = %q, want header only", got)
+	}
+
+	if _, err := renderDatapointsAs("yaml", dps); err == nil {
+		t.Error("renderDatapointsAs(yaml) = nil error, want error")
 	}
 }

--- a/data_test.go
+++ b/data_test.go
@@ -57,7 +57,7 @@ func TestRunDataCommand(t *testing.T) {
 			t.Fatalf("expected exit 0, got %d (stderr: %s)", code, errb.String())
 		}
 		var dps []Datapoint
-		if err := json.Unmarshal([]byte(out.String()), &dps); err != nil {
+		if err := json.Unmarshal(out.Bytes(), &dps); err != nil {
 			t.Fatalf("json output not valid: %v\n%s", err, out.String())
 		}
 		if len(dps) != 2 {

--- a/data_test.go
+++ b/data_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -44,8 +45,46 @@ func TestRunDataCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out, errb bytes.Buffer
-			code := runDataCommand(tt.args, &FakeClient{FetchGoalWithDatapointsFunc: tt.fn}, &out, &errb)
+			code := runDataCommand(tt.args, &FakeClient{FetchGoalWithDatapointsFunc: tt.fn}, "table", &out, &errb)
 			checkResult(t, code, out.String(), errb.String(), tt.wantCode, tt.wantOut, tt.wantErr)
 		})
+	}
+}
+
+// TestRenderDatapointsAs covers the --format json/csv output for `buzz data`:
+// csv reuses the date/value/comment columns, json is a valid array, and empty
+// input yields [] (json) / a header-only file (csv) rather than "null".
+func TestRenderDatapointsAs(t *testing.T) {
+	dps := []Datapoint{
+		{Daystamp: "20240101", Value: 3, Comment: "first"},
+		{Daystamp: "20240102", Value: 12.5, Comment: ""},
+	}
+
+	csvOut, err := renderDatapointsAs("csv", dps)
+	if err != nil {
+		t.Fatalf("csv error: %v", err)
+	}
+	wantCSV := "date,value,comment\n2024-01-01,3,first\n2024-01-02,12.5,\n"
+	if csvOut != wantCSV {
+		t.Errorf("csv = %q, want %q", csvOut, wantCSV)
+	}
+
+	jsonOut, err := renderDatapointsAs("json", dps)
+	if err != nil {
+		t.Fatalf("json error: %v", err)
+	}
+	var decoded []Datapoint
+	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+		t.Fatalf("json invalid: %v\n%s", err, jsonOut)
+	}
+	if len(decoded) != 2 || decoded[0].Comment != "first" {
+		t.Errorf("json roundtrip mismatch: %+v", decoded)
+	}
+
+	if got, _ := renderDatapointsAs("json", nil); got != "[]\n" {
+		t.Errorf("empty json = %q, want %q", got, "[]\n")
+	}
+	if got, _ := renderDatapointsAs("csv", nil); got != "date,value,comment\n" {
+		t.Errorf("empty csv = %q, want header only", got)
 	}
 }

--- a/data_test.go
+++ b/data_test.go
@@ -76,6 +76,18 @@ func TestRunDataCommand(t *testing.T) {
 			t.Errorf("empty json = %q, want %q", got, "[]\n")
 		}
 	})
+
+	t.Run("csv format emits header plus one row per datapoint", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := runDataCommand([]string{"g"}, &FakeClient{FetchGoalWithDatapointsFunc: twoPoints}, "csv", &out, &errb)
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", code, errb.String())
+		}
+		want := "date,value,comment\n2024-01-01,3,first\n2024-01-02,12.5,later\n"
+		if got := out.String(); got != want {
+			t.Errorf("csv output = %q, want %q", got, want)
+		}
+	})
 }
 
 // TestRenderDatapointsAs covers the --format json/csv output for `buzz data`:

--- a/filtered.go
+++ b/filtered.go
@@ -187,8 +187,9 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 		}
 	}
 
-	// If no matching goals, exit
-	if len(filteredGoals) == 0 {
+	// If no matching goals, exit — but only short-circuit the human table;
+	// json/csv still emit an empty result below so scripts get valid output.
+	if len(filteredGoals) == 0 && outputFormat == "table" {
 		fmt.Printf("No %s goals found.\n", filterName)
 		return
 	}
@@ -200,20 +201,35 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 	// displayed losedates are equal.
 	sortGoalsByDisplayedLosedate(filteredGoals, losedateFor)
 
+	// Headers are unused by the colorized text table (ShowHeader stays false)
+	// but label the columns for --format csv.
 	table := Table{
 		Colorize: true,
 		Columns: []Column{
-			{Cell: func(g Goal) string { return g.Slug }},
-			{Cell: func(g Goal) string { return bareminFor(g) }},
-			{Cell: func(g Goal) string {
+			{Header: "Slug", Cell: func(g Goal) string { return g.Slug }},
+			{Header: "Baremin", Cell: func(g Goal) string { return bareminFor(g) }},
+			{Header: "Due", Cell: func(g Goal) string {
 				if IsEndValueReached(g) {
 					return "COMPLETE"
 				}
 				return FormatDueDate(losedateFor(g))
 			}},
-			{Cell: func(g Goal) string { return FormatAbsoluteDeadline(losedateFor(g)) }},
+			{Header: "Deadline", Cell: func(g Goal) string { return FormatAbsoluteDeadline(losedateFor(g)) }},
 		},
 	}
+
+	// Machine-readable formats: emit just the data, no legend or update banner
+	// (they'd corrupt json/csv output).
+	if outputFormat != "table" {
+		rendered, err := table.RenderAs(outputFormat, filteredGoals)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
+			os.Exit(1)
+		}
+		fmt.Print(rendered)
+		return
+	}
+
 	fmt.Print(table.Render(filteredGoals))
 
 	if legendFor != nil {

--- a/filtered.go
+++ b/filtered.go
@@ -60,7 +60,15 @@ func handleTomorrowCommand() {
 		return v
 	}
 	filter := func(g Goal) bool { return isDueTomorrowFilterAt(g, now) }
-	bareminFor := func(g Goal) string { return viewFor(g).markedBaremin() }
+	// The "(!)" marker is a table-only annotation whose explanatory legend is
+	// suppressed for machine formats — so json/csv get the raw baremin, keeping
+	// the value parseable rather than leaking "(!) +5" into a numeric column.
+	bareminFor := func(g Goal) string {
+		if outputFormat != "table" {
+			return viewFor(g).baremin
+		}
+		return viewFor(g).markedBaremin()
+	}
 	losedateFor := func(g Goal) int64 { return viewFor(g).losedate }
 	// Explain the "(!)" marker, but only when a flagged goal is actually shown.
 	legendFor := func(goals []Goal) string { return tomorrowLegend(goals, viewFor) }

--- a/goaltable.go
+++ b/goaltable.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -95,6 +97,54 @@ func (t Table) Render(goals []Goal) string {
 	}
 
 	return b.String()
+}
+
+// RenderAs renders the goals in the requested output format for the global
+// --format flag. "table" (and "") give the human-readable column table; "json"
+// emits the raw goal objects (every API field) for scripting; "csv" emits the
+// table's own columns as comma-separated rows with a header.
+//
+// json intentionally carries the full objects rather than the displayed
+// columns, so a projected/bumped column value (e.g. the `tomorrow` view's
+// baremin) surfaces only in table and csv output — csv reuses the Cell
+// functions, json reflects the underlying goal.
+func (t Table) RenderAs(format string, goals []Goal) (string, error) {
+	switch format {
+	case "", "table":
+		return t.Render(goals), nil
+	case "json":
+		if goals == nil {
+			goals = []Goal{} // marshal an empty list as [] rather than null
+		}
+		b, err := json.MarshalIndent(goals, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(b) + "\n", nil
+	case "csv":
+		var buf strings.Builder
+		w := csv.NewWriter(&buf)
+		headers := make([]string, len(t.Columns))
+		for i, c := range t.Columns {
+			headers[i] = c.Header
+		}
+		if err := w.Write(headers); err != nil {
+			return "", err
+		}
+		for _, g := range goals {
+			row := make([]string, len(t.Columns))
+			for j, c := range t.Columns {
+				row[j] = c.Cell(g)
+			}
+			if err := w.Write(row); err != nil {
+				return "", err
+			}
+		}
+		w.Flush()
+		return buf.String(), w.Error()
+	default:
+		return "", fmt.Errorf("unknown format %q (want table, json, or csv)", format)
+	}
 }
 
 // padRow joins cells with two-space separators, left-padding every column

--- a/goaltable.go
+++ b/goaltable.go
@@ -122,29 +122,41 @@ func (t Table) RenderAs(format string, goals []Goal) (string, error) {
 		}
 		return string(b) + "\n", nil
 	case "csv":
-		var buf strings.Builder
-		w := csv.NewWriter(&buf)
+		// ponytail: cells (baremin "+1", free-text comments) aren't sanitized for
+		// spreadsheet formula injection — it's the user's own data on their own
+		// machine, so they'd only be attacking themselves. Add ^[=+\-@] quoting if
+		// csv ever carries another account's data.
 		headers := make([]string, len(t.Columns))
 		for i, c := range t.Columns {
 			headers[i] = c.Header
 		}
-		if err := w.Write(headers); err != nil {
-			return "", err
-		}
-		for _, g := range goals {
+		rows := make([][]string, len(goals))
+		for i, g := range goals {
 			row := make([]string, len(t.Columns))
 			for j, c := range t.Columns {
 				row[j] = c.Cell(g)
 			}
-			if err := w.Write(row); err != nil {
-				return "", err
-			}
+			rows[i] = row
 		}
-		w.Flush()
-		return buf.String(), w.Error()
+		return encodeCSV(headers, rows)
 	default:
 		return "", fmt.Errorf("unknown format %q (want table, json, or csv)", format)
 	}
+}
+
+// encodeCSV renders a header row followed by data rows as a CSV string. The
+// csv.Writer buffers and latches the first write error, surfaced by w.Error()
+// after Flush — so one final check replaces per-row error handling. Shared by
+// the goal, datapoint, and `next` csv output paths.
+func encodeCSV(headers []string, rows [][]string) (string, error) {
+	var buf strings.Builder
+	w := csv.NewWriter(&buf)
+	w.Write(headers)
+	for _, r := range rows {
+		w.Write(r)
+	}
+	w.Flush()
+	return buf.String(), w.Error()
 }
 
 // padRow joins cells with two-space separators, left-padding every column

--- a/goaltable_test.go
+++ b/goaltable_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -104,5 +105,60 @@ func TestTableRenderColorize(t *testing.T) {
 	if strings.ReplaceAll(overdueLine, "overdue", "") == strings.ReplaceAll(distantLine, "distant", "") {
 		t.Errorf("colourised rows for different urgencies are identical; expected different ANSI wrappers\noverdue: %q\ndistant: %q",
 			overdueLine, distantLine)
+	}
+}
+
+// TestTableRenderAs covers the --format json/csv paths: json carries the raw
+// goal objects, csv reuses the column headers/cells, table is unchanged, and an
+// unknown format errors. Empty goals must still produce valid output ([] / a
+// header row) rather than "null".
+func TestTableRenderAs(t *testing.T) {
+	tbl := Table{
+		Columns: []Column{
+			{Header: "Slug", Cell: func(g Goal) string { return g.Slug }},
+			{Header: "Baremin", Cell: func(g Goal) string { return g.Baremin }},
+		},
+	}
+	goals := []Goal{{Slug: "run", Baremin: "+1"}, {Slug: "read", Baremin: "+2"}}
+
+	// table == Render
+	if got, err := tbl.RenderAs("table", goals); err != nil || got != tbl.Render(goals) {
+		t.Errorf("RenderAs(table) = %q, %v; want == Render", got, err)
+	}
+
+	// json: valid array of the full goal objects (raw slug field present)
+	jsonOut, err := tbl.RenderAs("json", goals)
+	if err != nil {
+		t.Fatalf("RenderAs(json) error: %v", err)
+	}
+	var decoded []Goal
+	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+		t.Fatalf("json output not valid: %v\n%s", err, jsonOut)
+	}
+	if len(decoded) != 2 || decoded[0].Slug != "run" {
+		t.Errorf("json roundtrip mismatch: %+v", decoded)
+	}
+
+	// csv: header row from Column.Header, then one row per goal
+	csvOut, err := tbl.RenderAs("csv", goals)
+	if err != nil {
+		t.Fatalf("RenderAs(csv) error: %v", err)
+	}
+	wantCSV := "Slug,Baremin\nrun,+1\nread,+2\n"
+	if csvOut != wantCSV {
+		t.Errorf("csv output = %q, want %q", csvOut, wantCSV)
+	}
+
+	// empty goals: json emits [] not null; csv emits just the header
+	if got, _ := tbl.RenderAs("json", nil); got != "[]\n" {
+		t.Errorf("RenderAs(json, nil) = %q, want %q", got, "[]\n")
+	}
+	if got, _ := tbl.RenderAs("csv", nil); got != "Slug,Baremin\n" {
+		t.Errorf("RenderAs(csv, nil) = %q, want header only", got)
+	}
+
+	// unknown format is an error
+	if _, err := tbl.RenderAs("yaml", goals); err == nil {
+		t.Error("RenderAs(yaml) = nil error, want error")
 	}
 }

--- a/list.go
+++ b/list.go
@@ -34,7 +34,7 @@ func handleListCommand() {
 	}
 
 	client := NewHTTPClient(config)
-	code = runListCommand(context.Background(), client, archived, os.Stdout, os.Stderr)
+	code = runListCommand(context.Background(), client, archived, outputFormat, os.Stdout, os.Stderr)
 	if code == 0 {
 		// Check for updates and display message if available
 		fmt.Print(getUpdateMessage())
@@ -76,7 +76,7 @@ func parseListArgs(args []string, out, errOut io.Writer) (archived bool, exitCod
 // to out, writes any fetch error to errOut, and returns the process exit code.
 // Splitting stdout (out) from stderr (errOut) keeps the table pipeable and
 // matches the other command cores (e.g. runCreateCommand).
-func runListCommand(ctx context.Context, client Client, archived bool, out, errOut io.Writer) int {
+func runListCommand(ctx context.Context, client Client, archived bool, format string, out, errOut io.Writer) int {
 	noun := "goals"
 	fetch := client.FetchGoals
 	if archived {
@@ -93,14 +93,6 @@ func runListCommand(ctx context.Context, client Client, archived bool, out, errO
 	// Sort goals alphabetically by slug for easy scanning
 	SortGoalsBySlug(goals)
 
-	if len(goals) == 0 {
-		fmt.Fprintf(out, "No %s found.\n", noun)
-		return 0
-	}
-
-	// Print summary header
-	fmt.Fprintf(out, "Total %s: %d\n\n", noun, len(goals))
-
 	table := Table{
 		ShowHeader: true,
 		Columns: []Column{
@@ -116,6 +108,26 @@ func runListCommand(ctx context.Context, client Client, archived bool, out, errO
 			{Header: "Stakes", Cell: func(g Goal) string { return fmt.Sprintf("$%.2f", g.Pledge) }},
 		},
 	}
+
+	// Machine-readable formats: emit just the data (json/csv handle the empty
+	// case as [] / a header-only file), skipping the human summary header.
+	if format != "table" {
+		rendered, err := table.RenderAs(format, goals)
+		if err != nil {
+			fmt.Fprintf(errOut, "Error: %s\n", redactError(err))
+			return 1
+		}
+		fmt.Fprint(out, rendered)
+		return 0
+	}
+
+	if len(goals) == 0 {
+		fmt.Fprintf(out, "No %s found.\n", noun)
+		return 0
+	}
+
+	// Print summary header
+	fmt.Fprintf(out, "Total %s: %d\n\n", noun, len(goals))
 	fmt.Fprint(out, table.Render(goals))
 
 	return 0

--- a/list.go
+++ b/list.go
@@ -35,8 +35,9 @@ func handleListCommand() {
 
 	client := NewHTTPClient(config)
 	code = runListCommand(context.Background(), client, archived, outputFormat, os.Stdout, os.Stderr)
-	if code == 0 {
-		// Check for updates and display message if available
+	if code == 0 && outputFormat == "table" {
+		// Check for updates and display message if available. Skipped for json/csv
+		// so the update banner never corrupts machine-readable output.
 		fmt.Print(getUpdateMessage())
 	}
 	os.Exit(code)

--- a/list_test.go
+++ b/list_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -214,6 +215,44 @@ func TestRunListCommand(t *testing.T) {
 		}
 		if got := out.String(); !strings.Contains(got, "No archived goals found.") {
 			t.Errorf("expected empty-archived message, got:\n%s", got)
+		}
+	})
+
+	t.Run("json format skips the human header", func(t *testing.T) {
+		client := &FakeClient{
+			FetchGoalsFunc: func() ([]Goal, error) {
+				return []Goal{{Slug: "apple"}, {Slug: "zebra"}}, nil
+			},
+		}
+
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, false, "json", &out, &errOut)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		got := out.String()
+		if strings.Contains(got, "Total goals") {
+			t.Errorf("json output should not contain the human header, got:\n%s", got)
+		}
+		var goals []Goal
+		if err := json.Unmarshal([]byte(got), &goals); err != nil {
+			t.Fatalf("json output not valid: %v\n%s", err, got)
+		}
+		if len(goals) != 2 || goals[0].Slug != "apple" {
+			t.Errorf("json roundtrip mismatch: %+v", goals)
+		}
+	})
+
+	t.Run("json format emits [] for empty goals", func(t *testing.T) {
+		client := &FakeClient{FetchGoalsFunc: func() ([]Goal, error) { return nil, nil }}
+
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, false, "json", &out, &errOut)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		if got := out.String(); got != "[]\n" {
+			t.Errorf("empty json = %q, want %q", got, "[]\n")
 		}
 	})
 

--- a/list_test.go
+++ b/list_test.go
@@ -151,7 +151,7 @@ func TestRunListCommand(t *testing.T) {
 		}
 
 		var out, errOut bytes.Buffer
-		code := runListCommand(context.Background(), client, false, &out, &errOut)
+		code := runListCommand(context.Background(), client, false, "table", &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -175,7 +175,7 @@ func TestRunListCommand(t *testing.T) {
 		}
 
 		var out, errOut bytes.Buffer
-		code := runListCommand(context.Background(), client, true, &out, &errOut)
+		code := runListCommand(context.Background(), client, true, "table", &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -195,7 +195,7 @@ func TestRunListCommand(t *testing.T) {
 		client := &FakeClient{FetchGoalsFunc: func() ([]Goal, error) { return nil, nil }}
 
 		var out, errOut bytes.Buffer
-		code := runListCommand(context.Background(), client, false, &out, &errOut)
+		code := runListCommand(context.Background(), client, false, "table", &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -208,7 +208,7 @@ func TestRunListCommand(t *testing.T) {
 		client := &FakeClient{FetchArchivedGoalsFunc: func() ([]Goal, error) { return nil, nil }}
 
 		var out, errOut bytes.Buffer
-		code := runListCommand(context.Background(), client, true, &out, &errOut)
+		code := runListCommand(context.Background(), client, true, "table", &out, &errOut)
 		if code != 0 {
 			t.Fatalf("expected exit code 0, got %d", code)
 		}
@@ -225,7 +225,7 @@ func TestRunListCommand(t *testing.T) {
 		}
 
 		var out, errOut bytes.Buffer
-		code := runListCommand(context.Background(), client, true, &out, &errOut)
+		code := runListCommand(context.Background(), client, true, "table", &out, &errOut)
 		if code != 1 {
 			t.Fatalf("expected exit code 1, got %d", code)
 		}

--- a/list_test.go
+++ b/list_test.go
@@ -256,6 +256,31 @@ func TestRunListCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("csv format emits header plus one row per goal", func(t *testing.T) {
+		client := &FakeClient{
+			FetchGoalsFunc: func() ([]Goal, error) {
+				return []Goal{{Slug: "apple"}, {Slug: "zebra"}}, nil
+			},
+		}
+
+		var out, errOut bytes.Buffer
+		code := runListCommand(context.Background(), client, false, "csv", &out, &errOut)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d", code)
+		}
+		got := out.String()
+		if !strings.HasPrefix(got, "Slug,Title,Units,Rate,Stakes\n") {
+			t.Errorf("csv missing expected header row, got:\n%s", got)
+		}
+		if strings.Contains(got, "Total goals") {
+			t.Errorf("csv output should not contain the human summary, got:\n%s", got)
+		}
+		lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+		if len(lines) != 3 { // header + 2 goals
+			t.Errorf("expected 3 csv lines (header + 2 goals), got %d:\n%s", len(lines), got)
+		}
+	})
+
 	t.Run("fetch error returns exit code 1", func(t *testing.T) {
 		client := &FakeClient{
 			FetchArchivedGoalsFunc: func() ([]Goal, error) {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	// Embed the IANA timezone database so time.LoadLocation works on systems
 	// without system tzdata (e.g. Windows, minimal containers). The schedule
@@ -17,6 +18,14 @@ import (
 
 // version is set via ldflags during build
 var version = "dev"
+
+// outputFormat holds the global --format value ("table", "json", or "csv"),
+// set once in main from the CLI. The list-style read commands and `data` honor
+// it; other commands ignore it (like --no-color).
+var outputFormat = "table"
+
+// validFormats are the accepted --format values.
+var validFormats = map[string]bool{"table": true, "json": true, "csv": true}
 
 func printHelp() {
 	fmt.Println("buzz - A terminal user interface for Beeminder")
@@ -68,6 +77,7 @@ func printHelp() {
 	fmt.Println("  buzz help                         Show this help message")
 	fmt.Println("")
 	fmt.Println("GLOBAL OPTIONS:")
+	fmt.Println("  --format <table|json|csv>         Output format for list commands and data (default: table)")
 	fmt.Println("  --no-color                        Disable colored output")
 	fmt.Println("  -h, --help                        Show this help message")
 	fmt.Println("  -v, --version                     Show version information")
@@ -96,6 +106,34 @@ func parseNoColorFlag(args []string) (noColor bool, filteredArgs []string) {
 	return noColor, filteredArgs
 }
 
+// parseFormatFlag extracts a global --format <value> (or --format=<value>) flag
+// from args, returning the chosen format ("table" when absent) and args with
+// the flag removed. A missing or unknown value is an error.
+func parseFormatFlag(args []string) (format string, filteredArgs []string, err error) {
+	format = "table"
+	filteredArgs = []string{args[0]} // Keep program name
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--format":
+			if i+1 >= len(args) {
+				return "", nil, fmt.Errorf("--format requires a value (table, json, or csv)")
+			}
+			format = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--format="):
+			format = strings.TrimPrefix(arg, "--format=")
+		default:
+			filteredArgs = append(filteredArgs, arg)
+			continue
+		}
+		if !validFormats[format] {
+			return "", nil, fmt.Errorf("invalid --format value %q (want table, json, or csv)", format)
+		}
+	}
+	return format, filteredArgs, nil
+}
+
 func main() {
 	// Check for global --no-color flag before processing other commands
 	noColor, filteredArgs := parseNoColorFlag(os.Args)
@@ -105,6 +143,16 @@ func main() {
 	if noColor {
 		lipgloss.SetColorProfile(termenv.Ascii)
 	}
+
+	// Extract the global --format flag before command dispatch, mirroring
+	// --no-color. Handlers read outputFormat; unknown values fail fast.
+	format, formatFiltered, err := parseFormatFlag(os.Args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(2)
+	}
+	os.Args = formatFiltered
+	outputFormat = format
 
 	// Check for CLI arguments
 	if len(os.Args) > 1 {

--- a/main.go
+++ b/main.go
@@ -20,8 +20,8 @@ import (
 var version = "dev"
 
 // outputFormat holds the global --format value ("table", "json", or "csv"),
-// set once in main from the CLI. The list-style read commands and `data` honor
-// it; other commands ignore it (like --no-color).
+// set once in main from the CLI. The list-style read commands, `data`, and
+// `next` honor it; other commands ignore it (like --no-color).
 var outputFormat = "table"
 
 // validFormats are the accepted --format values.
@@ -77,7 +77,7 @@ func printHelp() {
 	fmt.Println("  buzz help                         Show this help message")
 	fmt.Println("")
 	fmt.Println("GLOBAL OPTIONS:")
-	fmt.Println("  --format <table|json|csv>         Output format for list commands and data (default: table)")
+	fmt.Println("  --format <table|json|csv>         Output format for the list commands, data, and next (default: table)")
 	fmt.Println("  --no-color                        Disable colored output")
 	fmt.Println("  -h, --help                        Show this help message")
 	fmt.Println("  -v, --version                     Show version information")

--- a/main_test.go
+++ b/main_test.go
@@ -168,6 +168,46 @@ func TestNoColorFlag(t *testing.T) {
 	}
 }
 
+// TestParseFormatFlag covers the global --format extraction: default, both flag
+// spellings, flag removal from args, and error cases (missing/invalid value).
+func TestParseFormatFlag(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantFormat string
+		wantArgs   []string
+		wantErr    bool
+	}{
+		{"no flag defaults to table", []string{"buzz", "list"}, "table", []string{"buzz", "list"}, false},
+		{"--format json (space)", []string{"buzz", "--format", "json", "list"}, "json", []string{"buzz", "list"}, false},
+		{"--format=csv (equals)", []string{"buzz", "list", "--format=csv"}, "csv", []string{"buzz", "list"}, false},
+		{"invalid value errors", []string{"buzz", "--format", "yaml", "list"}, "", nil, true},
+		{"missing value errors", []string{"buzz", "list", "--format"}, "", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, filtered, err := parseFormatFlag(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if format != tt.wantFormat {
+				t.Errorf("format = %q, want %q", format, tt.wantFormat)
+			}
+			if len(filtered) != len(tt.wantArgs) {
+				t.Fatalf("filtered args = %v, want %v", filtered, tt.wantArgs)
+			}
+			for i, a := range tt.wantArgs {
+				if filtered[i] != a {
+					t.Errorf("filtered[%d] = %q, want %q", i, filtered[i], a)
+				}
+			}
+		})
+	}
+}
+
 // TestDueFiltersSkipEndValueReached verifies that the today and tomorrow filters
 // exclude goals whose end value has already been reached — those goals can show
 // a negative baremin and shouldn't be surfaced as due.

--- a/next.go
+++ b/next.go
@@ -145,9 +145,16 @@ func clearScreen() {
 
 // displayNextGoalWithTimestamp displays the next goal with a timestamp and refresh info
 func displayNextGoalWithTimestamp() {
-	fmt.Printf("[%s]\n", time.Now().Format("2006-01-02 15:04:05"))
+	// Machine-readable formats skip the timestamp header and refresh footer so
+	// each watch iteration stays parseable (raw json/csv, no surrounding chrome).
+	table := outputFormat == "" || outputFormat == "table"
+	if table {
+		fmt.Printf("[%s]\n", time.Now().Format("2006-01-02 15:04:05"))
+	}
 	if err := displayNextGoal(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", redactError(err))
 	}
-	fmt.Printf("\nRefreshing every %dm... (Press Ctrl+C to exit)\n", int(RefreshInterval.Minutes()))
+	if table {
+		fmt.Printf("\nRefreshing every %dm... (Press Ctrl+C to exit)\n", int(RefreshInterval.Minutes()))
+	}
 }

--- a/next.go
+++ b/next.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -94,15 +92,11 @@ func displayNextGoal() error {
 		fmt.Println(string(b))
 		return nil
 	case "csv":
-		var buf strings.Builder
-		w := csv.NewWriter(&buf)
-		w.Write([]string{"slug", "baremin", "due"})
-		w.Write([]string{nextGoal.Slug, nextGoal.Baremin, timeframe})
-		w.Flush()
-		if err := w.Error(); err != nil {
+		out, err := encodeCSV([]string{"slug", "baremin", "due"}, [][]string{{nextGoal.Slug, nextGoal.Baremin, timeframe}})
+		if err != nil {
 			return err
 		}
-		fmt.Print(buf.String())
+		fmt.Print(out)
 		return nil
 	}
 

--- a/next.go
+++ b/next.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -79,6 +82,29 @@ func displayNextGoal() error {
 
 	// Format the output: "goalslug baremin timeframe"
 	timeframe := FormatGoalDueDateAt(nextGoal, now)
+
+	// Machine-readable formats emit just the goal (json = the raw object, csv =
+	// one row), skipping the update banner so the output stays parseable.
+	switch outputFormat {
+	case "json":
+		b, err := json.MarshalIndent(nextGoal, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	case "csv":
+		var buf strings.Builder
+		w := csv.NewWriter(&buf)
+		w.Write([]string{"slug", "baremin", "due"})
+		w.Write([]string{nextGoal.Slug, nextGoal.Baremin, timeframe})
+		w.Flush()
+		if err := w.Error(); err != nil {
+			return err
+		}
+		fmt.Print(buf.String())
+		return nil
+	}
 
 	// Output the terse summary
 	fmt.Printf("%s %s %s\n", nextGoal.Slug, nextGoal.Baremin, timeframe)


### PR DESCRIPTION
Closes #338.

Adds a global `--format {table|json|csv}` flag, parsed like the existing `--no-color` global flag (stripped from `os.Args` before command dispatch, unknown values fail fast with exit 2).

## Coverage

Honored by the goal-list read commands (`list`, `all`, `today`, `tomorrow`, `due`, `less`, `next`) and `buzz data`. Other commands ignore it, as `--no-color` does.

- **json** — the raw goal/datapoint objects (every API field), for `jq`/scripting.
- **csv** — reuses each command's displayed columns, with a header row. Filtered-view columns gained `Header` labels (unused by the colorized text table) so csv has headers.
- **table** — unchanged default.

## Notes

- Empty results still produce valid machine output (`[]` for json, a header-only file for csv) rather than the human "No goals found." text.
- Machine formats skip the legend and the update-available banner, which would otherwise corrupt the output.
- The `tomorrow` view's `(!)` malformed-bright-red-line marker is a table-only annotation (its explanatory legend is suppressed for machine output), so json/csv emit the raw baremin value and stay parseable.
- json carries the full underlying objects; a projected/bumped column (e.g. the `tomorrow` view's baremin) therefore appears only in table/csv, which reuse the display's Cell functions.
- CSV cells aren't sanitized against spreadsheet formula injection — the output is the user's own Beeminder data on their own machine (documented in-code; revisit if #265 multi-account ever makes csv carry another account's data).

## Tests

`parseFormatFlag`, `Table.RenderAs`, and `renderDatapointsAs` are unit-tested (table/json/csv/empty/invalid-format), plus handler-level json **and csv** tests for `runListCommand`/`runDataCommand`. Command-level `--format` coverage for the filtered views and `next` (which need a testability refactor to inject the client) is tracked in #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global `--format` option supporting `table`, `json`, and `csv` output.
  - Added machine-readable output for `buzz list`, `buzz data`, and `buzz next`.
  - JSON and CSV results now contain only structured command data, without human-readable banners.
  - Empty results produce valid output, including `[]` for JSON and header-only CSV.
  - Added CSV headers and consistent formatting for goals and datapoints.

- **Bug Fixes**
  - Invalid or missing format values now return a clear error and exit safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
