### PR TITLE
feat(goals): banner when a goal is scheduled for archive

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -13,6 +13,7 @@ type Goal struct {
 	Fineprint   string                `json:"fineprint"` // User-provided description of what they're committing to
 	GoalType    string                `json:"goal_type"` // Goal type (hustler, biker, fatloser, gainer, inboxer, drinker)
 	Losedate    int64                 `json:"losedate"`
+	Archivedate int64                 `json:"archivedate"` // Unix time the goal is scheduled to be archived; 0/null when not scheduled
 	Pledge      float64               `json:"pledge"`
 	PledgeCap   *float64              `json:"pledge_cap"` // Pointer to handle null values from API
 	Safebuf     int                   `json:"safebuf"`

--- a/grid.go
+++ b/grid.go
@@ -129,7 +129,7 @@ func RenderModal(goal *Goal, width, height int, inputDate, inputValue, inputComm
 	if goal.PledgeCap != nil && *goal.PledgeCap > 0 && *goal.PledgeCap != goal.Pledge {
 		pledgeDisplay = fmt.Sprintf("$%.2f / $%.2f", goal.Pledge, *goal.PledgeCap)
 	}
-	content := "Goal Details\n\n" + formatArchiveBanner(goal)
+	content := "Goal Details\n\n" + formatArchiveBanner(goal, time.Now())
 	content += fmt.Sprintf("Slug: %s\n"+
 		"Title: %s\n"+
 		"Pledge: %s\n"+

--- a/grid.go
+++ b/grid.go
@@ -129,8 +129,8 @@ func RenderModal(goal *Goal, width, height int, inputDate, inputValue, inputComm
 	if goal.PledgeCap != nil && *goal.PledgeCap > 0 && *goal.PledgeCap != goal.Pledge {
 		pledgeDisplay = fmt.Sprintf("$%.2f / $%.2f", goal.Pledge, *goal.PledgeCap)
 	}
-	content := fmt.Sprintf("Goal Details\n\n"+
-		"Slug: %s\n"+
+	content := "Goal Details\n\n" + formatArchiveBanner(goal)
+	content += fmt.Sprintf("Slug: %s\n"+
 		"Title: %s\n"+
 		"Pledge: %s\n"+
 		"Safe Buffer: %d days\n"+

--- a/review.go
+++ b/review.go
@@ -506,8 +506,21 @@ func formatRecentDatapoints(datapoints []Datapoint) string {
 // formatGoalDetails formats the goal details in a consistent way for both view
 // and review commands. now is the reference clock for the 7-day forecast; pass
 // time.Now() in production.
+// formatArchiveBanner returns a one-line warning banner when the goal is
+// scheduled for archive (Beeminder sets archivedate to the Unix time it will be
+// archived), or "" otherwise. Shared by every full goal view so the warning
+// shows up the same way everywhere.
+func formatArchiveBanner(goal *Goal) string {
+	if goal.Archivedate <= 0 {
+		return ""
+	}
+	when := time.Unix(goal.Archivedate, 0).Format("Mon Jan 2, 2006")
+	banner := fmt.Sprintf("⚠ Scheduled for archive on %s", when)
+	return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208")).Render(banner) + "\n"
+}
+
 func formatGoalDetails(goal *Goal, config *Config, now time.Time) string {
-	var details string
+	details := formatArchiveBanner(goal)
 
 	// Field order follows issue #229: the goal's commitment (rate, autoratchet)
 	// first, then urgency (limsum, deadline, due time), then stakes (pledge),

--- a/review.go
+++ b/review.go
@@ -503,15 +503,13 @@ func formatRecentDatapoints(datapoints []Datapoint) string {
 	return output
 }
 
-// formatGoalDetails formats the goal details in a consistent way for both view
-// and review commands. now is the reference clock for the 7-day forecast; pass
-// time.Now() in production.
 // formatArchiveBanner returns a one-line warning banner when the goal is
 // scheduled for archive (Beeminder sets archivedate to the Unix time it will be
 // archived), or "" otherwise. Shared by every full goal view so the warning
-// shows up the same way everywhere.
-func formatArchiveBanner(goal *Goal) string {
-	if goal.Archivedate <= 0 {
+// shows up the same way everywhere. now gates on a still-upcoming date so an
+// already-archived goal (reachable by slug) doesn't show a past-dated warning.
+func formatArchiveBanner(goal *Goal, now time.Time) string {
+	if goal.Archivedate <= 0 || goal.Archivedate <= now.Unix() {
 		return ""
 	}
 	when := time.Unix(goal.Archivedate, 0).Format("Mon Jan 2, 2006")
@@ -519,8 +517,11 @@ func formatArchiveBanner(goal *Goal) string {
 	return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("208")).Render(banner) + "\n"
 }
 
+// formatGoalDetails formats the goal details in a consistent way for both view
+// and review commands. now is the reference clock for the 7-day forecast; pass
+// time.Now() in production.
 func formatGoalDetails(goal *Goal, config *Config, now time.Time) string {
-	details := formatArchiveBanner(goal)
+	details := formatArchiveBanner(goal, now)
 
 	// Field order follows issue #229: the goal's commitment (rate, autoratchet)
 	// first, then urgency (limsum, deadline, due time), then stakes (pledge),

--- a/review_test.go
+++ b/review_test.go
@@ -949,13 +949,18 @@ func TestFormatGoalDetailsWithDatapoints(t *testing.T) {
 }
 
 func TestFormatArchiveBanner(t *testing.T) {
-	// archivedate set -> banner with the scheduled date; unset -> nothing.
-	archiving := formatGoalDetails(&Goal{Slug: "s", Archivedate: 1786075200}, &Config{Username: "u"}, time.Now())
-	if !strings.Contains(archiving, "Scheduled for archive on") {
-		t.Errorf("expected archive banner, got:\n%s", archiving)
+	now := time.Unix(1786075200, 0) // reference clock
+	// Future archivedate -> banner with the scheduled date.
+	future := formatArchiveBanner(&Goal{Archivedate: now.Unix() + 86400}, now)
+	if !strings.Contains(future, "Scheduled for archive on") {
+		t.Errorf("expected archive banner, got:\n%s", future)
 	}
-	if got := formatArchiveBanner(&Goal{Slug: "s"}); got != "" {
+	// Unset -> nothing. Past date (already-archived goal) -> nothing.
+	if got := formatArchiveBanner(&Goal{}, now); got != "" {
 		t.Errorf("expected no banner when archivedate unset, got %q", got)
+	}
+	if got := formatArchiveBanner(&Goal{Archivedate: now.Unix() - 86400}, now); got != "" {
+		t.Errorf("expected no banner for past archivedate, got %q", got)
 	}
 }
 

--- a/review_test.go
+++ b/review_test.go
@@ -950,10 +950,11 @@ func TestFormatGoalDetailsWithDatapoints(t *testing.T) {
 
 func TestFormatArchiveBanner(t *testing.T) {
 	now := time.Unix(1786075200, 0) // reference clock
-	// Future archivedate -> banner with the scheduled date.
-	future := formatArchiveBanner(&Goal{Archivedate: now.Unix() + 86400}, now)
-	if !strings.Contains(future, "Scheduled for archive on") {
-		t.Errorf("expected archive banner, got:\n%s", future)
+	// Future archivedate -> banner naming the scheduled date.
+	tomorrow := now.Add(24 * time.Hour)
+	future := formatArchiveBanner(&Goal{Archivedate: tomorrow.Unix()}, now)
+	if want := "Scheduled for archive on " + tomorrow.Format("Mon Jan 2, 2006"); !strings.Contains(future, want) {
+		t.Errorf("expected banner to contain %q, got:\n%s", want, future)
 	}
 	// Unset -> nothing. Past date (already-archived goal) -> nothing.
 	if got := formatArchiveBanner(&Goal{}, now); got != "" {

--- a/review_test.go
+++ b/review_test.go
@@ -948,6 +948,17 @@ func TestFormatGoalDetailsWithDatapoints(t *testing.T) {
 	}
 }
 
+func TestFormatArchiveBanner(t *testing.T) {
+	// archivedate set -> banner with the scheduled date; unset -> nothing.
+	archiving := formatGoalDetails(&Goal{Slug: "s", Archivedate: 1786075200}, &Config{Username: "u"}, time.Now())
+	if !strings.Contains(archiving, "Scheduled for archive on") {
+		t.Errorf("expected archive banner, got:\n%s", archiving)
+	}
+	if got := formatArchiveBanner(&Goal{Slug: "s"}); got != "" {
+		t.Errorf("expected no banner when archivedate unset, got %q", got)
+	}
+}
+
 func TestFormatGoalDetailsWithoutDatapoints(t *testing.T) {
 	// Test that formatGoalDetails works correctly when no datapoints are present
 	goal := &Goal{


### PR DESCRIPTION
## What

Beeminder's API now returns `archivedate` (a Unix timestamp) on goals scheduled to be archived. This surfaces a warning banner in the full goal views when a goal is scheduled for archive:

```
Goal: stime
⚠ Scheduled for archive on Thu Aug 6, 2026
Rate:        0 hours / day
...
```

## How

- Added `Archivedate int64` to the `Goal` struct (`beeminder.go`), decoded straight from the API JSON (null → 0).
- New shared `formatArchiveBanner(goal, now)` helper renders the banner, gated on `archivedate` being **still in the future** — so an already-archived goal (reachable by slug via `buzz view`) never shows a past-dated "scheduled" warning.
- Wired into `formatGoalDetails` (covers `buzz view` and `buzz review`) and the grid TUI modal `RenderModal`.

## Not included

Row-based table output (`buzz list`, filtered views) — a full-width banner doesn't fit a column layout. Add a `⚠` indicator column there if wanted.

## Testing

- `TestFormatArchiveBanner` covers future date → banner, unset → nothing, past date → nothing.
- Manually verified against the live API: `buzz view stime` (scheduled for archive) shows the banner; `buzz view abed` (not scheduled) does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scheduled archive dates to goals.
  - Goal details now display a prominent warning when archival is scheduled for a future date.

- **Bug Fixes**
  - Archive warnings are omitted when no archive is scheduled or the scheduled date has passed.

- **Tests**
  - Added coverage for future, unset, and past archive dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->