### PR TITLE
feat(schedule): color archive-scheduled slugs in the timeline

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -49,8 +50,8 @@ func handleScheduleCommand() {
 	// Display hourly density overview
 	displayHourlyDensity(hourCounts)
 
-	// Display detailed timeline
-	displayTimeline(timeSlots)
+	// Display detailed timeline, colouring slugs scheduled for archive.
+	displayTimeline(os.Stdout, timeSlots, archivingSlugs(goals, time.Now()))
 
 	// Check for updates and display message if available
 	fmt.Print(getUpdateMessage())
@@ -115,6 +116,19 @@ func extractTimeSlots(goals []Goal, loc *time.Location) []timeSlot {
 	})
 
 	return slots
+}
+
+// archivingSlugs returns the set of slugs whose goal is scheduled for archive as
+// of now — the timeline colours these. Extracted from handleScheduleCommand so
+// the selection is unit-testable, matching archiveDot / formatArchiveBanner.
+func archivingSlugs(goals []Goal, now time.Time) map[string]bool {
+	set := make(map[string]bool)
+	for _, g := range goals {
+		if g.ScheduledForArchive(now) {
+			set[g.Slug] = true
+		}
+	}
+	return set
 }
 
 // displayHourlyDensity displays a compact bar chart showing goals per hour
@@ -249,18 +263,23 @@ func displayHourlyDensity(hourCounts []int) {
 	fmt.Println()
 }
 
-// displayTimeline displays a vertical timeline listing all goals grouped by deadline time
-func displayTimeline(slots []timeSlot) {
-	fmt.Println("TIMELINE")
-	fmt.Println("────────────────────────────────────────────────")
+// displayTimeline displays a vertical timeline listing all goals grouped by
+// deadline time. Slugs present in archiving (goals scheduled for archive) are
+// coloured to match the archive indication elsewhere; wrapping is measured on
+// the plain slug so the colour bytes never shift the layout. Writes to w.
+func displayTimeline(w io.Writer, slots []timeSlot, archiving map[string]bool) {
+	fmt.Fprintln(w, "TIMELINE")
+	fmt.Fprintln(w, "────────────────────────────────────────────────")
 
 	// Define styles for timeline elements (disabled if --no-color)
 	colorProfile := lipgloss.ColorProfile()
 	timeStyle := lipgloss.NewStyle()
 	treeStyle := lipgloss.NewStyle()
+	archiveStyle := lipgloss.NewStyle()
 	if colorProfile != termenv.Ascii {
-		timeStyle = timeStyle.Foreground(lipgloss.Color("6")) // Cyan for time labels
-		treeStyle = treeStyle.Foreground(lipgloss.Color("8")) // Gray for tree structure (├─ and │)
+		timeStyle = timeStyle.Foreground(lipgloss.Color("6"))         // Cyan for time labels
+		treeStyle = treeStyle.Foreground(lipgloss.Color("8"))         // Gray for tree structure (├─ and │)
+		archiveStyle = archiveStyle.Foreground(lipgloss.Color("208")) // Orange for archive-scheduled slugs (matches the list dot / banner)
 	}
 
 	// Determine terminal width once; it doesn't change across slots.
@@ -288,30 +307,35 @@ func displayTimeline(slots []timeSlot) {
 		line.WriteString(prefix)
 		current := 0
 		for _, goal := range slot.goals {
+			// Colour the slug when archive-scheduled, but measure the plain slug —
+			// the ANSI bytes have zero display width and must not affect wrapping.
+			display := goal
+			if archiving[goal] {
+				display = archiveStyle.Render(goal)
+			}
 			// Determine separator
 			sep := ""
 			if current > 0 {
 				// Add comma+space before this goal if there's already content on this line
 				sep = ", "
 			}
-			chunk := sep + goal
-			if current+len(chunk) > available && current > 0 {
+			if current+len(sep)+len(goal) > available && current > 0 {
 				// Always add trailing comma when wrapping (more content follows)
 				line.WriteString(",")
-				fmt.Println(line.String())
+				fmt.Fprintln(w, line.String())
 				// start new wrapped line with indent matching prefix width
 				// Use vertical line to show continuation
 				line.Reset()
 				// Time column width (5 chars) + space + vertical continuation (styled)
 				line.WriteString("      " + treeStyle.Render("│") + "  ")
 				// Add the goal that didn't fit
-				line.WriteString(goal)
+				line.WriteString(display)
 				current = len(goal)
 				continue
 			}
-			line.WriteString(chunk)
-			current += len(chunk)
+			line.WriteString(sep + display)
+			current += len(sep) + len(goal)
 		}
-		fmt.Println(line.String())
+		fmt.Fprintln(w, line.String())
 	}
 }

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // TestExtractTimeSlots tests the extraction and grouping of time slots from goals
@@ -322,9 +328,87 @@ func TestDisplayTimeline(t *testing.T) {
 				}
 			}()
 
-			displayTimeline(tt.slots)
+			displayTimeline(io.Discard, tt.slots, nil)
 			tt.verify(t)
 		})
