### PR TITLE
fix(chart): align road risers with same-day datapoint risers

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -609,8 +609,8 @@ func renderXAxis(start, end time.Time, gutter, chartWidth int) string {
 	return strings.TrimRight(string(tickRow), " ") + "\n" + strings.TrimRight(string(labelRow), " ")
 }
 
-// roadValuesForTimeframe samples a parsed bright red line at numPoints evenly
-// distributed instants across [startTime, endTime] — one per chart column.
+// roadValuesForTimeframe samples a parsed bright red line into numPoints
+// chart columns spanning [startTime, endTime].
 //
 // Each column is sampled at its RIGHT edge (the next column's instant): a
 // column stands for the time span up to the next column, and datapointSeries
@@ -618,6 +618,11 @@ func renderXAxis(start, end time.Time, gutter, chartWidth int) string {
 // right edge makes a day-snapped road knot change value in that same column,
 // so a road riser and a same-day data riser land in the same column instead
 // of one apart.
+//
+// The last column has no next column; its sample is clamped to endTime so the
+// rightmost column — the one read as "now" — never shows a value extrapolated
+// a column-width past the window's end (real roads almost always keep running
+// past now, so an unclamped sample would be visibly in the future).
 func roadValuesForTimeframe(r road, startTime, endTime time.Time, numPoints int) []float64 {
 	values := make([]float64, numPoints)
 	if numPoints == 1 {
@@ -628,6 +633,9 @@ func roadValuesForTimeframe(r road, startTime, endTime time.Time, numPoints int)
 	duration := endTime.Sub(startTime)
 	for i := 0; i < numPoints; i++ {
 		t := startTime.Add(time.Duration(float64(duration) * float64(i+1) / float64(numPoints-1)))
+		if t.After(endTime) {
+			t = endTime
+		}
 		values[i] = r.valueAt(t)
 	}
 	return values
@@ -638,11 +646,22 @@ func roadValuesForTimeframe(r road, startTime, endTime time.Time, numPoints int)
 // daysnap equivalent). Flooring is monotone, so segment order is preserved;
 // a vertical step's two equal boundaries stay equal, and a sub-day segment
 // collapsing to zero duration is handled by valueAt like any vertical step.
+//
+// slopePerDay is recomputed from the snapped boundaries (0 for zero-duration
+// steps, matching parseRoad's vertical-step convention): valueAt's before-start
+// extrapolation branch reads it directly, so leaving the pre-snap slope in
+// place would extrapolate along a slope inconsistent with the segment's own
+// snapped endpoints.
 func daysnapRoad(r road, loc *time.Location) road {
 	snapped := make(road, len(r))
 	for i, seg := range r {
 		seg.startT = floorUnixToDay(seg.startT, loc)
 		seg.endT = floorUnixToDay(seg.endT, loc)
+		if seg.endT == seg.startT {
+			seg.slopePerDay = 0
+		} else {
+			seg.slopePerDay = (seg.endV - seg.startV) / (seg.endT - seg.startT) * 86400.0
+		}
 		snapped[i] = seg
 	}
 	return snapped

--- a/chart.go
+++ b/chart.go
@@ -53,6 +53,13 @@ func renderGoalChart(goal Goal, width int) string {
 		return "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 2).
 			Render("The bright red line wasn't populated for this goal.") + "\n"
 	}
+	// Snap road knots onto the same local-midnight day grid the datapoints are
+	// bucketed on, mirroring beebrain (stampIn dayparses road rows and data to
+	// one day grid). Beeminder stores knot times mid-day (deadline-aligned), so
+	// without this a road step and a same-day datapoint — e.g. a derailment's
+	// road jump and its #DERAIL datapoint — draw risers several columns apart
+	// instead of overlapping as they do on Beeminder's own graph.
+	brightLine = daysnapRoad(brightLine, startTime.Location())
 
 	chartWidth := width - 10 // leave room for padding and axis labels
 	if chartWidth < minChartWidth {
@@ -604,6 +611,13 @@ func renderXAxis(start, end time.Time, gutter, chartWidth int) string {
 
 // roadValuesForTimeframe samples a parsed bright red line at numPoints evenly
 // distributed instants across [startTime, endTime] — one per chart column.
+//
+// Each column is sampled at its RIGHT edge (the next column's instant): a
+// column stands for the time span up to the next column, and datapointSeries
+// assigns a day to the column at-or-before it (int truncation). Sampling the
+// right edge makes a day-snapped road knot change value in that same column,
+// so a road riser and a same-day data riser land in the same column instead
+// of one apart.
 func roadValuesForTimeframe(r road, startTime, endTime time.Time, numPoints int) []float64 {
 	values := make([]float64, numPoints)
 	if numPoints == 1 {
@@ -613,8 +627,30 @@ func roadValuesForTimeframe(r road, startTime, endTime time.Time, numPoints int)
 
 	duration := endTime.Sub(startTime)
 	for i := 0; i < numPoints; i++ {
-		t := startTime.Add(time.Duration(float64(duration) * float64(i) / float64(numPoints-1)))
+		t := startTime.Add(time.Duration(float64(duration) * float64(i+1) / float64(numPoints-1)))
 		values[i] = r.valueAt(t)
 	}
 	return values
+}
+
+// daysnapRoad floors every segment boundary to local midnight in loc, putting
+// road knots on the same day grid the datapoints are bucketed on (beebrain's
+// daysnap equivalent). Flooring is monotone, so segment order is preserved;
+// a vertical step's two equal boundaries stay equal, and a sub-day segment
+// collapsing to zero duration is handled by valueAt like any vertical step.
+func daysnapRoad(r road, loc *time.Location) road {
+	snapped := make(road, len(r))
+	for i, seg := range r {
+		seg.startT = floorUnixToDay(seg.startT, loc)
+		seg.endT = floorUnixToDay(seg.endT, loc)
+		snapped[i] = seg
+	}
+	return snapped
+}
+
+// floorUnixToDay floors a unix-seconds instant to midnight of its calendar day
+// in loc.
+func floorUnixToDay(t float64, loc *time.Location) float64 {
+	d := time.Unix(int64(t), 0).In(loc)
+	return float64(time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, loc).Unix())
 }

--- a/chart_test.go
+++ b/chart_test.go
@@ -916,9 +916,11 @@ func TestRoadStepAlignsWithSameDayDatapoint(t *testing.T) {
 
 // TestDaysnapRoad pins the properties daysnapRoad's doc comment claims:
 // boundaries floor to local midnight, a vertical step's equal boundaries stay
-// equal, segments stay contiguous and ordered, a sub-day sloped segment
-// collapses to a zero-duration step, and slopePerDay is recomputed from the
-// snapped boundaries (0 for zero-duration, per parseRoad's convention).
+// equal, a sub-day sloped segment collapses to a zero-duration step, and
+// slopePerDay is recomputed from the snapped boundaries (0 for zero-duration,
+// per parseRoad's convention). Contiguity needs no assertion: adjacent parsed
+// segments share the exact same boundary value, so flooring — a pure function
+// — cannot break it.
 func TestDaysnapRoad(t *testing.T) {
 	loc := time.Local
 	day := func(d int, hour int) float64 {
@@ -946,12 +948,6 @@ func TestDaysnapRoad(t *testing.T) {
 		}
 		if math.Abs(s[i].slopePerDay-want.slope) > 1e-9 {
 			t.Errorf("seg %d slopePerDay = %f, want %f (recomputed from snapped boundaries)", i, s[i].slopePerDay, want.slope)
-		}
-	}
-	// Contiguity preserved across the chain.
-	for i := 1; i < len(s); i++ {
-		if s[i].startT != s[i-1].endT {
-			t.Errorf("seg %d not contiguous: startT %f != prev endT %f", i, s[i].startT, s[i-1].endT)
 		}
 	}
 }

--- a/chart_test.go
+++ b/chart_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"math"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -905,15 +907,51 @@ func TestRoadStepAlignsWithSameDayDatapoint(t *testing.T) {
 		_, nodes := datapointSeries(processed, start, end, width)
 		nodeCol := nodes[len(nodes)-1]
 
-		stepCol := -1
-		for i, v := range roadValues {
-			if v > 5000 {
-				stepCol = i
-				break
-			}
-		}
+		stepCol := slices.IndexFunc(roadValues, func(v float64) bool { return v > 5000 })
 		if stepCol != nodeCol {
 			t.Errorf("width %d: road step first shows in column %d, datapoint node in column %d — risers won't overlap", width, stepCol, nodeCol)
+		}
+	}
+}
+
+// TestDaysnapRoad pins the properties daysnapRoad's doc comment claims:
+// boundaries floor to local midnight, a vertical step's equal boundaries stay
+// equal, segments stay contiguous and ordered, a sub-day sloped segment
+// collapses to a zero-duration step, and slopePerDay is recomputed from the
+// snapped boundaries (0 for zero-duration, per parseRoad's convention).
+func TestDaysnapRoad(t *testing.T) {
+	loc := time.Local
+	day := func(d int, hour int) float64 {
+		return float64(time.Date(2026, 7, 1+d, hour, 0, 0, 0, loc).Unix())
+	}
+	midnight := func(d int) float64 { return day(d, 0) }
+
+	r := road{
+		// sloped, mid-day boundaries spanning days 0..2
+		{startT: day(0, 11), startV: 0, endV: 4, endT: day(2, 11), slopePerDay: 2},
+		// vertical step at a mid-day instant
+		{startT: day(2, 11), startV: 4, endV: 100, endT: day(2, 11), slopePerDay: 0},
+		// sub-day sloped segment: 11:00 → 20:00 same day
+		{startT: day(2, 11), startV: 100, endV: 103, endT: day(2, 20), slopePerDay: 8},
+	}
+	s := daysnapRoad(r, loc)
+
+	for i, want := range []struct{ startT, endT, slope float64 }{
+		{midnight(0), midnight(2), 2},
+		{midnight(2), midnight(2), 0},
+		{midnight(2), midnight(2), 0}, // sub-day segment collapsed to a step
+	} {
+		if s[i].startT != want.startT || s[i].endT != want.endT {
+			t.Errorf("seg %d boundaries = (%f, %f), want (%f, %f)", i, s[i].startT, s[i].endT, want.startT, want.endT)
+		}
+		if math.Abs(s[i].slopePerDay-want.slope) > 1e-9 {
+			t.Errorf("seg %d slopePerDay = %f, want %f (recomputed from snapped boundaries)", i, s[i].slopePerDay, want.slope)
+		}
+	}
+	// Contiguity preserved across the chain.
+	for i := 1; i < len(s); i++ {
+		if s[i].startT != s[i-1].endT {
+			t.Errorf("seg %d not contiguous: startT %f != prev endT %f", i, s[i].startT, s[i-1].endT)
 		}
 	}
 }

--- a/chart_test.go
+++ b/chart_test.go
@@ -867,3 +867,53 @@ func TestAsciiRound(t *testing.T) {
 		}
 	}
 }
+
+// TestRoadStepAlignsWithSameDayDatapoint guards the derailment picture: a
+// derailment writes a vertical road step at a mid-day knot time (Beeminder
+// stores knot times at the goal deadline's time-of-day) plus a datapoint whose
+// daystamp is that same day. Beeminder day-snaps both onto one day grid so the
+// two risers overlap; buzz must land the road's value change in the same
+// column as the datapoint node (daysnapRoad + right-edge sampling), or the
+// chart draws two separate vertical lines a few columns apart.
+func TestRoadStepAlignsWithSameDayDatapoint(t *testing.T) {
+	loc := time.Local
+	start := time.Date(2026, 7, 13, 0, 0, 0, 0, loc)
+	end := start.AddDate(0, 0, 10)
+
+	stepDay := start.AddDate(0, 0, 7)
+	stepAt := float64(stepDay.Add(11 * time.Hour).Unix()) // mid-day derail knot
+
+	r, err := parseRoad([][]*float64{
+		roadallRow(float64(start.Unix()), fptr(30), nil),
+		roadallRow(stepAt, nil, fptr(30)),
+		roadallRow(stepAt, fptr(10091), nil), // vertical derail step
+		roadallRow(float64(end.AddDate(0, 0, 300).Unix()), nil, fptr(30)),
+	}, "d")
+	if err != nil || len(r) == 0 {
+		t.Fatalf("derail road parse: err=%v len=%d", err, len(r))
+	}
+	r = daysnapRoad(r, loc)
+
+	for _, width := range []int{70, 71} { // 71: step day lands exactly on a column instant
+		roadValues := roadValuesForTimeframe(r, start, end, width)
+
+		// The datapoint the derailment wrote, bucketed to its daystamp's midnight.
+		processed := []timedValue{
+			{timestamp: start.Unix(), value: 0},
+			{timestamp: stepDay.Unix(), value: 9881},
+		}
+		_, nodes := datapointSeries(processed, start, end, width)
+		nodeCol := nodes[len(nodes)-1]
+
+		stepCol := -1
+		for i, v := range roadValues {
+			if v > 5000 {
+				stepCol = i
+				break
+			}
+		}
+		if stepCol != nodeCol {
+			t.Errorf("width %d: road step first shows in column %d, datapoint node in column %d — risers won't overlap", width, stepCol, nodeCol)
+		}
+	}
+}

--- a/road_test.go
+++ b/road_test.go
@@ -228,15 +228,17 @@ func TestRoadValuesForTimeframe(t *testing.T) {
 		t.Fatalf("validRoad parse: err=%v len=%d", err, len(r))
 	}
 
+	// Each column samples its RIGHT edge (see roadValuesForTimeframe): with
+	// 11 columns over days 0..10 at 1/day, column i holds the value at day i+1.
 	values := roadValuesForTimeframe(r, roadDay(0), roadDay(10), 11)
 	if len(values) != 11 {
 		t.Fatalf("want 11 values, got %d", len(values))
 	}
-	if values[0] < -0.5 || values[0] > 0.5 {
-		t.Errorf("first sample = %f, want ~0", values[0])
+	if values[0] < 0.5 || values[0] > 1.5 {
+		t.Errorf("first sample = %f, want ~1 (right edge of column 0)", values[0])
 	}
 	if values[10] < 9.5 || values[10] > 10.5 {
-		t.Errorf("last sample = %f, want ~10", values[10])
+		t.Errorf("last sample = %f, want ~10 (past the road end holds flat)", values[10])
 	}
 
 	// numPoints == 1 must not divide by (numPoints-1): one sample at startTime.

--- a/road_test.go
+++ b/road_test.go
@@ -241,6 +241,21 @@ func TestRoadValuesForTimeframe(t *testing.T) {
 		t.Errorf("last sample = %f, want ~10 (past the road end holds flat)", values[10])
 	}
 
+	// A road that keeps running past the window end (the normal case — real
+	// roads extend to the goal date, far past "now") must NOT leak into the
+	// last column: its sample is clamped to endTime, not one column-width
+	// beyond it. validRoad can't catch this — it ends exactly at the window
+	// end, so the overshoot lands in valueAt's hold-flat branch and returns
+	// the right value by coincidence.
+	long, _ := parseRoad([][]*float64{
+		roadallRow(roadUnix(0), fptr(0), nil),
+		roadallRow(roadUnix(40), nil, fptr(1)),
+	}, "d")
+	clamped := roadValuesForTimeframe(long, roadDay(0), roadDay(10), 11)
+	if want := long.valueAt(roadDay(10)); math.Abs(clamped[10]-want) > 1e-9 {
+		t.Errorf("last sample = %f, want %f (clamped to endTime, not extrapolated past it)", clamped[10], want)
+	}
+
 	// numPoints == 1 must not divide by (numPoints-1): one sample at startTime.
 	single := roadValuesForTimeframe(r, roadDay(5), roadDay(10), 1)
 	if len(single) != 1 || single[0] < 4.9 || single[0] > 5.1 {


### PR DESCRIPTION
## What

Make `buzz view`'s goal-progress chart match Beeminder's own graph at a **derailment**: the bright red line's vertical jump and the same-day datapoint's vertical riser now draw in the **same column** (overlapping), instead of several columns apart.

## Why it looked wrong

Beeminder day-snaps both the road (roadall) knots and the datapoints onto one shared local-midnight grid before plotting, so a derail's road step and its `#DERAIL` datapoint line up. Buzz did neither:

- Road knots kept their raw mid-day (deadline-aligned) timestamps, while datapoints were bucketed to local midnight — so a road step and a same-day datapoint landed in different columns.
- The road was sampled at each column's **left** edge while datapoints bucket to the column at-or-before them (`int` truncation), adding a further one-column offset.

Result: on `narthur/abed` (a real derailment — road jumps 30 → 10091 on Jul 20, `#DERAIL` datapoint on the same day) the red riser sat **4 columns right** of the blue one.

## The fix

1. **`daysnapRoad`** — floor every parsed road segment boundary to local midnight (beebrain's `daysnap` equivalent), and recompute `slopePerDay` from the snapped boundaries.
2. **Right-edge column sampling** in `roadValuesForTimeframe` — sample each column at its right edge so a day-snapped knot's value change lands in the same column as a same-day datapoint node. The last column is clamped to `endTime` so the rightmost ("today") column never shows a value extrapolated past the window.

## Before → after (real `narthur/abed` chart)

**Before** — stray red riser offset right of the blue one:

![before](https://narthur-uploads.surge.sh/7e623eabcf94.png)

**After** — the red road riser is hidden directly behind the blue datapoint riser (same column; blue drawn on top), exactly as on Beeminder's graph:

```
   10149 ┤                                            ●──────●──────●──────────
    9134 ┤                                            │
     ...                                              │
       0 ┼●─────●─────●─────────────────────────●─────╯
          ┬                      ┬                      ┬                      ┬
          Jul 13              Jul 16                 Jul 20               Jul 23
```

(No stray red segment: the road step now coincides with the datapoint riser and is overdrawn by blue.)

## Notes

- Right-edge sampling is a deliberate whole-road convention (matches the datapoint columns); at terminal resolution the sub-column shift on sloped roads is invisible — it only matters at vertical jumps, which is exactly where it makes the chart correct.
- This does **not** widen the chart window into the future — Beeminder's default graph also shows some future road, but that's a separate change.

## Test plan

- `go test ./...` — green.
- New/updated tests: `TestRoadStepAlignsWithSameDayDatapoint` (road step and same-day datapoint node share a column, at two widths), `TestDaysnapRoad` (flooring, vertical-step equality, sub-day collapse, `slopePerDay` recompute), `TestRoadValuesForTimeframe` (right-edge sampling + last-column clamp regression case).
- Verified by rendering the real `narthur/abed` goal before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart alignment by ensuring road changes and datapoints that occur on the same day appear in the same column.
  * Corrected road sampling at chart column boundaries.
  * Prevented chart values from extending beyond the selected timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->