### PR TITLE
feat(list): mark goals scheduled for archive in buzz list

### DIFF
--- a/beeminder.go
+++ b/beeminder.go
@@ -42,6 +42,15 @@ type Goal struct {
 	Datapoints  []Datapoint           `json:"datapoints,omitempty"`
 }
 
+// ScheduledForArchive reports whether the goal has an archive date still in the
+// future. Beeminder sets Archivedate to the Unix time a goal will be archived;
+// gating on now (not just presence) means an already-archived goal reachable by
+// slug doesn't read as "scheduled". Shared by the detail banner and the list
+// marker so both agree.
+func (g Goal) ScheduledForArchive(now time.Time) bool {
+	return g.Archivedate > 0 && g.Archivedate > now.Unix()
+}
+
 // DuebyEntry is one entry in a goal's `dueby` map, keyed by daystamp.
 // Beeminder pre-rounds FormattedDelta and FormattedTotal to the goal's
 // configured Display Precision, so honouring those strings avoids the

--- a/filtered.go
+++ b/filtered.go
@@ -238,6 +238,10 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 		return
 	}
 
+	// Human table only: flag goals scheduled for archive on the slug (csv/json
+	// above keep the clean Cell).
+	now := time.Now()
+	table.Columns[0].Cell = func(g Goal) string { return archiveMarker(g, now) + g.Slug }
 	fmt.Print(table.Render(filteredGoals))
 
 	if legendFor != nil {

--- a/filtered.go
+++ b/filtered.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Filtered list views: `buzz all`, `buzz today`, `buzz tomorrow`, `buzz due`,
@@ -238,10 +240,12 @@ func handleFilteredCommandWithDisplay(filterName string, filter func(Goal) bool,
 		return
 	}
 
-	// Human table only: flag goals scheduled for archive on the slug (csv/json
-	// above keep the clean Cell).
+	// Human table only: flag goals scheduled for archive with a trailing dot
+	// (csv/json above keep the clean Cell). These views colour the whole row by
+	// urgency, so the dot is left unstyled — it inherits the row colour instead
+	// of resetting it mid-line, and still marks the goal by its presence.
 	now := time.Now()
-	table.Columns[0].Cell = func(g Goal) string { return archiveMarker(g, now) + g.Slug }
+	table.Columns[0].Cell = func(g Goal) string { return g.Slug + archiveDot(g, now, lipgloss.NewStyle()) }
 	fmt.Print(table.Render(filteredGoals))
 
 	if legendFor != nil {

--- a/goaltable.go
+++ b/goaltable.go
@@ -6,20 +6,23 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
-// archiveMarker is the display-only prefix a table's slug cell gets when the
-// goal is scheduled for archive. Table output only — the Cell functions feed
-// csv (and stay clean slugs); json already carries the raw archivedate. The
-// marker is ASCII (like the tomorrow view's "(!)" — #325/ADR-0003) so it has a
-// known display width and never shifts the goaltable's column alignment; "(A)"
-// rather than "(!)" so it never collides with the malformed-road marker that
-// shares the filtered views. The detail-view banner uses ⚠ (no column there).
-func archiveMarker(g Goal, now time.Time) string {
-	if g.ScheduledForArchive(now) {
-		return "(A) "
+// archiveDot returns a trailing " •" marking a goal scheduled for archive, or ""
+// otherwise. Table output only — the Cell functions feed csv (slugs stay clean)
+// and json already carries the raw archivedate. The bullet is a *suffix* so it
+// never shifts the slug's left edge (the "(A) " prefix did, ruining alignment),
+// and Render measures display width so the multibyte glyph — and any colour on
+// it — stays aligned. style colours the dot: an orange style for the plain
+// `buzz list`; an unstyled one for the urgency-coloured filtered views, so the
+// dot inherits the row colour rather than resetting it mid-line.
+func archiveDot(g Goal, now time.Time, style lipgloss.Style) string {
+	if !g.ScheduledForArchive(now) {
+		return ""
 	}
-	return ""
+	return " " + style.Render("•")
 }
 
 // goaltable renders a list of goals as a column-aligned text table. The
@@ -71,15 +74,15 @@ func (t Table) Render(goals []Goal) string {
 	if t.ShowHeader {
 		// Seed widths from header lengths so the header row never gets clipped.
 		for i, c := range t.Columns {
-			widths[i] = len(c.Header)
+			widths[i] = lipgloss.Width(c.Header)
 		}
 	}
 	for i, g := range goals {
 		row := make([]string, len(t.Columns))
 		for j, c := range t.Columns {
 			row[j] = c.Cell(g)
-			if len(row[j]) > widths[j] {
-				widths[j] = len(row[j])
+			if w := lipgloss.Width(row[j]); w > widths[j] {
+				widths[j] = w
 			}
 		}
 		cells[i] = row
@@ -175,14 +178,17 @@ func encodeCSV(headers []string, rows [][]string) (string, error) {
 }
 
 // padRow joins cells with two-space separators, left-padding every column
-// except the last to its measured width.
+// except the last to its measured width. Padding is by display width (via
+// lipgloss.Width), not byte length, so a cell carrying ANSI colour or a
+// multibyte glyph (the archive dot) still aligns; fmt's %-*s pads by bytes and
+// would misalign it.
 func padRow(cells []string, widths []int) string {
 	parts := make([]string, len(cells))
 	for i, cell := range cells {
 		if i == len(cells)-1 {
 			parts[i] = cell
 		} else {
-			parts[i] = fmt.Sprintf("%-*s", widths[i], cell)
+			parts[i] = cell + strings.Repeat(" ", widths[i]-lipgloss.Width(cell))
 		}
 	}
 	return strings.Join(parts, "  ")

--- a/goaltable.go
+++ b/goaltable.go
@@ -5,7 +5,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
+
+// archiveMarker is the display-only prefix a table's slug cell gets when the
+// goal is scheduled for archive. Table output only — the Cell functions feed
+// csv (and stay clean slugs); json already carries the raw archivedate. The
+// marker is ASCII (like the tomorrow view's "(!)" — #325/ADR-0003) so it has a
+// known display width and never shifts the goaltable's column alignment; "(A)"
+// rather than "(!)" so it never collides with the malformed-road marker that
+// shares the filtered views. The detail-view banner uses ⚠ (no column there).
+func archiveMarker(g Goal, now time.Time) string {
+	if g.ScheduledForArchive(now) {
+		return "(A) "
+	}
+	return ""
+}
 
 // goaltable renders a list of goals as a column-aligned text table. The
 // pipeline every list command was reimplementing —

--- a/goaltable_test.go
+++ b/goaltable_test.go
@@ -76,32 +76,35 @@ func TestTableRenderNoHeader(t *testing.T) {
 	}
 }
 
-// TestArchiveMarker checks the slug marker gates on a still-future archivedate:
-// future -> prefixed, unset or past/now -> plain.
-func TestArchiveMarker(t *testing.T) {
+// TestArchiveDot checks the slug dot gates on a still-future archivedate:
+// future -> trailing " •", unset or past/now -> nothing.
+func TestArchiveDot(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
+	plain := lipgloss.NewStyle()
 	cases := map[string]struct {
 		archivedate int64
 		want        string
 	}{
-		"future":  {now.Unix() + 86400, "(A) "},
+		"future":  {now.Unix() + 86400, " •"},
 		"unset":   {0, ""},
 		"past":    {now.Unix() - 86400, ""},
 		"exactly": {now.Unix(), ""}, // boundary: not strictly future
 	}
 	for name, c := range cases {
-		if got := archiveMarker(Goal{Archivedate: c.archivedate}, now); got != c.want {
-			t.Errorf("%s: archiveMarker = %q, want %q", name, got, c.want)
+		if got := archiveDot(Goal{Archivedate: c.archivedate}, now, plain); got != c.want {
+			t.Errorf("%s: archiveDot = %q, want %q", name, got, c.want)
 		}
 	}
 }
 
-// TestTableArchiveMarkerAlignment guards that the slug marker doesn't knock the
-// next column out of alignment: the marked and unmarked rows must line up.
-func TestTableArchiveMarkerAlignment(t *testing.T) {
+// TestTableArchiveDotAlignment guards that the trailing dot (multibyte, and in
+// production coloured) doesn't knock the next column out of alignment: the
+// marked and unmarked rows must line up. Byte-length padding would misalign it.
+func TestTableArchiveDotAlignment(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
+	orange := lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
 	tbl := Table{Columns: []Column{
-		{Cell: func(g Goal) string { return archiveMarker(g, now) + g.Slug }},
+		{Cell: func(g Goal) string { return g.Slug + archiveDot(g, now, orange) }},
 		{Cell: func(g Goal) string { return g.Baremin }},
 	}}
 	goals := []Goal{
@@ -109,16 +112,17 @@ func TestTableArchiveMarkerAlignment(t *testing.T) {
 		{Slug: "xyz", Baremin: "+2"},                                  // plain
 	}
 	lines := strings.Split(strings.TrimRight(tbl.Render(goals), "\n"), "\n")
-	if !strings.HasPrefix(lines[0], "(A) abc") {
-		t.Errorf("marked row = %q, want (A) prefix", lines[0])
+	if !strings.Contains(lines[0], "abc •") {
+		t.Errorf("marked row = %q, want slug + dot", lines[0])
 	}
-	if strings.HasPrefix(lines[1], "(A)") {
-		t.Errorf("unscheduled row = %q, want no marker", lines[1])
+	if strings.Contains(lines[1], "•") {
+		t.Errorf("unscheduled row = %q, want no dot", lines[1])
 	}
-	// Equal total width => the Baremin column lines up in both rows.
-	if len(lines[0]) != len(lines[1]) {
+	// Equal display width => the Baremin column lines up in both rows, even
+	// though the marked cell carries extra bytes (glyph + any colour codes).
+	if lipgloss.Width(lines[0]) != lipgloss.Width(lines[1]) {
 		t.Errorf("rows misaligned: %q (w=%d) vs %q (w=%d)",
-			lines[0], len(lines[0]), lines[1], len(lines[1]))
+			lines[0], lipgloss.Width(lines[0]), lines[1], lipgloss.Width(lines[1]))
 	}
 }
 
@@ -152,6 +156,41 @@ func TestTableRenderColorize(t *testing.T) {
 	if strings.ReplaceAll(overdueLine, "overdue", "") == strings.ReplaceAll(distantLine, "distant", "") {
 		t.Errorf("colourised rows for different urgencies are identical; expected different ANSI wrappers\noverdue: %q\ndistant: %q",
 			overdueLine, distantLine)
+	}
+}
+
+// TestTableColorizeArchiveDot guards the filtered-view interaction: in a
+// Colorize table (today/tomorrow/…), the plain archive dot must sit INSIDE the
+// row's colour span — an empty-style dot that emitted its own reset would blank
+// the urgency colour for the rest of the row — and must not break alignment.
+func TestTableColorizeArchiveDot(t *testing.T) {
+	orig := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(orig) })
+
+	now := time.Unix(1_000_000_000, 0)
+	tbl := Table{
+		Colorize: true,
+		Columns: []Column{
+			{Cell: func(g Goal) string { return g.Slug + archiveDot(g, now, lipgloss.NewStyle()) }},
+			{Cell: func(g Goal) string { return g.Baremin }},
+		},
+	}
+	marked := Goal{Slug: "arch", Safebuf: 0, Archivedate: now.Unix() + 86400, Baremin: "+1"}
+	plain := Goal{Slug: "keep", Safebuf: 0, Baremin: "+2"}
+	out := tbl.Render([]Goal{marked, plain})
+
+	markedLine, _, _ := strings.Cut(out, "\n")
+	if !strings.Contains(markedLine, "•") {
+		t.Fatalf("marked row missing dot: %q", markedLine)
+	}
+	if before, _, _ := strings.Cut(markedLine, "•"); strings.Contains(before, "\x1b[0m") {
+		t.Errorf("colour reset before the dot; row colour would break mid-line: %q", markedLine)
+	}
+	plainLine, _, _ := strings.Cut(strings.SplitN(out, "\n", 2)[1], "\n")
+	if lipgloss.Width(markedLine) != lipgloss.Width(plainLine) {
+		t.Errorf("colourised rows misaligned: %q (w=%d) vs %q (w=%d)",
+			markedLine, lipgloss.Width(markedLine), plainLine, lipgloss.Width(plainLine))
 	}
 }
 

--- a/goaltable_test.go
+++ b/goaltable_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -72,6 +73,52 @@ func TestTableRenderNoHeader(t *testing.T) {
 	want := "short       +1\nwider-slug  +0.5\n"
 	if got != want {
 		t.Errorf("no-header render mismatch\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestArchiveMarker checks the slug marker gates on a still-future archivedate:
+// future -> prefixed, unset or past/now -> plain.
+func TestArchiveMarker(t *testing.T) {
+	now := time.Unix(1_000_000_000, 0)
+	cases := map[string]struct {
+		archivedate int64
+		want        string
+	}{
+		"future":  {now.Unix() + 86400, "(A) "},
+		"unset":   {0, ""},
+		"past":    {now.Unix() - 86400, ""},
+		"exactly": {now.Unix(), ""}, // boundary: not strictly future
+	}
+	for name, c := range cases {
+		if got := archiveMarker(Goal{Archivedate: c.archivedate}, now); got != c.want {
+			t.Errorf("%s: archiveMarker = %q, want %q", name, got, c.want)
+		}
+	}
+}
+
+// TestTableArchiveMarkerAlignment guards that the slug marker doesn't knock the
+// next column out of alignment: the marked and unmarked rows must line up.
+func TestTableArchiveMarkerAlignment(t *testing.T) {
+	now := time.Unix(1_000_000_000, 0)
+	tbl := Table{Columns: []Column{
+		{Cell: func(g Goal) string { return archiveMarker(g, now) + g.Slug }},
+		{Cell: func(g Goal) string { return g.Baremin }},
+	}}
+	goals := []Goal{
+		{Slug: "abc", Archivedate: now.Unix() + 86400, Baremin: "+1"}, // marked
+		{Slug: "xyz", Baremin: "+2"},                                  // plain
+	}
+	lines := strings.Split(strings.TrimRight(tbl.Render(goals), "\n"), "\n")
+	if !strings.HasPrefix(lines[0], "(A) abc") {
+		t.Errorf("marked row = %q, want (A) prefix", lines[0])
+	}
+	if strings.HasPrefix(lines[1], "(A)") {
+		t.Errorf("unscheduled row = %q, want no marker", lines[1])
+	}
+	// Equal total width => the Baremin column lines up in both rows.
+	if len(lines[0]) != len(lines[1]) {
+		t.Errorf("rows misaligned: %q (w=%d) vs %q (w=%d)",
+			lines[0], len(lines[0]), lines[1], len(lines[1]))
 	}
 }
 

--- a/list.go
+++ b/list.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 // handleListCommand outputs a summary list of goals with slug, title, units,
@@ -129,6 +130,10 @@ func runListCommand(ctx context.Context, client Client, archived bool, format st
 
 	// Print summary header
 	fmt.Fprintf(out, "Total %s: %d\n\n", noun, len(goals))
+	// Human table only: flag goals scheduled for archive on the slug. Left the
+	// Cell above clean so csv slugs stay plain.
+	now := time.Now()
+	table.Columns[0].Cell = func(g Goal) string { return archiveMarker(g, now) + g.Slug }
 	fmt.Fprint(out, table.Render(goals))
 
 	return 0

--- a/list.go
+++ b/list.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // handleListCommand outputs a summary list of goals with slug, title, units,
@@ -130,10 +132,13 @@ func runListCommand(ctx context.Context, client Client, archived bool, format st
 
 	// Print summary header
 	fmt.Fprintf(out, "Total %s: %d\n\n", noun, len(goals))
-	// Human table only: flag goals scheduled for archive on the slug. Left the
-	// Cell above clean so csv slugs stay plain.
+	// Human table only: flag goals scheduled for archive with a coloured dot
+	// after the slug. Left the Cell above clean so csv slugs stay plain. buzz
+	// list isn't row-coloured, so the dot gets its own orange (matching the
+	// detail-view banner).
 	now := time.Now()
-	table.Columns[0].Cell = func(g Goal) string { return archiveMarker(g, now) + g.Slug }
+	archiveStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+	table.Columns[0].Cell = func(g Goal) string { return g.Slug + archiveDot(g, now, archiveStyle) }
 	fmt.Fprint(out, table.Render(goals))
 
 	return 0

--- a/list_test.go
+++ b/list_test.go
@@ -281,6 +281,25 @@ func TestRunListCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("scheduled-for-archive goal: table slug marked, csv slug clean", func(t *testing.T) {
+		// Far-future archivedate so ScheduledForArchive is true against the real
+		// clock runListCommand samples internally.
+		scheduled := []Goal{{Slug: "apple", Archivedate: 4102444800}, {Slug: "zebra"}}
+		client := &FakeClient{FetchGoalsFunc: func() ([]Goal, error) { return scheduled, nil }}
+
+		var tblOut, errOut bytes.Buffer
+		runListCommand(context.Background(), client, false, "table", &tblOut, &errOut)
+		if !strings.Contains(tblOut.String(), "(A) apple") {
+			t.Errorf("table should mark the scheduled goal, got:\n%s", tblOut.String())
+		}
+
+		var csvOut bytes.Buffer
+		runListCommand(context.Background(), client, false, "csv", &csvOut, &errOut)
+		if strings.Contains(csvOut.String(), "(A)") {
+			t.Errorf("csv slug must stay clean (no marker), got:\n%s", csvOut.String())
+		}
+	})
+
 	t.Run("fetch error returns exit code 1", func(t *testing.T) {
 		client := &FakeClient{
 			FetchArchivedGoalsFunc: func() ([]Goal, error) {

--- a/list_test.go
+++ b/list_test.go
@@ -289,14 +289,14 @@ func TestRunListCommand(t *testing.T) {
 
 		var tblOut, errOut bytes.Buffer
 		runListCommand(context.Background(), client, false, "table", &tblOut, &errOut)
-		if !strings.Contains(tblOut.String(), "(A) apple") {
-			t.Errorf("table should mark the scheduled goal, got:\n%s", tblOut.String())
+		if !strings.Contains(tblOut.String(), "apple •") {
+			t.Errorf("table should mark the scheduled goal with a dot, got:\n%s", tblOut.String())
 		}
 
 		var csvOut bytes.Buffer
 		runListCommand(context.Background(), client, false, "csv", &csvOut, &errOut)
-		if strings.Contains(csvOut.String(), "(A)") {
-			t.Errorf("csv slug must stay clean (no marker), got:\n%s", csvOut.String())
+		if strings.Contains(csvOut.String(), "•") {
+			t.Errorf("csv slug must stay clean (no dot), got:\n%s", csvOut.String())
 		}
 	})
 

--- a/review.go
+++ b/review.go
@@ -509,7 +509,7 @@ func formatRecentDatapoints(datapoints []Datapoint) string {
 // shows up the same way everywhere. now gates on a still-upcoming date so an
 // already-archived goal (reachable by slug) doesn't show a past-dated warning.
 func formatArchiveBanner(goal *Goal, now time.Time) string {
-	if goal.Archivedate <= 0 || goal.Archivedate <= now.Unix() {
+	if !goal.ScheduledForArchive(now) {
 		return ""
 	}
 	when := time.Unix(goal.Archivedate, 0).Format("Mon Jan 2, 2006")


### PR DESCRIPTION
## What

Follow-up to #356. That PR added the "⚠ Scheduled for archive" banner to the **detail** views (`buzz view`, `buzz review`, grid modal) but left the row-based tables untouched. This surfaces the same status in `buzz list` and the filtered views (`today`/`tomorrow`/`due`/`less`/`all`) with a **colored dot after the slug**:

```
Slug            Title                            Units      Rate
-------------   ------------------------------   --------   ----
bm-time •       #autodialMin=0.1 #autodialMax=1  hours      0.29/d     ← dot is orange
bottlewash      -                                cleanings  0.06/d
clean •         -                                hours      0.1/d
clozemaster     #autodialMin=50 #autodialMax=500 points     53/d
```

## Design notes

- **Dot, not a prefix.** An earlier cut used an `(A) ` slug *prefix*, but that shifted the slug's left edge and hurt scanning. A trailing dot keeps every slug left-aligned.
- **Color where it's free.** `buzz list` isn't row-colored, so its dot is orange (ANSI 208, matching the detail banner). The filtered views color the *whole row* by urgency, so there the dot is left unstyled — it inherits the row color rather than resetting it mid-line, and still marks the goal by its presence.
- **Alignment.** The dot is multibyte and (in `buzz list`) colored, so the table now measures/pads columns by **display width** (`lipgloss.Width`) instead of byte length.
- **Piping.** lipgloss drops color on non-TTY output, so `buzz list | cat` still shows a plain `•` — the indicator survives redirection.
- **Machine formats untouched.** The marker is applied only on the human-table path; `csv` slugs stay clean (test-guarded), `json` carries the raw `archivedate`.
- Shared `Goal.ScheduledForArchive(now)` gates both the detail banner and the dot on a still-future date, so they always agree.

## Testing

- `TestArchiveDot` — future → ` •`, unset/past/exactly-now → none.
- `TestTableArchiveDotAlignment` — marked/unmarked rows stay column-aligned despite the glyph + color bytes.
- `TestTableColorizeArchiveDot` — in a colorized (filtered-view) table, the dot sits inside the row's color span (no mid-line reset) and stays aligned.
- `TestRunListCommand/scheduled-for-archive…` — table slug marked, **csv slug clean**.
- `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)