+	}
+}
+
+// TestDisplayTimelineArchiveColor asserts archive-scheduled slugs are coloured
+// (orange 208) in the timeline while others stay plain, and that the colour
+// bytes don't shift wrapping — the wrap point is measured on the plain slug.
+func TestDisplayTimelineArchiveColor(t *testing.T) {
+	orig := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(orig) })
+
+	orange := "\x1b[38;5;208m" // SGR prefix Color("208") renders under TrueColor
+	slots := []timeSlot{{hour: 9, minute: 0, goals: []string{"archer", "keeper"}}}
+
+	var buf bytes.Buffer
+	displayTimeline(&buf, slots, map[string]bool{"archer": true})
+	out := buf.String()
+
+	// "archer" is archive-scheduled -> wrapped in the orange SGR; "keeper" is not.
+	if !strings.Contains(out, orange+"archer") {
+		t.Errorf("expected archer coloured orange, got:\n%q", out)
+	}
+	if strings.Contains(out, orange+"keeper") {
+		t.Errorf("expected keeper to stay plain, got:\n%q", out)
+	}
+
+	// No archiving set (nil) -> no orange anywhere, even for the same slugs.
+	buf.Reset()
+	displayTimeline(&buf, slots, nil)
+	if strings.Contains(buf.String(), orange) {
+		t.Errorf("expected no archive colour when nothing scheduled, got:\n%q", buf.String())
+	}
+}
+
+// TestArchivingSlugs verifies the archive-scheduled slug set: future-dated in,
+// unset/past out, empty goals -> empty (non-nil) set.
+func TestArchivingSlugs(t *testing.T) {
+	now := time.Unix(1_000_000_000, 0)
+	goals := []Goal{
+		{Slug: "sched", Archivedate: now.Unix() + 86400},
+		{Slug: "plain"},
+		{Slug: "past", Archivedate: now.Unix() - 86400},
+	}
+	got := archivingSlugs(goals, now)
+	if !got["sched"] || got["plain"] || got["past"] {
+		t.Errorf("archivingSlugs = %v, want only {sched}", got)
+	}
+	if empty := archivingSlugs(nil, now); empty == nil || len(empty) != 0 {
+		t.Errorf("expected empty non-nil set for no goals, got %v", empty)
+	}
+}
+
+// TestDisplayTimelineWrapUnaffectedByColor guards the core invariant of the
+// colouring change: the ANSI colour bytes must not shift where lines wrap. It
+// renders the same wrapping slot with and without the archive colour and asserts
+// the layouts are byte-identical once ANSI is stripped.
+func TestDisplayTimelineWrapUnaffectedByColor(t *testing.T) {
+	orig := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(orig) })
+
+	// Enough goals to overflow the 80-col fallback width and force wrapping,
+	// with archiving slugs among those near the wrap boundary.
+	goals := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+		"golf", "hotel", "india", "juliet", "kilo", "lima"}
+	slot := []timeSlot{{hour: 9, minute: 0, goals: goals}}
+
+	var colored, plain bytes.Buffer
+	displayTimeline(&colored, slot, map[string]bool{"golf": true, "kilo": true})
+	displayTimeline(&plain, slot, nil)
+
+	strip := regexp.MustCompile("\x1b\\[[0-9;]*m")
+	if got, want := strip.ReplaceAllString(colored.String(), ""), strip.ReplaceAllString(plain.String(), ""); got != want {
+		t.Errorf("colour shifted the layout:\ncolored (stripped):\n%s\nplain:\n%s", got, want)
+	}
+	// Sanity: the colour really is applied in the coloured render.
+	if !strings.Contains(colored.String(), "\x1b[38;5;208mgolf") {
+		t.Errorf("expected golf coloured orange, got:\n%q", colored.String())
 	}
 }
 


### PR DESCRIPTION
## What

Continues the archive-indicator work (#356 banner, #357 `buzz list` dot). `buzz schedule`'s **TIMELINE** now renders slugs whose goal is scheduled for archive in **orange** (ANSI 208), matching the list dot and the detail-view banner:

```
TIMELINE
────────────────────────────────────────────────
12:59 ├─ flipper, jobbsokande, ledgible, sowstack, ansokningar, octonix, soktid,
         ppd-finance, reapstack, bm-time, hellyer, bm-report, rolofresh,
         tr-email-zero, tr-time, bm-invoice, kontakt, beetherpad, rolotouch, uvi
17:59 ├─ clean, dishes, distill, fillup, cpap-replace, cpap-wash, bottlewash,
         trash, round, barber
```
(the archiving slugs — flipper, jobbsokande, octonix, soktid, bm-time, bm-report, rolofresh, tr-time, bm-invoice, beetherpad, rolotouch, clean, dishes, trash — render orange; the rest stay default.)

## How

- `handleScheduleCommand` builds the archiving-slug set via a new `archivingSlugs(goals, now)` helper (shared `Goal.ScheduledForArchive`) and passes it to `displayTimeline`.
- `displayTimeline` colors matching slugs. **Wrapping is measured on the plain slug** so the color bytes never shift where lines wrap.
- `displayTimeline` now writes to an `io.Writer` — this closed the pre-existing "can't easily test output" gap noted in the tests.

## Design note — color-only

Per the request, this uses **font color** rather than a glyph. Consequence: in no-color/piped output (`termenv.Ascii`, e.g. `buzz schedule | cat`), there's no archive indication — color is the whole signal here. (`buzz list` uses a dot that survives piping; `schedule` is color-only by choice.)

## Testing

- `TestArchivingSlugs` — future-dated in, unset/past out, empty → empty set.
- `TestDisplayTimelineArchiveColor` — archiving slug wrapped in orange SGR, others plain, nil set → no color.
- `TestDisplayTimelineWrapUnaffectedByColor` — renders a wrapping slot with and without color and asserts byte-identical layout once ANSI is stripped (the core invariant).
- `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled-for-archive goals are now highlighted in the timeline.
  * Timeline output preserves accurate text wrapping when archive highlighting is applied.

* **Bug Fixes**
  * Improved timeline rendering to ensure colored goal slugs do not affect layout or line width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->