### PR TITLE
refactor(review): route detail fetch through the injected Client seam

### DIFF
--- a/review.go
+++ b/review.go
@@ -77,12 +77,12 @@ type reviewModel struct {
 	ctx      context.Context     // cancelled when the TUI exits; cancels in-flight fetches
 	client   Client              // Beeminder API seam; injected so tests can drive detail fetches with a fake
 	config   *Config             // credentials for browser-URL/detail rendering (not API calls — those go through client)
-	current  int            // current goal index
-	width    int            // terminal width
-	height   int            // terminal height
-	err      string         // error message to display
-	viewport viewport.Model // scrollable pane for the goal content (keeps tall goals reachable on short terminals)
-	ready    bool           // viewport has been sized by a WindowSizeMsg
+	current  int                 // current goal index
+	width    int                 // terminal width
+	height   int                 // terminal height
+	err      string              // error message to display
+	viewport viewport.Model      // scrollable pane for the goal content (keeps tall goals reachable on short terminals)
+	ready    bool                // viewport has been sized by a WindowSizeMsg
 }
 
 // initialReviewModel creates a new review model. The first goal's details fetch

--- a/review.go
+++ b/review.go
@@ -59,6 +59,7 @@ func handleReviewCommand() {
 
 	// Launch the interactive review TUI
 	model := initialReviewModel(goals, config)
+	model.client = client // use the client built above; the constructor's default is discarded
 	model.ctx = ctx
 	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
@@ -74,7 +75,8 @@ type reviewModel struct {
 	inFlight map[string]struct{} // slugs with a detail fetch currently in flight (dedup)
 	loading  bool                // a detail fetch for the current goal is in flight
 	ctx      context.Context     // cancelled when the TUI exits; cancels in-flight fetches
-	config   *Config
+	client   Client              // Beeminder API seam; injected so tests can drive detail fetches with a fake
+	config   *Config             // credentials for browser-URL/detail rendering (not API calls — those go through client)
 	current  int            // current goal index
 	width    int            // terminal width
 	height   int            // terminal height
@@ -86,12 +88,16 @@ type reviewModel struct {
 // initialReviewModel creates a new review model. The first goal's details fetch
 // is dispatched by Init; because Init can't persist model state (it returns only
 // a Cmd), the constructor pre-marks that goal as in-flight and loading here.
+//
+// The client defaults to the real HTTP client for config; handleReviewCommand
+// and tests can override m.client to inject a fake before the TUI runs.
 func initialReviewModel(goals []Goal, config *Config) reviewModel {
 	m := reviewModel{
 		goals:    goals,
 		details:  make(map[string]*Goal),
 		inFlight: make(map[string]struct{}),
 		ctx:      context.Background(), // overridden with a cancellable ctx by handleReviewCommand
+		client:   NewHTTPClient(config),
 		config:   config,
 		current:  0,
 		loading:  len(goals) > 0,
@@ -111,10 +117,12 @@ type goalDetailsMsg struct {
 
 // fetchGoalDetailsCmd fetches one goal's full details (datapoints + road) in the
 // background so the TUI opens immediately and navigation stays responsive. The
-// context lets the fetch be cancelled when the user quits.
-func fetchGoalDetailsCmd(ctx context.Context, config *Config, slug string) tea.Cmd {
+// context lets the fetch be cancelled when the user quits. The fetch goes through
+// the injected Client seam so the review TUI is testable with a fake, like every
+// other command.
+func fetchGoalDetailsCmd(ctx context.Context, client Client, slug string) tea.Cmd {
 	return func() tea.Msg {
-		goal, err := NewHTTPClient(config).FetchGoalWithDatapoints(ctx, slug)
+		goal, err := client.FetchGoalWithDatapoints(ctx, slug)
 		return goalDetailsMsg{slug: slug, goal: goal, err: err}
 	}
 }
@@ -138,7 +146,7 @@ func (m *reviewModel) ensureDetails() tea.Cmd {
 		return nil // already fetching this goal; just keep showing the spinner
 	}
 	m.inFlight[slug] = struct{}{}
-	return fetchGoalDetailsCmd(m.ctx, m.config, slug)
+	return fetchGoalDetailsCmd(m.ctx, m.client, slug)
 }
 
 func (m reviewModel) Init() tea.Cmd {
@@ -146,7 +154,7 @@ func (m reviewModel) Init() tea.Cmd {
 	if len(m.goals) == 0 {
 		return nil
 	}
-	return fetchGoalDetailsCmd(m.ctx, m.config, m.goals[0].Slug)
+	return fetchGoalDetailsCmd(m.ctx, m.client, m.goals[0].Slug)
 }
 
 func (m reviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/review_test.go
+++ b/review_test.go
@@ -82,6 +82,83 @@ func TestReviewModelInit(t *testing.T) {
 	}
 }
 
+// TestReviewModelInitFetchesThroughClient proves the review TUI's lazy detail
+// fetch runs through the injected Client seam (not a hardwired NewHTTPClient),
+// so it is testable with a fake like every other command. Executing the Cmd
+// Init returns must invoke the fake and surface its goal via a goalDetailsMsg;
+// feeding that back through Update must cache the details.
+func TestReviewModelInitFetchesThroughClient(t *testing.T) {
+	config := &Config{Username: "u", AuthToken: "t"}
+	m := initialReviewModel([]Goal{{Slug: "g1"}}, config)
+
+	var fetched []string
+	m.client = &FakeClient{
+		FetchGoalWithDatapointsFunc: func(slug string) (*Goal, error) {
+			fetched = append(fetched, slug)
+			return &Goal{Slug: slug, Datapoints: []Datapoint{{Value: 1}}}, nil
+		},
+	}
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("expected Init() to return a fetch command")
+	}
+	msg := cmd() // executes the fetch against the injected fake
+	if len(fetched) != 1 || fetched[0] != "g1" {
+		t.Fatalf("expected fake to be called for g1, got %v", fetched)
+	}
+	dm, ok := msg.(goalDetailsMsg)
+	if !ok {
+		t.Fatalf("expected goalDetailsMsg, got %T", msg)
+	}
+	if dm.err != nil || dm.goal == nil || len(dm.goal.Datapoints) != 1 {
+		t.Fatalf("fake goal did not flow through the seam: %+v", dm)
+	}
+
+	updated, _ := m.Update(dm)
+	m = updated.(reviewModel)
+	if _, ok := m.details["g1"]; !ok {
+		t.Error("expected fetched details to be cached after the message")
+	}
+}
+
+// TestReviewModelInitFetchThroughClientError mirrors the success test for the
+// failure branch: a fetch error from the injected client must surface as a
+// goalDetailsMsg carrying the error (not a cached goal), and feeding that back
+// through Update must set the on-screen error and clear loading. This branch is
+// only reachable through the seam now that the fetch no longer builds its own
+// HTTP client.
+func TestReviewModelInitFetchThroughClientError(t *testing.T) {
+	config := &Config{Username: "u", AuthToken: "t"}
+	m := initialReviewModel([]Goal{{Slug: "g1"}}, config)
+	m.client = &FakeClient{
+		FetchGoalWithDatapointsFunc: func(string) (*Goal, error) {
+			return nil, fmt.Errorf("boom")
+		},
+	}
+
+	msg := m.Init()() // execute the fetch Cmd against the failing fake
+	dm, ok := msg.(goalDetailsMsg)
+	if !ok {
+		t.Fatalf("expected goalDetailsMsg, got %T", msg)
+	}
+	if dm.err == nil || dm.goal != nil {
+		t.Fatalf("expected an error message with no goal, got %+v", dm)
+	}
+
+	updated, _ := m.Update(dm)
+	m = updated.(reviewModel)
+	if m.loading {
+		t.Error("expected loading cleared after a failed fetch")
+	}
+	if !strings.Contains(m.err, "Failed to load goal details") {
+		t.Errorf("expected surfaced fetch error, got %q", m.err)
+	}
+	if _, ok := m.details["g1"]; ok {
+		t.Error("expected no cached details after a failed fetch")
+	}
+}
+
 func TestReviewModelNavigationForward(t *testing.T) {
 	goals := []Goal{
 		{Slug: "goal1", Title: "First Goal"},


### PR DESCRIPTION
## Problem

`review` was the one command that bypassed the `Client` interface seam. Every other command routes through `loadClient` → a `Client`, so a `FakeClient` can drive it in tests. But `reviewModel` stored a `*Config` and each detail-fetch `tea.Cmd` called `NewHTTPClient(config)` *inside* the command — so the largest interactive surface (~680 lines, including chart wiring) was the one place a fake couldn't reach.

## Change

- `reviewModel` holds a `client Client` field (defaulted in the constructor to `NewHTTPClient(config)`; `handleReviewCommand` overrides it with the client it already built for the initial `FetchGoals`).
- `fetchGoalDetailsCmd` takes that `Client` instead of a `*Config` and no longer constructs its own HTTP client — closing the bypass.
- `config` is retained on the model, but only for non-API concerns (`openBrowser` and `formatGoalDetails` URL building).
- The ~40 existing `initialReviewModel(goals, config)` call sites are untouched — the constructor default keeps them compiling; the seam is exercised by overriding `m.client`.

## Tests

Two new tests drive the fetch end-to-end through a `FakeClient` — the path that previously required a real/failing HTTP call:
- `TestReviewModelInitFetchesThroughClient` — success branch: `Init()`'s Cmd invokes the fake and the goal flows through `goalDetailsMsg` into the cache.
- `TestReviewModelInitFetchThroughClientError` — error branch: a fetch error surfaces on screen and caches nothing.

Full `go test ./...` passes; `go vet` clean.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading goal details in the review interface.
  * Errors during detail loading are now surfaced clearly without leaving the interface in a loading state.

* **Tests**
  * Added coverage for successful and failed goal-detail loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->